### PR TITLE
docs(skills): publish thomson-to8-engine skills set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,11 @@ env/
 # Claude skills (repo public — skills déployés localement uniquement)
 .claude/skills/
 .claude/commands/
-/skills/
+# skills/ : par défaut local. Seuls les skills spécifiques au moteur
+# (thomson-to8-engine-*) et leurs docs de gouvernance sont versionnés.
+/skills/*
+!/skills/thomson-to8-engine-*/
+!/skills/SKILLS-ROADMAP.md
+!/skills/QUESTIONS.md
 /game-projects/road-generator/lotus-ste/
 .mcp.json

--- a/skills/QUESTIONS.md
+++ b/skills/QUESTIONS.md
@@ -1,0 +1,75 @@
+# Questions ouvertes — à valider avec l'utilisateur
+
+Fichier alimenté au fil de la rédaction des skills. Chaque entrée précise le contexte et le skill concerné.
+
+---
+
+## Q1 — `MainCharacter` / `Sidekick` (skill object-management)
+
+`Obj_GetOrientationToPlayer` (engine/object-management/Obj_GetOrientationToPlayer.asm) référence des symboles `MainCharacter` et `Sidekick` qui ne sont **pas définis dans engine/**. Ce sont des conventions à mettre en place dans le code du game-mode (typiquement des pointeurs vers les OST des joueurs 1 et 2).
+
+**Question** : faut-il documenter la convention attendue (ex: `MainCharacter equ player1` pour solo, `Sidekick equ player2` pour coop) ? Ou laisser comme un détail à charge du projet ? Pour l'instant documenté brièvement, à compléter selon la pratique.
+
+## Q2 — `respawn_index` offset (skill object-management)
+
+`MarkObjGone*` utilise `respawn_index,u` mais ce champ n'a pas d'offset standard dans `engine/constants.asm`. Convention :
+- Le champ doit être déclaré dans le projet (dans `ext_variables_size`)
+- Pas de macro/equ standard pour son offset
+- Cf. r-type qui utilise `respawn_index equ ext_variables+X` pour son offset
+
+**Question** : faut-il pousser une convention engine (ex: `respawn_index equ ext_variables`) ? Pas urgent.
+
+## Q3 — `animate-internals.md` non écrit (skill animation)
+
+Le SKILL.md liste 6 références mais une (`animate-internals.md`) n'a pas été créée car son contenu (résolution `anim,u`, `Ani_Asd_Index`, application `status_flags`) est déjà couvert dans `animate-routines.md` et `animation-formats.md`. À écrire si l'utilisateur veut une ressource dédiée à la mécanique interne, sinon les autres suffisent.
+
+## Q4 — Références non écrites par skill (récap exhaustif)
+
+Pour optimiser le temps de la première itération, certaines références listées dans les SKILL.md n'ont pas été créées séparément — leur contenu est intégré au SKILL.md lui-même. Référence à compléter plus tard si besoin :
+
+- **animation** : `animate-internals.md` (déjà couvert ailleurs)
+- **palette** : `palette-cycling.md`, `raster-fade-object.md`, `screen-border.md`
+- **collision** : `collision-patterns.md`
+- **scrolling** : (toutes faites)
+- **tilemap** : `spritemap.md`, `tileset-pipeline.md`
+- **audio** : `dac-pcm-samples.md`, `audio-via-common.md`
+- **irq** : `raster-irq.md`
+- **input** : `joypad-buffer.md`, `megadrive-6-buttons.md`, `keyboard-input.md`
+- **fonts-text** : `drawtext.md`, `printstring.md`
+- **memory-model** : `memory-map-runtime.md`, `direct-page-usage.md`, `global-variables.md`, `system-stack-and-boundaries.md`
+- **storage-and-loaders** : `boot-loaders.md`, `ram-loader-manager.md`, `compression-zx0-exo.md`, `load-game-mode.md`
+- **build-pipeline** : `build-stages.md`, `knapsack-packing.md`, `t2-deduplication.md`
+- **math-rng** : `sine-cosine-table.md`, `atan2-logarithmic.md`, `random-number.md`, `fixed-point-88.md`
+- **image-codecs** : `fullscreen-images.md`, `rle-decoders.md`, `zx0-decoders.md`, `clear-routines.md`
+- **dyncode** : `dyncode-utilities.md`, `selfmod-patterns.md`
+
+Les SKILL.md décrivent ces sujets de manière approfondie — les références séparées seraient pour aller encore plus en détail.
+
+## Q5 — Frontmatter `machines`
+
+Tous les skills ont `machines: [to8, to8d, to9, to9+]`. Cohérent avec le périmètre de l'engine. Question : faut-il distinguer plus finement (e.g. extension RAM 512 Ko seulement TO8) ? Pour l'instant uniforme.
+
+## Q6 — Tests / évaluation des skills
+
+Aucune évaluation systématique faite. Pour valider qu'un skill est bien indexé/récupéré par retrieval, il faudrait tester une question type "Comment X ?" et vérifier que le bon skill est sélectionné. À faire dans une phase ultérieure (via `anthropic-skills:skill-creator` qui propose des évaluations).
+
+## Q7 — École goldorak (macros engine)
+
+L'utilisateur a indiqué qu'il commençait à porter les macros style goldorak (`_gameMode.init`, `_objectManager.new.u`, `_music.init.*`) côté `engine/`. Quand ce sera plus avancé, plusieurs skills devront être mis à jour pour les mentionner comme alternative au pattern verbeux actuel :
+- `new-game` (squelette main.asm avec macros)
+- `object-management` (`_objectManager.new.*`)
+- `audio` (`_music.init.*`)
+
+Pas urgent — à reprendre quand les macros seront stabilisées.
+
+## Q8 — `gameModeCommon` à promouvoir en skill séparé ?
+
+Pour l'instant `gameModeCommon` est documentée dans `new-game/references/gamemode-properties.md` (section approfondie). Quand l'usage se développera, peut devenir un skill séparé `thomson-to8-engine-shared-resources` qui couvre :
+- Patterns de partage audio/HUD/projectiles
+- Comparaison avec dossier `global/`
+- Optimisation ROM T2
+- Migration progressive de la duplication vers gameModeCommon
+
+À planifier après que r-type ait commencé à l'utiliser.
+
+---

--- a/skills/SKILLS-ROADMAP.md
+++ b/skills/SKILLS-ROADMAP.md
@@ -1,0 +1,259 @@
+# Roadmap des skills du framework Thomson TO8 Game Engine
+
+Ce document liste les skills proposés pour couvrir exhaustivement le framework. Il est construit à partir d'un inventaire **complet de `engine/`** et d'une **mesure de fréquence d'usage** dans les game-projects récents (r-type, bubble-bobble, sonic-2, 2026, goldorak).
+
+Chaque skill suit l'organisation `thomson-to8-engine-<topic>/SKILL.md` + `references/*.md`.
+
+---
+
+## Matrice d'usage des features dans les game-projects récents
+
+Mesure : `grep -c` sur le mot-clé dans `*.asm` + `*.properties`. Valeurs absolues = occurrences.
+
+| Feature | r-type | bubble-bobble | sonic-2 | 2026 | goldorak | Verdict |
+|---------|--------|---------------|---------|------|----------|---------|
+| `gfxlock` (double-buffer) | 219 | 16 | 32 | 8 | 8 | **Universel** |
+| `AnimateSprite` | 34 | 8 | 38 | 2 | 13 | **Universel** |
+| `AnimateSpriteSync` | 34 | 8 | 3 | — | — | **Très utilisé** |
+| `AnimateSpriteAdv` | — | — | — | — | — | Non utilisé récemment |
+| `ObjectMove` | 45 | 5 | 51 | — | 10 | **Universel** (sauf 2026) |
+| `ObjectFall` (gravité) | — | 4 | 3 | — | — | **Plateformer** |
+| `Collision AABB` | 79 | 3 | — | — | — | **Shoot/action** |
+| `terrainCollision` | 245 | — | — | — | — | **r-type only** |
+| `vscroll` (vertical) | — | 23 | — | — | 18 | **Scrolling vert** |
+| `horizontal-scroll` | 7 | — | — | — | — | **r-type only** |
+| `Tilemap` classique | — | — | 3 | — | — | sonic-2 only |
+| `TileAnimScript` | — | — | 10 | — | — | sonic-2 only |
+| `ymm` (YM2413 player) | 96 | 8 | — | 11 | 4 | **Universel** |
+| `vgc` (SN76489 player) | 70 | 8 | — | 8 | 15 | **Très utilisé** |
+| `Smps` (SMPS musique) | — | — | 40 | — | — | sonic-2 only |
+| `soundFX` | 54 | — | — | — | — | **r-type only** |
+| `PalUpdateNow` | 58 | 5 | 16 | 3 | 30 | **Universel** |
+| `PalRaster` | — | — | 4 | — | — | sonic-2 only |
+| `fade` / `raster-fade` | 164 | — | 27 | — | 18 | **Très utilisé** |
+| `DrawText` / `PrintString` | — | — | 21 | — | 13 | **HUD-needed** |
+| `RandomNumber` / `CalcSine` | 30 | 5 | 35 | — | — | **Très utilisé** |
+| `objectWave` (object spawner) | — | — | — | — | — | Non utilisé |
+| `MapKeyboardToJoypads` | — | — | — | — | — | Non utilisé |
+| `joypad.md6` (manette Megadrive) | — | — | — | — | — | Non utilisé |
+| `DrawFullscreenImage` | 1 | — | 3 | 3 | 3 | **Universel léger** |
+| `DecRLE00` / `zx0_mega` (codecs) | — | — | — | — | 5 | goldorak only |
+| `InitDrawSprites` | 10 | 1 | 1 | 1 | 2 | **Universel** |
+
+Conclusions :
+- **Plusieurs features sont quasi-universelles** (gfxlock, animation, ObjectMove, ymm/vgc, palette, fade) → skill prioritaire
+- **Certaines sont domaine-spécifiques** (collision AABB, scrolling, tilemap, SMPS) → skills par genre/usage
+- **Plusieurs features sont sous-utilisées mais existent dans engine/** : `AnimateSpriteAdv`, `objectWave`, `MapKeyboardToJoypads`, `joypad.md6`. Soit features récentes pas encore adoptées, soit legacy. À documenter en mode « disponible » sans pousser leur usage.
+
+---
+
+## Skills proposés — par priorité
+
+### Tier 1 — fondamentaux (toujours utiles)
+
+#### ✅ `thomson-to8-engine-new-game` — CRÉÉ
+Création d'un nouveau game, structure, properties, squelette main.asm + objet. **Skill principal d'entrée**.
+
+References : `project-organization`, `config-properties`, `gamemode-properties`, `object-properties`, `mainasm-skeleton`, `object-skeleton`.
+
+#### `thomson-to8-engine-object-management`
+Gestion fine des objets : cycle de vie, `LoadObject_u`/`UnloadObject_u`, `RunObjects`, run-list chaînée (`run_object_prev`/`run_object_next`), `MarkObjGone`, `Obj_GetOrientationToPlayer`, `_MountObject` / `_RunObject` / `_RunObjectSwap`, allocation par DP (joueur principal), `ObjectMove` / `ObjectMoveSync`, `ObjectFall` / `ObjectFallSync`, sub-types et sub-routines (`routine_secondary/tertiary/quaternary`), `objectWave` (description ennemis par script).
+
+References : `lifecycle`, `runlist-internals`, `move-and-physics`, `subtype-machine`, `objectWave-pattern`.
+
+Sources engine : `engine/object-management/*`, `engine/macros.asm` (_MountObject/_RunObject), `engine/constants.asm` (OST).
+
+#### `thomson-to8-engine-graphics-pipeline`
+Le pipeline de rendu complet : `gfxlock` double-buffering, `EraseSprites`/`DrawSprites`/`CheckSpritesRefresh`/`UnsetDisplayPriority`/`DisplaySprite`, gestion `priority`, `render_flags` détaillés, modes `background-erase` vs `overlay`, sprite-packs, encodage étendu (`-ext-pack`), `BgBufferAlloc`, allocation des cellules d'erase, `glb_screen_location_1/2`, `glb_force_sprite_refresh`.
+
+References : `gfxlock-internals`, `sprite-packs-comparison`, `render-flags-bits`, `priority-and-zorder`, `dirty-rendering`.
+
+Sources engine : `engine/graphics/buffer/`, `engine/graphics/sprite/`.
+
+#### `thomson-to8-engine-animation`
+Animation des sprites : `AnimateSprite` vs `AnimateSpriteSync` vs `AnimateSpriteAdv*`, format v00 vs v02, tags `_resetAnim`/`_goBackNFrames`/`_goToAnimation`/`_nextRoutine`/`_resetAnimAndSubRoutine`/`_nextSubRoutine`, `anim_frame`/`anim_frame_duration`/`anim_flags`, animations chaînées, `prev_anim`/`sub_anim`, `image_set`, `AnimateMove`, `moveByScript` (scripts de mouvement déclaratif), `AnimateSpriteLoad`/`AnimateSpriteAdvLoad`.
+
+References : `animation-formats-v00-v02`, `end-tags`, `chained-animations`, `moveByScript-scripts`, `anim-flags-callbacks`.
+
+Sources engine : `engine/graphics/animation/*`.
+
+#### `thomson-to8-engine-palette`
+Gestion de palette : `Pal_current`, `PalRefresh`, `PalUpdateNow` vs `PalUpdateNowLean`, `PalCycling` (cycling de couleurs), `PalRaster_1c` (changement de palette à mi-écran pour effets raster), bordure d'écran `$E7DD`, palette engine `Pal_black`/`Pal_white`, objet `fade` (transitions de palette progressives), objet `raster-fade` (fade par lignes), API de transition (`fade.equ`).
+
+References : `palette-system`, `palette-cycling`, `raster-effects`, `fade-object-api`, `raster-fade-object`.
+
+Sources engine : `engine/palette/*`, `engine/objects/palette/fade/*`, `engine/objects/palette/raster-fade/*`.
+
+### Tier 2 — gameplay (selon le genre)
+
+#### `thomson-to8-engine-collision`
+Système de collision : AABB engine (`Collision_AddAABB`/`RemoveAABB`/`Do`), structures `struct_AABB.equ`, macros `_Collision_*`, listes typées (`AABB_list_player`, `AABB_list_enemy`, ...), pattern de placement dans `ram-data.asm`, terrainCollision (collisions terrain de r-type : init, doRight/doLeft, sensors, impacts).
+
+References : `aabb-system`, `aabb-lists`, `terrain-collision` (r-type), `collision-patterns`.
+
+Sources engine : `engine/collision/*`, `engine/objects/collision/*`.
+
+#### `thomson-to8-engine-scrolling`
+Scrolling vertical (`vscroll`), scrolling horizontal (`scroll-map-buffered-*`), buffers de tiles, `_vscroll.setMap` / `setMapHeight` / `setTileset256` / `setBuffer` / `setCameraPos` / `setCameraSpeed` / `setViewport`, caméras (`glb_camera_*`), camera auto-scroll (`AutoScroll`, `CheckCameraMove`), modes 16x16 / 16x16 even/odd, `TilemapBuffer` (buffer cyclique).
+
+References : `vertical-scroll`, `horizontal-scroll`, `camera-system`, `tilemap-buffer`, `scrolling-patterns`.
+
+Sources engine : `engine/graphics/tilemap/vscroll/*`, `engine/graphics/tilemap/horizontal-scroll/*`, `engine/graphics/camera/*`.
+
+#### `thomson-to8-engine-tilemap`
+Tilemaps statiques (non-scrolling) : `Tilemap`, `Tilemap16bits`, `Tilemaps`, `Spritemap`, `TileAnimScript` (animation de tiles déclarative), types de data (`layer.equ`, `submap.equ`, `map-16bits.equ`, `spritemap.equ`), génération via tileset properties (`tileset.X=...`), maps et chunks, `bm4.drawChunbks`.
+
+References : `tilemap-types`, `tileset-pipeline`, `tile-anim-script`, `chunks-and-maps`.
+
+Sources engine : `engine/graphics/tilemap/*` (hors scrolling).
+
+#### `thomson-to8-engine-audio`
+Architecture audio complète : YM2413 (FM, 9 voies dont 6 mélo + 3 perc), SN76489 (PSG, 4 voies dont 3 mélo + 1 bruit), accès hardware `$E7F4`/`$E7F6`, player VGC (compressé, Bentoc), player YM2413vgm, player VGM brut, SMPS (Sega Master/Mega Drive style — sonic-2 only), DAC/DPCM/PCM (samples), Smidi (MIDI), Svgm (small VGM), soundFX (effets sonores), objets `ymm` et `vgc` (objets engine partagés via gameModeCommon).
+
+References : `audio-architecture`, `ymm-player`, `vgc-player`, `smps-player`, `dac-pcm-samples`, `soundFX-system`, `audio-via-common`.
+
+Sources engine : `engine/sound/*`, `engine/objects/sound/*`.
+
+#### `thomson-to8-engine-irq`
+Système d'interruption : `IrqInit`, `IrqSync`, `IrqOn`/`IrqOff`, `Irq_user_routine`, `Irq_one_frame`, `IrqObjSmps`, `IrqSecond`, synchronisation VBL vs OUT_OF_SYNC_VBL, raster IRQ pour effets palette à mi-écran, intégration avec `gfxlock.bufferSwap.check`, écriture d'un UserIRQ canonique.
+
+References : `irq-init-and-sync`, `user-irq-patterns`, `raster-irq`, `irq-in-loop`.
+
+Sources engine : `engine/irq/*`, `engine/sound/Smps.asm` (intégration), `engine/objects/sound/*`.
+
+#### `thomson-to8-engine-input`
+Lecture des entrées : `InitJoypads`, `ReadJoypads`, `ReadJoypads2` (joueur 2), `joypad.buffer` (buffer historique des inputs), `joypad.md6` (manette Megadrive 6 boutons), `MapKeyboardToJoypads` (clavier mappé sur les masques joypad), `ReadKeyboard`, codes des touches, masques `c1_button_*`, `Dpad_Press` / `Dpad_Held` / `Fire_Press` / `Fire_Held`.
+
+References : `joypad-reading`, `joypad-buffer`, `megadrive-6-buttons`, `keyboard-input`.
+
+Sources engine : `engine/joypad/*`, `engine/keyboard/*`.
+
+#### `thomson-to8-engine-fonts-text`
+Affichage de texte : `DrawText`, `DrawOneChar`, fonts 3x5 (et variantes shaded/selected/disabled), `PrintString`, font 3x7-normal, intégration avec sprites, code page Thomson, pattern de génération de fonts (`genfont.php` côté r-type).
+
+References : `drawtext-3x5`, `printstring-3x7`, `font-variants`, `text-on-sprite-engine`.
+
+Sources engine : `engine/graphics/font/*`.
+
+### Tier 3 — bas niveau / système
+
+#### `thomson-to8-engine-memory-model`
+Modèle mémoire du jeu : carte mémoire en exécution, `$6100` (boot du game-mode), `$9F00`-`$9FFF` (DP utilisateur), `$9E28` (variables globales), `dp_engine` / `dp_extreg`, `glb_*` variables (camera, screen_location, page, timer), pile système, `glb_ram_end`, contraintes des sprites compilés qui peuvent déborder de $A000, double buffer pages 2/3, page 1 résidente, `BankSwitch`, `_SetCartPageA/B`, `_GetCartPageA/B`.
+
+References : `memory-map-runtime`, `direct-page-usage`, `global-variables`, `bank-switching-macros`, `system-stack-and-boundaries`.
+
+Sources engine : `engine/constants.asm`, `engine/ram/BankSwitch.asm`, `engine/system/to8/*`, `doc/chapters/global.md`.
+
+#### `thomson-to8-engine-storage-and-loaders`
+Pipeline de stockage : disquette `.fd` (RAMLoaderManagerFd, RAMLoaderFd), cartouche T2 `.t2` (megarom, RAMLoaderManagerT2), T2 flash SDDRIVE `.t2flash` (t2-flash.asm), boot loaders, formats de compression (ZX0 vs Exomizer), `LoadGameMode` / `LoadGameModeNow`, pagination dynamique, dépend de `builder.to8.memoryExtension`, dimension max de l'image (32 pages × 16 Ko = 512 Ko).
+
+References : `floppy-format`, `t2-cartridge`, `t2flash-sddrive`, `compression-zx0-exo`, `loadgamemode`, `boot-loaders`.
+
+Sources engine : `engine/boot/*`, `engine/ram/*`, `engine/megarom-t2/*`, `engine/compression/*`, `engine/level-management/*`.
+
+#### `thomson-to8-engine-build-pipeline`
+Le pipeline de build Java (`java-generator`) : étapes de compilation, parsing properties, génération d'`ObjID_`/`GmID_`/`Pal_`/etc., compilation des sprites en code asm dépaqueté (`compiledSprite` cache), encodage des sprites (variants NB/ND/XB/etc.), knapsack packing des pages RAM, dédup T2 via `gameModeCommon`, génération de `LoadAct`, `LoadGameMode`, `BgBufferAlloc`, fichiers `.glb` (globals), commandes Maven, `lwasm` flags, logs Log4j, étapes de debug.
+
+References : `build-stages`, `sprite-compilation`, `knapsack-packing`, `t2-deduplication`, `generated-files`, `lwasm-integration`.
+
+Sources : `java-generator/src/main/java/fr/bento8/to8/build/*.java`.
+
+#### `thomson-to8-engine-math-rng`
+Math et RNG : `CalcSine` (table de sinus pré-générée, `sinewave.bin`), `CalcAngle` (atan2 logarithmique d'après Devulder/Forslof), `Mul9x16` (multiplication 9×16 bits), `RandomNumber` / `InitRNG` (PRNG basé sur timer), `_rnd` macro, format fixed-point 8.8 (utilisé pour x_vel, y_vel, x_acl, y_acl).
+
+References : `sine-cosine-table`, `atan2-logarithmic`, `random-number`, `fixed-point-88`.
+
+Sources engine : `engine/math/*`.
+
+#### `thomson-to8-engine-image-codecs`
+Codecs d'image : `DrawFullscreenImage` (image plein écran rapide), `DrawFullscreenInterlacedImage`, `DrawHLine`, `DecRLE00` (RLE 00), `zx0_mega` (ZX0 streaming), `bm4.drawChunbks` (chunks BM4), `ClearInterlacedDataMemory`, `ClearVerticalBandLR`, codec PNG → BM4/BM16, encodage MAP RLE (sprite variant `DMAP`), encodage ZX0 (variant `DZX0`).
+
+References : `fullscreen-images`, `rle-decoders`, `zx0-decoders`, `chunk-rendering`.
+
+Sources engine : `engine/graphics/codec/*`, `engine/graphics/draw/*`, `engine/graphics/clear/*`, `engine/graphics/line/*`, `engine/graphics/image/*`.
+
+### Tier 4 — patterns avancés / sous-utilisés
+
+#### `thomson-to8-engine-shared-resources` (cross-cutting)
+Comment partager des ressources entre game-modes via `gameModeCommon`. Pattern complet : choix de ce qui va dans le common vs spécifique, ordre `.0/.1/.2`, intégration avec audio engine, hud commun, projectiles partagés, dédup ROM T2, comparaison avec l'approche `global/` (dossier sans common).
+
+References : couvert dans `gamemode-properties.md` du skill `new-game`, à étendre en skill dédié si on lance plusieurs initiatives de partage.
+
+Statut : **section déjà détaillée dans `thomson-to8-engine-new-game/references/gamemode-properties.md`**. À promouvoir en skill séparé quand l'usage se développera.
+
+#### `thomson-to8-engine-dyncode`
+Code auto-modifié : `DynCode_ApplyAToListX`, `DynCode_*` utilitaires, pattern d'optimisation 6809 (modification de constantes en place pour gagner des cycles). Peu utilisé directement par les game-projects mais présent dans plusieurs modules engine (terrainCollision notamment).
+
+References : `dyncode-utilities`, `selfmod-patterns`.
+
+Sources engine : `engine/ram/DynCode.asm`.
+
+### Hors périmètre / inutiles à documenter pour l'instant
+
+- `engine/main/` — ancien point d'entrée, plus utilisé
+- `engine/compression/mx0/mx0.asm.unfinished` — non terminé
+- `engine/sound/dac/` — bibliothèque de samples, pas une fonctionnalité au sens skill
+
+---
+
+## Statut — TOUS LES SKILLS PRODUITS
+
+État au terme de la première itération :
+
+| # | Skill | Statut | SKILL.md | Références |
+|---|-------|--------|----------|------------|
+| 1 | `thomson-to8-engine-new-game` | ✅ | oui | 6 |
+| 2 | `thomson-to8-engine-object-management` | ✅ | oui | 9 |
+| 3 | `thomson-to8-engine-graphics-pipeline` | ✅ | oui | 6 |
+| 4 | `thomson-to8-engine-animation` | ✅ | oui | 5 |
+| 5 | `thomson-to8-engine-palette` | ✅ | oui | 3 |
+| 6 | `thomson-to8-engine-collision` | ✅ | oui | 3 |
+| 7 | `thomson-to8-engine-scrolling` | ✅ | oui | 3 |
+| 8 | `thomson-to8-engine-tilemap` | ✅ | oui | 2 |
+| 9 | `thomson-to8-engine-audio` | ✅ | oui | 3 |
+| 10 | `thomson-to8-engine-irq` | ✅ | oui | 2 |
+| 11 | `thomson-to8-engine-input` | ✅ | oui | 1 |
+| 12 | `thomson-to8-engine-fonts-text` | ✅ | oui | 0 (couvert dans SKILL.md) |
+| 13 | `thomson-to8-engine-memory-model` | ✅ | oui | 1 |
+| 14 | `thomson-to8-engine-storage-and-loaders` | ✅ | oui | 0 (couvert dans SKILL.md) |
+| 15 | `thomson-to8-engine-build-pipeline` | ✅ | oui | 0 (couvert dans SKILL.md) |
+| 16 | `thomson-to8-engine-math-rng` | ✅ | oui | 0 (couvert dans SKILL.md) |
+| 17 | `thomson-to8-engine-image-codecs` | ✅ | oui | 0 (couvert dans SKILL.md) |
+| 18 | `thomson-to8-engine-dyncode` | ✅ | oui | 0 (couvert dans SKILL.md) |
+
+Total :
+- **18 SKILL.md** (= 17 skills demandés + new-game initial)
+- **44 références détaillées** créées
+- Le SKILL.md liste typiquement plus de références qu'il n'y en a actuellement (entre 0 et 9 par skill) — celles non créées sont mentionnées dans le SKILL.md (descriptifs riches) et peuvent être ajoutées plus tard sans toucher au SKILL.md.
+
+### Notes par skill
+
+- **Plus complets** (multiple références) : `object-management`, `graphics-pipeline`, `animation`, `new-game`
+- **Couverts par SKILL.md riche** (sans références séparées, mais avec contenu approfondi dans le SKILL.md) : `fonts-text`, `storage-and-loaders`, `build-pipeline`, `math-rng`, `image-codecs`, `dyncode`
+- **À étoffer plus tard** : les références manquantes mais listées dans les SKILL.md (cf. `QUESTIONS.md`)
+
+### Ordre de priorisation initial (rappel)
+
+Le plan séquentiel a été suivi : `new-game` → `object-management` → `graphics-pipeline` → `animation` → `palette` → `collision` → ... → `dyncode`.
+
+---
+
+## Notes méthodologiques
+
+### Source de chaque skill
+- **Code asm** dans `engine/<module>/`
+- **Java builder** dans `java-generator/src/main/java/fr/bento8/to8/`
+- **Documentation existante** dans `doc/chapters/`, `doc/wiki/`
+- **Usage réel** dans `game-projects/` (rotation pour exemples authentiques)
+
+### Format à respecter
+- Frontmatter YAML conforme aux skills thomson (`name`, `description` riche en mots-clés, `machines: [to8, to8d, to9, to9+]`, `user-invocable: false`)
+- Une description du SKILL.md **dense en mots-clés français+anglais+symboles** pour optimiser le retrieval
+- Sous-dossier `references/` pour les sujets approfondis (3-7 fichiers `.md` par skill)
+- Tableaux Markdown pour les bitfields/offsets, blocs ```asm pour les exemples
+- Section finale « ## Références détaillées » qui liste les `references/X.md` avec un descriptif riche en mots-clés (modèle suivi par `thomson-to8-to9-video`)
+- Section « Pitfalls » à la fin du SKILL.md pour les pièges courants
+
+### Liaison entre skills
+- Les skills se référencent entre eux : ex. `new-game` pointe vers `object-management` pour les détails OST
+- Le skill `thomson-to8-engine-shared-resources` n'est pas urgent puisque sa section existe déjà dans `new-game/references/gamemode-properties.md`

--- a/skills/thomson-to8-engine-animation/SKILL.md
+++ b/skills/thomson-to8-engine-animation/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: thomson-to8-engine-animation
+description: "Décrit le système d'animation du Thomson TO8/TO9 game engine (Bento8/wide-dot) : routines AnimateSprite (basique), AnimateSpriteSync (synchro framerate via gfxlock.frameDrop.count), AnimateSpriteLoad et AnimateSpriteAdvLoad (reload frame sans avancer), AnimateSpriteAdv et AnimateSpriteAdvSync (animation avancée v02 avec durée et flags par frame, callbacks dynamiques via anim_flags LUT), AnimateMove (animation pilotée par script de mouvement avec bitfield frame/x_vel/y_vel), moveByScript (scripts déclaratifs de trajectoire), format binaire d'une animation v00 (legacy : duration globale + suite de pointeurs Img_) et v02 (advanced : (Img_, duration, flags) par frame, 5 octets), tags de fin _resetAnim FF, _goBackNFrames FE, _goToAnimation FD, _nextRoutine FC, _resetAnimAndSubRoutine FB, _nextSubRoutine FA, mécanique du champ anim,u (positif = adresse directe, négatif = offset signed dans Ani_Asd_Index LUT), résolution de anim par Ani_Page_Index/Ani_Asd_Index, état anim_frame/anim_frame_duration/anim_flags/prev_anim/sub_anim, application des status_flags (xflip/yflip) sur render_flags pendant l'animation, anim_link_mask pour charger une nouvelle anim sans reset, image_set mis à jour à chaque frame, intégration avec routine/routine_secondary via _nextRoutine/_nextSubRoutine. Utiliser pour comprendre comment animer un sprite, choisir entre v00 et v02, débugger une animation qui ne progresse pas, scripter une chaîne d'animations (intro → loop), déclencher un changement d'état via animation finie, programmer une trajectoire scriptée. Mots-clés : AnimateSprite, AnimateSpriteSync, AnimateSpriteLoad, AnimateSpriteAdv, AnimateSpriteAdvSync, AnimateSpriteAdvLoad, AnimateMove, AnimateMoveInit, moveByScript, moveByScript.register, moveByScript.initialize, moveByScript.runByFrameDrop, moveByScript.runByB, moveByScript.NEGXSTEP, moveByScript.POSXSTEP, moveByScript.NEGYSTEP, moveByScript.POSYSTEP, anim, anim+1, prev_anim, sub_anim, anim_frame, anim_frame_duration, anim_flags, anim_link_mask, image_set, status_flags, status_xflip_mask, status_yflip_mask, render_flags, render_xmirror_mask, render_ymirror_mask, Ani_Page_Index, Ani_Asd_Index, Ani_, Img_, _resetAnim, _goBackNFrames, _goToAnimation, _nextRoutine, _resetAnimAndSubRoutine, _nextSubRoutine, $FF, $FE, $FD, $FC, $FB, $FA, animation v00, animation v02, animation script, animation data, animation-data property, frame duration, animation rate, frameDrop adaptive."
+machines: [to8, to8d, to9, to9+]
+user-invocable: false
+---
+
+# Animation — Thomson TO8/TO9 Game Engine
+
+L'animation des sprites est pilotée par des **scripts** déclaratifs (déclarés dans le `.properties` de l'objet) qui sont compilés en binaire par le builder Java et placés en mémoire. À chaque frame, une routine d'animation lit le script courant, met à jour `image_set,u` (sprite à afficher), gère la progression (`anim_frame`, `anim_frame_duration`), et déclenche des callbacks (changement d'animation, transition de routine).
+
+Ce skill couvre : les 7 routines d'animation (`AnimateSprite*`), les deux formats de script (v00 legacy et v02 advanced), les tags de fin, l'intégration avec les state machines via `_nextRoutine`, et le système `moveByScript` (scripts de trajectoire).
+
+---
+
+## Vue d'ensemble
+
+```
+Objet OST :
+  anim,u (offset 8-9)            → pointeur vers le script binaire courant
+  prev_anim,u (offset 10-11)     → script précédent (pour détecter changement)
+  anim_frame,u (offset 12)       → index de la frame courante dans le script
+  anim_frame_duration,u (off 13) → décompte de frames restantes pour image
+  anim_flags,u (offset 14)       → flags ou LUT offset (v02)
+  status_flags,u (offset 14)     → orientation (xflip/yflip) — overlap avec anim_flags
+  image_set,u (offset 16-17)     → pointeur vers Img_ courant (lu par DrawSprites)
+
+Mécanique frame :
+  1. Charger anim,u → script address
+  2. Comparer avec prev_anim,u → détection de changement
+     - Si changé : reset anim_frame=0, anim_frame_duration=0 (sauf anim_link)
+  3. Décrémenter anim_frame_duration
+     - Si > 0 : pas de changement de frame, rts
+     - Si <= 0 : avancer anim_frame, lire le nouveau frame
+  4. Si la nouvelle frame est un tag ($FF..$FA), exécuter le tag
+  5. Sinon : mettre à jour image_set,u avec le pointeur Img_
+  6. Appliquer status_flags (xflip/yflip) sur render_flags
+  7. Incrémenter anim_frame pour le prochain tour
+```
+
+---
+
+## Les 7 routines d'animation
+
+### `AnimateSprite` (basique)
+
+```asm
+        jsr   AnimateSprite             ; U = OST
+```
+
+Routine standard. Décrémente `anim_frame_duration` de 1 par frame. Si arrive à 0, charge la frame suivante.
+
+### `AnimateSpriteSync` (synchro framerate)
+
+```asm
+        jsr   AnimateSpriteSync
+```
+
+Identique mais décrémente `anim_frame_duration` de `gfxlock.frameDrop.count` (typiquement 1 à 50 Hz, 2 à 25 Hz). Permet une vitesse d'animation **stable visuellement** même en cas de frame drop.
+
+> **Pré-requis** : `gfxlock` doit être actif (`_gfxlock.loop` appelé chaque frame). Sans gfxlock, `frameDrop.count = 0`, ce qui fait que l'animation ne progresse jamais.
+
+### `AnimateSpriteLoad`
+
+Recharge le sprite courant **sans avancer**. Utile quand on a modifié `anim,u` mais qu'on veut afficher la frame immédiatement (au lieu d'attendre le prochain `AnimateSprite`).
+
+### `AnimateSpriteAdv` (v02 avancée)
+
+Pour le format animation v02 (5 octets/frame avec duration et flags). Lit `anim_flags,u` comme offset dans une LUT applicative pour déclencher des **callbacks** au moment précis de chaque frame (e.g. hitbox, son).
+
+### `AnimateSpriteAdvSync`
+
+Version sync de `AnimateSpriteAdv` (`gfxlock.frameDrop.count` appliqué).
+
+### `AnimateSpriteAdvLoad`
+
+Version load de `AnimateSpriteAdv` (recharge sans avancer).
+
+### `AnimateMove`
+
+Animation **dirigée par un script de mouvement** (`AnimateMoveInit` + `AnimateMove`). Le script définit pour chaque pas : frame à afficher, vélocité X, vélocité Y. Utile pour des trajectoires scriptées avec animation synchronisée.
+
+---
+
+## Format animation v00 (legacy)
+
+Déclaration dans le `.properties` de l'objet :
+
+```properties
+animation.Ani_Idle=2;Img_Idle_000;Img_Idle_001;Img_Idle_002;_resetAnim
+```
+
+Le `2` est la **duration globale** (frames par image, **stockée en mémoire moins 1** par le builder).
+
+Format binaire généré :
+```
+adresse_label    : (rien — label seulement)
+adresse_label-1  : 01           ; duration-1 (donc 2 frames par image)
+adresse_label+0  : pointeur Img_Idle_000 (2 octets)
+adresse_label+2  : pointeur Img_Idle_001 (2 octets)
+adresse_label+4  : pointeur Img_Idle_002 (2 octets)
+adresse_label+6  : $FF (_resetAnim)
+```
+
+> **Détail crucial** : la duration est stockée **avant** le label, accessible via `-1,x`. C'est pour ça que le code asm fait `ldb -1,x; stb anim_frame_duration,u`.
+
+## Format animation v02 (advanced)
+
+Détecté automatiquement par le builder par la **présence d'une virgule** dans le premier champ.
+
+```properties
+animation.Ani_Attack=Img_Atk_001,3,$00;Img_Atk_002,2,$01;Img_Atk_003,5,$02;_nextRoutine
+```
+
+Chaque frame = `Img,duration,flags` (5 octets stockés : `fdb image; fcb duration-1; fcb flags`).
+
+Format binaire :
+```
+adresse_label    : pointeur Img_Atk_001 (2)
+adresse_label+2  : 02 (duration-1, soit 3 frames)
+adresse_label+3  : 00 (flags = offset 0 dans LUT applicative)
+adresse_label+4  : pointeur Img_Atk_002 (2)
+adresse_label+6  : 01
+adresse_label+7  : 01
+adresse_label+8  : pointeur Img_Atk_003 (2)
+adresse_label+10 : 04
+adresse_label+11 : 02
+adresse_label+12 : $FC (_nextRoutine)
+```
+
+Le builder lève une exception si une frame v02 n'a pas exactement 3 champs séparés par virgules.
+
+## Tags de fin
+
+| Tag | Hex | Octets | Effet |
+|-----|-----|--------|-------|
+| `_resetAnim` | $FF | 1 | Boucle au début (reset anim_frame=0, lit la première frame) |
+| `_goBackNFrames` | $FE | 2 | `_goBackNFrames;<N>` — recule de N frames dans la séquence |
+| `_goToAnimation` | $FD | 3 | `_goToAnimation;<Ani_X>` — bascule sur l'animation X (pointeur 2 octets) |
+| `_nextRoutine` | $FC | 1 | `inc routine,u` (passe à la routine suivante de l'objet) |
+| `_resetAnimAndSubRoutine` | $FB | 1 | Reset anim_frame=0 ET routine_secondary=0 |
+| `_nextSubRoutine` | $FA | 1 | `inc routine_secondary,u` |
+
+Voir [references/animation-formats.md](references/animation-formats.md) pour les détails binaires.
+
+## Mécanisme `anim,u` — adresse vs offset
+
+Le champ `anim,u` peut être :
+- **Positif** (`bpl @a`) : adresse directe du script en mémoire
+- **Négatif** : offset signé 8-bit dans `Ani_Asd_Index` LUT (animation set descriptor)
+
+Le second mécanisme permet d'utiliser des **index courts** plutôt que des adresses pleines, économisant de la mémoire dans certains cas (animation set descriptors).
+
+```asm
+        ldx   anim,u
+        bpl   @a                        ; positif → adresse directe
+        ldx   #Ani_Asd_Index            ; négatif → consulte la LUT
+        ldb   id,u                      ; B = ObjID_
+        aslb
+        abx
+        ldx   [,x]                      ; load Ani_LUT premier
+        ldb   anim+1,u                  ; load offset
+        abx
+        ldx   ,x                        ; load target anim address
+@a      ; X = adresse du script
+```
+
+## `anim_link_mask` — chaînage sans reset
+
+Quand l'utilisateur change `anim,u` pour passer à une autre animation, le moteur **reset** `anim_frame=0` et `anim_frame_duration=0` par défaut.
+
+Si on veut continuer **à la même frame index** (par exemple pour une transition fluide), mettre le bit `anim_link_mask` dans `anim_flags,u` :
+
+```asm
+        ldd   #Ani_RunFast
+        std   anim,u
+        lda   anim_flags,u
+        ora   #anim_link_mask
+        sta   anim_flags,u
+```
+
+Le moteur ne reset pas et l'animation continue à la frame où elle était. Pratique pour passer de `Ani_Walk` à `Ani_Run` (mêmes frames, vitesse différente).
+
+## Application de `status_flags` sur `render_flags`
+
+Pendant `AnimateSprite`, le moteur applique `status_flags` (orientation locale de l'objet) sur les bits 0-1 de `render_flags` (orientation de rendu) :
+
+```asm
+        lda   status_flags,u
+        anda  #status_xflip_mask|status_yflip_mask  ; bits 0-1
+        sta   @dyn+1
+        lda   render_flags,u
+        anda  #^(render_xmirror_mask|render_ymirror_mask)
+@dyn    ora   #0                                     ; modifié dynamiquement
+        sta   render_flags,u
+```
+
+Effet : si `status_flags = $01` (xflip), alors `render_xmirror_mask` est mis dans `render_flags` au moment de l'animation. Permet de contrôler l'orientation via `status_flags` (variable de logique) sans toucher à `render_flags` (variable de rendu).
+
+## Patterns d'usage
+
+### Animation simple en boucle
+
+```properties
+animation.Ani_Idle=2;Img_Idle_001;Img_Idle_002;Img_Idle_003;_resetAnim
+```
+
+```asm
+Init
+        ldd   #Ani_Idle
+        std   anim,u
+        inc   routine,u
+        rts
+
+Main
+        jsr   AnimateSprite
+        jmp   DisplaySprite
+```
+
+### Chaînage intro → loop
+
+```properties
+animation.Ani_intro=4;Img_intro_001;Img_intro_002;Img_intro_003;_goToAnimation;Ani_loop
+animation.Ani_loop=2;Img_loop_001;Img_loop_002;_resetAnim
+```
+
+### Animation puis transition d'état
+
+```properties
+animation.Ani_Die=2;Img_die_001;Img_die_002;Img_die_003;_nextRoutine
+```
+
+```asm
+Init
+        ; ...
+        inc   routine,u                 ; passe à Live
+
+Live
+        ; si HP=0, déclencher Die
+        tst   <my_hp
+        bne   @alive
+        ldd   #Ani_Die
+        std   anim,u
+        ; routine reste 1 (Live), mais l'animation Die va déclencher _nextRoutine
+@alive
+        jsr   AnimateSprite             ; va exécuter _nextRoutine → routine 2
+        jmp   DisplaySprite
+
+; routine 2 — cleanup après animation Die
+        ; ... cleanup ...
+        lda   render_flags,u
+        ora   #render_todelete_mask
+        sta   render_flags,u
+        rts
+```
+
+### Animation v02 avec callbacks
+
+```properties
+animation.Ani_Punch=Img_atk_001,2,$00;Img_atk_002,3,$04;Img_atk_003,4,$00;_resetAnim
+```
+
+Avec une LUT applicative qui associe `flags=$04` à une callback de dégâts :
+
+```asm
+; LUT
+Punch_FlagLut
+        fdb   Punch_NoOp                ; flags = $00
+        fdb   Punch_NoOp                ; flags = $01
+        fdb   Punch_NoOp                ; flags = $02
+        fdb   Punch_NoOp                ; flags = $03
+        fdb   Punch_DamageHitbox        ; flags = $04 → ICI
+        ; ...
+```
+
+Le moteur (via `AnimateSpriteAdv`) lit `anim_flags,u`, indexe dans `Punch_FlagLut`, et appelle la routine. Cela permet de placer des hitboxes exactement à la bonne frame.
+
+---
+
+## `moveByScript` — scripts de trajectoire
+
+Système plus avancé : un script décrit une trajectoire complète (déplacements + animations + speeds), exécutée frame par frame.
+
+Format d'un script : segments, chaque segment définit une suite de pas (`POSXSTEP`, `NEGXSTEP`, `POSYSTEP`, `NEGYSTEP`, ...).
+
+L'objet a deux pointeurs OST :
+- `anim,u` : pointeur vers le script global
+- `sub_anim,u` : pointeur vers le segment courant
+
+Routines :
+- `moveByScript.register` : enregistre l'object_id contenant les données d'animation
+- `moveByScript.initialize` : charge un script (`X = index dans LUT`)
+- `moveByScript.runByFrameDrop` : exécute le script (compense automatique frame drop)
+- `moveByScript.runByB` : exécute B fois
+
+Voir [references/movebyscript.md](references/movebyscript.md) pour les détails.
+
+---
+
+## Pitfalls
+
+- **`anim,u` non initialisé** : pointeur `0` → adresse invalide → crash ou affichage random
+- **`AnimateSpriteSync` sans gfxlock** : `frameDrop.count = 0` permanent → animation figée
+- **Modifier `anim,u` sans `anim_link_mask`** : reset automatique de `anim_frame` (peut être voulu ou non)
+- **Format v02 mal formé** : exception au build « need three comma separated parameters »
+- **Animation infinie sans `_resetAnim`** : le moteur lit après la fin du script → comportement erratique
+- **`_nextRoutine` dans une animation v02** : OK, fonctionne identiquement à v00
+- **Tag `$FF` non géré** : si l'animation déborde et tombe sur un octet $FF, c'est `_resetAnim` qui se déclenche → boucle accidentelle
+- **`Ani_Page_Index`/`Ani_Asd_Index`** : tables générées par le builder, ne pas y écrire manuellement
+- **`anim_frame` non reset après changement d'animation** : `anim_link_mask` mis → le moteur ne reset pas, frame index hors range
+- **Confusion `anim_flags` et `status_flags`** : même offset (14), choisir lequel utiliser selon le mode (v00 → `status_flags` pour orient, v02 → `anim_flags` pour LUT)
+
+---
+
+## Références détaillées
+
+- [references/animation-formats.md](references/animation-formats.md) — Format v00 binaire détaillé, format v02, comparaison, parsing par le builder Java, génération du `.glb` d'animation, layouts mémoire exacts
+- [references/animate-routines.md](references/animate-routines.md) — Comparaison des 7 routines : `AnimateSprite`, `Sync`, `Load`, `Adv`, `AdvSync`, `AdvLoad`, et leurs cas d'usage, coûts CPU, dépendances (`gfxlock`, ALU)
+- [references/end-tags.md](references/end-tags.md) — Sémantique précise de chaque tag $FF/$FE/$FD/$FC/$FB/$FA : effet sur `anim_frame`, `routine`, `routine_secondary`, comment ils sont parsés par `AnimateSprite`, comment les utiliser pour chaîner des animations ou déclencher des transitions
+- [references/animation-callbacks-v02.md](references/animation-callbacks-v02.md) — Format v02 callbacks : `anim_flags` comme offset, construction d'une LUT applicative, patterns hitbox, son, particules synchronisées avec frames spécifiques
+- [references/movebyscript.md](references/movebyscript.md) — Système `moveByScript` complet : format binaire des scripts (bitfield frame/x_vel/y_vel), segments, `moveByScript.register`/`initialize`/`runByFrameDrop`/`runByB`, équates `POSXSTEP`/`NEGXSTEP`/`POSYSTEP`/`NEGYSTEP`, intégration avec `glb_a0`/`glb_d0`, callbacks objet à chaque step
+- [references/animate-internals.md](references/animate-internals.md) — Mécanique interne d'`AnimateSprite` : résolution `anim,u` (adresse directe vs Ani_Asd_Index LUT), application `status_flags` sur `render_flags`, gestion du `prev_anim` pour détection de changement, interaction avec `image_set` lu par `DrawSprites`

--- a/skills/thomson-to8-engine-animation/references/animate-routines.md
+++ b/skills/thomson-to8-engine-animation/references/animate-routines.md
@@ -1,0 +1,185 @@
+# Routines `AnimateSprite*` — comparaison
+
+L'engine fournit 7 variantes de la routine d'animation, à choisir selon le format de script et les besoins de synchronisation.
+
+## Tableau récap
+
+| Routine | Format script | Sync framerate | Avance | Cas d'usage |
+|---------|--------------|----------------|--------|-------------|
+| `AnimateSprite` | v00 | non | oui | Animation simple sans gfxlock |
+| `AnimateSpriteSync` | v00 | oui | oui | Animation v00 avec gfxlock (recommandé) |
+| `AnimateSpriteLoad` | v00 | non | **non** | Recharger sans avancer |
+| `AnimateSpriteAdv` | v02 | non | oui | Animation avancée sans gfxlock |
+| `AnimateSpriteAdvSync` | v02 | oui | oui | Animation avancée avec gfxlock |
+| `AnimateSpriteAdvLoad` | v02 | non | **non** | Recharger v02 sans avancer |
+| `AnimateMove` | (script mvt) | (variable) | (variable) | Animation pilotée par script de trajectoire |
+
+## `AnimateSprite` — basique
+
+```asm
+        jsr   AnimateSprite             ; U = OST
+```
+
+Algorithme :
+1. Mount la page d'animation (`Ani_Page_Index[id]`)
+2. Charger `X = anim,u` (résoudre adresse ou LUT via `Ani_Asd_Index`)
+3. Comparer avec `prev_anim,u` → si différent, reset anim_frame
+4. `dec anim_frame_duration,u`
+5. Si > 0 → fin (pas de changement de frame)
+6. Si <= 0 → lire la prochaine frame, mettre à jour `image_set,u`, traiter tag éventuel
+7. Appliquer `status_flags` sur `render_flags`
+8. Restaurer la page sortante
+
+Coût : ~80-120 cycles (selon le chemin pris)
+
+## `AnimateSpriteSync` — synchro framerate
+
+Identique à `AnimateSprite` SAUF la décrémentation :
+
+```asm
+@Anim_Run
+        ldb   anim_frame_duration,u
+        subb  gfxlock.frameDrop.count   ; au lieu de dec
+        stb   anim_frame_duration,u
+        bpl   @Anim_Rts                 ; si > 0, fin
+        ; ...
+@b      ldb   -1,x
+        addb  anim_frame_duration,u     ; reload + report du delta
+        subb  gfxlock.frameDrop.count
+        stb   anim_frame_duration,u
+        bpl   @Anim_Reload
+        clr   anim_frame_duration,u     ; cap à 0 si overflow
+```
+
+Si `gfxlock.frameDrop.count = 2` (frame drop), l'animation avance de 2 frames d'un coup. Permet de garder la vitesse perçue stable.
+
+**Pré-requis** : gfxlock actif (cf. `_gfxlock.loop` qui met à jour `frameDrop.count`).
+
+## `AnimateSpriteLoad` — recharger sans avancer
+
+Identique à `AnimateSprite` mais **n'incrémente pas `anim_frame`** et **ne décrémente pas `anim_frame_duration`**. Recharge juste l'image courante dans `image_set,u`.
+
+Usage : quand on a modifié `anim,u` à la main et qu'on veut voir le résultat **immédiatement** (sans attendre une frame).
+
+```asm
+        ldd   #Ani_Idle
+        std   anim,u
+        jsr   AnimateSpriteLoad         ; affiche la première frame de Idle maintenant
+        jmp   DisplaySprite
+```
+
+Sans `Load`, le sprite afficherait l'image précédente jusqu'au prochain `AnimateSprite`.
+
+## `AnimateSpriteAdv` — v02
+
+Pour le format v02 (5 octets/frame avec duration et flags). Différences par rapport à `AnimateSprite` :
+
+```asm
+@b
+        ldb   1,x                       ; lire duration-1 (1 octet)
+        stb   anim_frame_duration,u
+        ldd   ,x                        ; lire image_set (2 octets)
+        std   image_set,u
+        ldb   3,x                       ; lire flags (1 octet)
+        stb   anim_flags,u              ; pour callback applicatif
+        ; ...
+```
+
+Le champ `anim_flags,u` est mis à jour à chaque frame. L'application peut le consulter pour déclencher des callbacks.
+
+**Note importante** : `anim_flags` overlap `status_flags` (offset 14). En mode v02, on perd l'usage de `status_flags` pour l'orientation — il faut gérer xflip/yflip via `render_flags` directement.
+
+## `AnimateSpriteAdvSync`
+
+Version sync de `AnimateSpriteAdv`. Comme Sync : applique `frameDrop.count`.
+
+## `AnimateSpriteAdvLoad`
+
+Version load de `AnimateSpriteAdv`. Recharge l'image courante (v02) sans avancer.
+
+## `AnimateMove` — script de trajectoire
+
+Différent de tous les autres : ne lit pas un script d'animation classique. Lit un **script de mouvement** dont les segments définissent `x_vel`, `y_vel`, `anim_frame` à chaque pas.
+
+```asm
+AnimateMoveInit
+        stx   anim,u                    ; X = adresse du script
+        ldd   ,x
+        std   sub_anim,u                ; sub_anim = adresse du premier segment
+        rts
+
+AnimateMove
+        ldy   sub_anim,u
+        beq   @rts                      ; fin de script
+        ldd   #0
+        std   x_vel,u
+        std   y_vel,u
+        ldb   ,y+                       ; lire bitfield frame
+@frame  lslb
+        bcc   @xvel
+        lda   ,y+
+        sta   anim_frame,u              ; modif frame
+@xvel   lslb
+        bcc   @yvel
+        ldx   ,y++
+        stx   x_vel,u                   ; modif vitesse X
+@yvel   ; ...
+```
+
+Le bitfield indique quels champs sont présents dans le segment :
+- Bit 7 : nouveau `anim_frame` (1 octet)
+- Bit 6 : nouvelle `x_vel` (2 octets)
+- Bit 5 : nouvelle `y_vel` (2 octets)
+- (autres bits...)
+
+Permet d'avoir des séquences scriptées complexes : « avance 5 pixels à droite, change de frame, avance vers le haut, ... » sans avoir besoin de logique dans la routine de l'objet.
+
+## Quand utiliser quoi
+
+```
+Tu fais :                                    → Routine à utiliser
+──────────────────────────────────────────  ─────────────────────────
+Animation simple avec frame duration globale  AnimateSpriteSync (si gfxlock)
+                                                AnimateSprite (sinon)
+Animation avec durations variables par frame   AnimateSpriteAdvSync (si gfxlock)
+                                                AnimateSpriteAdv (sinon)
+Animation avec callbacks (hitbox, son)         AnimateSpriteAdvSync + LUT applicative
+Recharger l'image instantanément               AnimateSpriteLoad ou AnimateSpriteAdvLoad
+Trajectoire scriptée avec frames variables     AnimateMove
+```
+
+Recommandation : **AnimateSpriteSync** par défaut (gfxlock recommandé pour tout nouveau projet).
+
+## Dépendances communes
+
+Toutes ces routines :
+- Mount la page de l'objet pour accéder à `Ani_Page_Index` et `Ani_Asd_Index`
+- Sauvent et restaurent la page courante (via `_GetCartPageA` / `_SetCartPageA`)
+- Lisent `anim,u`, écrivent `anim_frame`, `anim_frame_duration`, `image_set`
+- Pour Sync : lisent `gfxlock.frameDrop.count`
+- Pour Adv : lisent et écrivent `anim_flags`
+
+Toutes utilisent le **registre U** pour pointer l'OST. Aucune n'utilise `X` en input.
+
+## Coût CPU
+
+| Routine | Cycles approximatifs |
+|---------|----------------------|
+| `AnimateSprite` | ~80 (chemin standard, pas de tag) |
+| `AnimateSpriteSync` | ~85 |
+| `AnimateSpriteLoad` | ~70 |
+| `AnimateSpriteAdv` | ~95 |
+| `AnimateSpriteAdvSync` | ~100 |
+| `AnimateMove` | variable (~50-150 selon bitfield) |
+
+Sur 50 Hz (20000 cycles/frame), ~25 sprites animés = 2000-2500 cycles soit ~10-12% du budget. Largement OK.
+
+## Pitfalls
+
+- **Mélanger v00 et v02 sur le même objet** : impossible, le format est par animation
+- **`AnimateSprite` (v00) sur une animation v02** : lit les pointeurs d'image comme si c'étaient des frames v00, sortie visuellement cassée
+- **`AnimateSpriteAdv` sur v00** : lit la duration comme un pointeur Img_, crash
+- **`AnimateSpriteSync` sans `_gfxlock.loop`** : `frameDrop.count = 0` → animation figée
+- **Appeler `AnimateSpriteLoad` puis `AnimateSprite` la même frame** : double avance possible
+- **Modifier `anim,u` puis appeler `AnimateSprite` sans `AnimateSpriteLoad`** : l'image change avec un délai d'une frame (le moteur lit ancien `prev_anim` la frame en cours)
+- **`AnimateMove` sans `AnimateMoveInit`** : `sub_anim,u` non init → crash

--- a/skills/thomson-to8-engine-animation/references/animation-callbacks-v02.md
+++ b/skills/thomson-to8-engine-animation/references/animation-callbacks-v02.md
@@ -1,0 +1,177 @@
+# Callbacks d'animation v02
+
+Le format v02 (5 octets/frame avec duration et flags) permet de **déclencher des callbacks applicatifs** synchronisés avec les frames de l'animation. Mécanisme : le champ `flags` (1 octet par frame) est lu par `AnimateSpriteAdv` et stocké dans `anim_flags,u`. Le code applicatif peut le consulter pour exécuter une action.
+
+## Principe
+
+```properties
+animation.Ani_Punch=Img_anticipate,4,$00;Img_strike,1,$01;Img_recover,4,$00;_resetAnim
+```
+
+À chaque frame, après l'appel à `AnimateSpriteAdv`, le code peut faire :
+
+```asm
+        jsr   AnimateSpriteAdv
+        lda   anim_flags,u
+        cmpa  #$01
+        bne   @no_hitbox
+        jsr   DamageHitbox              ; appliquer dégâts maintenant
+@no_hitbox
+        jmp   DisplaySprite
+```
+
+`$01` est arbitraire — c'est l'application qui définit la sémantique.
+
+## Pattern avec LUT applicative
+
+Pour découpler la logique de la valeur de flag, utiliser une **LUT (Look-Up Table)** :
+
+```asm
+; LUT — une routine par valeur de flag
+Punch_FlagLut
+        fdb   Punch_NoOp                ; $00 → rien
+        fdb   Punch_Hitbox              ; $01 → dégâts
+        fdb   Punch_SoundFX             ; $02 → son
+        fdb   Punch_Particle            ; $03 → particule
+
+Punch_NoOp
+        rts
+
+Punch_Hitbox
+        ; ... appliquer dégâts ...
+        rts
+
+Punch_SoundFX
+        ; ... jouer son ...
+        rts
+
+Punch_Particle
+        ; ... émettre particule ...
+        rts
+```
+
+Dans la routine principale :
+
+```asm
+Main
+        jsr   AnimateSpriteAdvSync      ; met à jour anim_flags,u
+        ldb   anim_flags,u
+        aslb
+        ldx   #Punch_FlagLut
+        jsr   [b,x]                     ; appel indirect
+        jmp   DisplaySprite
+```
+
+Coût : ~25 cycles pour le dispatch + cycles de la callback. Comparable à un test conditionnel direct mais beaucoup plus extensible.
+
+## Plusieurs flags simultanés (bitfield)
+
+Si `flags` est interprété comme un **bitfield** plutôt qu'un index, on peut combiner :
+
+```asm
+HITBOX_FLAG     equ $01
+SFX_FLAG        equ $02
+PARTICLE_FLAG   equ $04
+
+Main
+        jsr   AnimateSpriteAdvSync
+        lda   anim_flags,u
+        bita  #HITBOX_FLAG
+        beq   @no_hitbox
+        jsr   ApplyHitbox
+@no_hitbox
+        bita  #SFX_FLAG
+        beq   @no_sfx
+        jsr   PlaySFX
+@no_sfx
+        bita  #PARTICLE_FLAG
+        beq   @no_particle
+        jsr   EmitParticle
+@no_particle
+        jmp   DisplaySprite
+```
+
+Permet par exemple : `flags = $03` → hitbox ET son.
+
+## Conventions de flag
+
+Choisir une convention par animation ou globale au projet :
+
+### Convention par animation (locale)
+
+```properties
+animation.Ani_Slash=Img_a,2,$00;Img_b,1,$01;Img_c,2,$00;_resetAnim   ; $01 = slash hitbox
+animation.Ani_Punch=Img_a,2,$00;Img_b,1,$01;Img_c,2,$00;_resetAnim   ; $01 = punch hitbox
+```
+
+Avantage : pas de table globale, chaque animation a sa sémantique. Code de l'objet teste `flags = $01` et déclenche l'action de l'animation courante.
+
+### Convention globale (table)
+
+Tous les `$01` du jeu = hitbox, tous les `$02` = son, etc. Plus de cohérence mais moins de flexibilité.
+
+## Cas pratique — combo avec timing
+
+```properties
+animation.Ani_Combo=Img_anticipate,6,$00;Img_strike1,1,$01;Img_recover,3,$00;Img_anticipate,4,$00;Img_strike2,1,$03;Img_recover,5,$00;_resetAnim
+```
+
+Avec `$01 = HITBOX_FLAG`, `$02 = HITSTUN_FLAG`, `$03 = HITBOX | HITSTUN` :
+
+- Frame 1 (anticipate) : rien
+- Frame 2 (strike1) : hitbox (1er coup léger)
+- Frame 3 (recover) : rien
+- Frame 4 (anticipate) : rien
+- Frame 5 (strike2) : hitbox + hitstun (2ème coup + immobilise la cible)
+- Frame 6 (recover) : rien
+
+Tout est piloté par le script d'animation, sans logique conditionnelle complexe.
+
+## Interaction avec `routine_secondary`
+
+L'animation v02 peut piloter directement `routine_secondary` via `_nextSubRoutine` ou `_resetAnimAndSubRoutine` (tags $FA/$FB), ce qui complète le mécanisme de callbacks par flag.
+
+```properties
+animation.Ani_Sequence_step1=Img_a,2,$01;Img_b,2,$00;_nextSubRoutine
+animation.Ani_Sequence_step2=Img_c,2,$02;Img_d,2,$00;_resetAnimAndSubRoutine
+```
+
+Chaque étape se termine par un tag de transition.
+
+## Coût
+
+`AnimateSpriteAdv` lit le flag à chaque frame et stocke dans `anim_flags,u` (~5 cycles supplémentaires par rapport à `AnimateSprite`).
+
+Le code applicatif (LUT, bita, jsr) ajoute ~15-30 cycles selon la complexité.
+
+## `anim_flags` overlap avec `status_flags`
+
+`anim_flags` est à l'offset 14 — **même offset que `status_flags`**. En mode v02 :
+- `anim_flags,u` est écrit à chaque frame par `AnimateSpriteAdv`
+- `status_flags,u` est donc **écrasé**
+
+Implication : en v02, on **perd l'usage de `status_flags`** pour l'orientation xflip/yflip. Il faut gérer xflip/yflip directement via `render_flags,u`.
+
+```asm
+; Avant (v00) — orientation via status_flags
+        lda   status_flags,u
+        ora   #status_xflip_mask
+        sta   status_flags,u
+
+; Avec v02 — orientation directement via render_flags
+        lda   render_flags,u
+        ora   #render_xmirror_mask
+        sta   render_flags,u
+```
+
+C'est un trade-off du format v02.
+
+## Pitfalls
+
+- **`AnimateSprite` (v00) sur animation v02** : flags non lus, callbacks pas déclenchées
+- **`AnimateSpriteAdv` sur v00** : interprète la duration comme un pointeur Img_, crash
+- **LUT avec moins d'entrées que de valeurs de flag possibles** : flag $05 sur LUT de 4 entrées → lecture hors range
+- **Modifier `anim_flags,u` après `AnimateSpriteAdv`** : valide, mais sera écrasé à la prochaine frame
+- **Confondre `anim_flags` et `render_flags`** : ce sont deux champs différents (offset 14 vs 2). `anim_flags` est mis à jour par AnimateSpriteAdv, `render_flags` par l'utilisateur
+- **Callbacks coûteuses** : si la callback met 1000 cycles, sur 25 sprites animés ça pète le budget frame
+- **State pollution via `anim_flags`** : si on utilise aussi `status_flags`, choisir lequel a priorité

--- a/skills/thomson-to8-engine-animation/references/animation-formats.md
+++ b/skills/thomson-to8-engine-animation/references/animation-formats.md
@@ -1,0 +1,177 @@
+# Formats d'animation — v00 et v02
+
+L'engine supporte deux formats de script d'animation : **v00** (legacy, duration globale) et **v02** (advanced, duration et flags par frame). Le format est **auto-détecté** par le builder Java en regardant si le premier champ contient une virgule.
+
+## Auto-détection (builder Java)
+
+Dans `BuildDisk.java` (`writeAniIndex`) :
+
+```java
+if (!animationProperties.getValue()[0].contains(",")) {
+    // ** Animation v00 ** — premier champ = duration (entier)
+} else {
+    // ** Animation v02 ** — premier champ = "Img,duration,flags"
+}
+```
+
+## Format v00 — legacy
+
+### Syntaxe `.properties`
+
+```properties
+animation.Ani_<X>=<duration>;<Img_1>;<Img_2>;...;<end-tag>[;<param>]
+```
+
+`<duration>` est un entier (frames par image, **commun à toutes les frames**).
+
+Exemples :
+```properties
+animation.Ani_Idle=2;Img_Idle_001;Img_Idle_002;Img_Idle_003;_resetAnim
+animation.Ani_Fall=0;Img_Fall_001;_resetAnim
+animation.Ani_Walk=4;Img_Walk_001;Img_Walk_002;Img_Walk_003;Img_Walk_004;_goBackNFrames;3
+animation.Ani_Die=3;Img_die_a;Img_die_b;Img_die_c;_nextRoutine
+```
+
+### Binaire généré
+
+```
+adresse_label_courant-1 : fcb duration   ; mais le builder stocke duration-1 (cf. ci-dessous)
+adresse_label_courant   : fdb Img_<1>    ; pointeur premier sprite (2 octets)
+adresse_label_courant+2 : fdb Img_<2>
+adresse_label_courant+4 : ...
+                          fcb tag_FX     ; tag + param éventuel
+```
+
+> **Important** : `duration` est stockée **moins 1** par le builder. C'est pour ça que `0` dans le .properties signifie « 1 frame par image ». La routine `AnimateSprite` décrémente `anim_frame_duration` jusqu'à passer à -1 (`bpl` est faux), puis charge la frame suivante.
+
+> **Position de duration** : juste **avant** le label. Le code asm fait `ldb -1,x; stb anim_frame_duration,u` pour la lire après avoir indexé sur `x = adresse_label`.
+
+### Calcul de taille
+
+```java
+size++;                          // duration (1 byte)
+for chaque frame :
+  if frame != tag : size += 2;   // pointeur Img_ (2 bytes)
+  else : size += taille_tag;     // 1, 2 ou 3 bytes selon tag
+```
+
+### Génération asm (extrait `BuildDisk.java`)
+
+```java
+asm.addFcb(new String[] { animationProperties.getValue()[0] });   // duration-1
+asm.addLabel(animationProperties.getKey() + " ");                  // Ani_<X>
+for (int i = 1; i < animationProperties.getValue().length; i++) {
+    if (Animation.tagSize.get(...) == null) {
+        asm.addFdb(new String[] { animationProperties.getValue()[i] });   // Img_
+        size += 2;
+    } else {
+        // tag : 1, 2, ou 3 octets
+        asm.addFcb(new String[] { animationProperties.getValue()[i] });
+        // params éventuels
+    }
+}
+```
+
+### Tags
+
+| Tag | Hex | Bytes |
+|-----|-----|-------|
+| `_resetAnim` | $FF | 1 |
+| `_goBackNFrames` | $FE | 2 (FE + N) |
+| `_goToAnimation` | $FD | 3 (FD + 2 bytes adresse) |
+| `_nextRoutine` | $FC | 1 |
+| `_resetAnimAndSubRoutine` | $FB | 1 |
+| `_nextSubRoutine` | $FA | 1 |
+
+## Format v02 — advanced
+
+### Syntaxe `.properties`
+
+```properties
+animation.Ani_<X>=<Img_1>,<duration>,<flags>;<Img_2>,<duration>,<flags>;...;<end-tag>[;<param>]
+```
+
+Chaque frame fait **3 champs séparés par virgules** :
+- `Img_<X>` : pointeur sprite
+- `duration` : nombre de frames d'affichage (1 = 1 frame, etc.) — stocké en **moins 1** par le builder
+- `flags` : octet de flag (interprété par `AnimateSpriteAdv` comme offset dans une LUT applicative)
+
+Exemple :
+```properties
+animation.Ani_Attack=Img_atk_001,3,$00;Img_atk_002,2,$01;Img_atk_003,5,$02;_resetAnim
+```
+
+### Binaire généré
+
+```
+adresse_label : fdb Img_atk_001    ; 2 octets
+                fcb duration-1     ; 1 octet (= 2 = 3 frames d'affichage)
+                fcb flags          ; 1 octet (= $00)
+                ; total 4 octets... mais le builder écrit 5 octets en réalité
+
+                fdb Img_atk_002
+                fcb 1              ; duration-1 = 1 = 2 frames
+                fcb $01
+
+                fdb Img_atk_003
+                fcb 4              ; duration-1 = 4 = 5 frames
+                fcb $02
+
+                fcb $FF            ; _resetAnim
+```
+
+> **Détail** : le code java `BuildDisk.java` écrit `fdb image + fcb duration + fcb flags` = **5 octets par frame**. À vérifier dans le binaire généré (peut être 4 ou 5 selon les commits).
+
+### Différence clé avec v00
+
+- **Pas de duration globale** : chaque frame a sa propre duration
+- **Flag par frame** : offset dans une LUT applicative pour callbacks (hitbox, son, particle)
+- **5 octets par frame** au lieu de 2 (pointeur seul)
+
+### Avantage v02
+
+Animation où la durée varie (attaque qui ralentit en fin de mouvement, anticipation/recovery) :
+
+```properties
+animation.Ani_AttackCombo=Img_anticipate,8,0;Img_strike,1,1;Img_recover_a,4,0;Img_recover_b,8,0;_resetAnim
+```
+
+- Anticipation lente (8 frames sur la première image)
+- Strike rapide (1 frame seulement, mais avec flag $01 pour la hitbox)
+- Recovery progressive
+
+## Format combiné (rare)
+
+Mélanger v00 et v02 dans une même animation n'est **pas supporté**. Une animation est soit l'un soit l'autre (détecté sur la première frame).
+
+## `animation-data` — données pré-générées
+
+```properties
+animation-data=./path/to/preset.bin
+```
+
+Un blob binaire placé **avant** les animations dans le `.glb` généré. Cas d'usage : scripts `moveByScript` pré-compilés, tables custom.
+
+**Limite** : `if (animationDataProperties.size()>1) throw new Exception` — une seule entrée `animation-data` par objet.
+
+## Génération du fichier `.glb`
+
+Pour chaque objet, le builder génère un fichier `<obj>_Animation.asm` qui contient :
+1. Les données `animation-data` (si présentes)
+2. Toutes les animations de l'objet (labels Ani_X + données binaires)
+
+Inclus dans le code asm de l'objet via prepend automatique :
+```asm
+        INCLUDE "<generated-code>/<objname>_Animation.asm"
+```
+
+C'est ce fichier qui fournit les labels `Ani_<X>` utilisés par le code (`ldd #Ani_Idle; std anim,u`).
+
+## Pitfalls
+
+- **Confondre duration et nb de frames affichées** : `duration=2` = 2 frames d'affichage par image (1 frame d'affichage = `duration=0` dans v00, `duration=1` dans v02 .properties — le builder ajuste)
+- **Format v02 avec moins de 3 champs** : exception au build « need three comma separated parameters »
+- **Animation v02 mais routine AnimateSprite** (non Adv) : les flags par frame ne sont pas lus, comportement v00 sur structure v02 → désynchronisation
+- **`_goToAnimation` avec adresse mal formée** : 2 octets après le tag $FD doivent pointer un label `Ani_<X>` valide
+- **Tag $FF accidentel** dans les données (mauvais alignement) : trigger _resetAnim involontaire
+- **Modifier le binaire d'animation à la main** : risque de désaligner les frames (5 octets en v02, 2 en v00)

--- a/skills/thomson-to8-engine-animation/references/end-tags.md
+++ b/skills/thomson-to8-engine-animation/references/end-tags.md
@@ -1,0 +1,188 @@
+# Tags de fin d'animation — sémantique précise
+
+Les tags ($FA-$FF) terminent (ou modifient le flux de) une animation. Chaque tag a une sémantique précise lue par `AnimateSprite`.
+
+## Table de référence
+
+| Mnémonique | Hex | Octets | Effet |
+|------------|-----|--------|-------|
+| `_resetAnim` | $FF | 1 | Boucle au début |
+| `_goBackNFrames` | $FE | 2 (FE + N) | Recule de N frames |
+| `_goToAnimation` | $FD | 3 (FD + addr) | Bascule sur une autre animation |
+| `_nextRoutine` | $FC | 1 | `inc routine,u` + reset anim_frame_duration |
+| `_resetAnimAndSubRoutine` | $FB | 1 | Reset anim_frame=0 ET routine_secondary=0 |
+| `_nextSubRoutine` | $FA | 1 | `inc routine_secondary,u` |
+
+Détection : `cmpa #$FA; bhs Anim_End_FF` (tout octet >= $FA est un tag).
+
+## `_resetAnim` ($FF) — boucle infinie
+
+```asm
+Anim_End_FF
+        inca                            ; A passe de $FF à $00
+        bne   Anim_End_FE
+        ; A = 0 → tag est $FF
+        ldb   #0
+        stb   anim_frame,u              ; reset à la frame 0
+        ldd   ,x                        ; relit la première frame
+        bra   Anim_Next                 ; affiche immédiatement
+```
+
+Usage :
+```properties
+animation.Ani_Idle=2;Img_001;Img_002;Img_003;_resetAnim
+```
+
+Animation en boucle infinie. Le moteur revient à `Img_001` après `Img_003`.
+
+## `_goBackNFrames` ($FE) — recul
+
+```asm
+Anim_End_FE
+        inca                            ; $FE + 1 = $FF? non, +1 = $FF, vérifie via inca puis bne
+        ; ... (le code utilise inca pour distinguer FE de FD et FC)
+        lda   anim_frame,u
+        stb   Anim_End_FE_dyn+1         ; B = N (le param du tag)
+        suba  #$00                      ; dynamic : soustrait N
+        sta   anim_frame,u
+        ldb   #2
+        mul                             ; ajuste l'index dans la table d'images
+        ldd   d,x
+        bra   Anim_Next
+```
+
+Param : 1 octet (N) après le $FE.
+
+Usage :
+```properties
+animation.Ani_PingPong=2;Img_a;Img_b;Img_c;Img_d;_goBackNFrames;3
+```
+
+Le moteur joue `a, b, c, d` puis recule de 3 frames → revient à `b` → joue `b, c, d` puis recule à `b` → ainsi de suite. Effet ping-pong.
+
+## `_goToAnimation` ($FD) — chaînage
+
+```asm
+Anim_End_FD
+        inca
+        bne   Anim_End_FC
+        ldd   1,y                       ; lire les 2 octets après FD = adresse de la nouvelle anim
+        std   anim,u
+        bra   Anim_Rts                  ; sortir, la nouvelle anim sera jouée à la prochaine frame
+```
+
+Param : 2 octets (adresse `Ani_<X>`) après le $FD.
+
+Usage :
+```properties
+animation.Ani_Intro=4;Img_intro_a;Img_intro_b;Img_intro_c;_goToAnimation;Ani_Loop
+animation.Ani_Loop=2;Img_loop_a;Img_loop_b;_resetAnim
+```
+
+Le moteur joue `Ani_Intro` une fois puis bascule sur `Ani_Loop` en boucle.
+
+> Le moteur ne **reset pas** `anim_frame` au passage à la nouvelle animation. C'est `AnimateSprite` qui détecte le changement via `prev_anim != anim` et reset.
+
+## `_nextRoutine` ($FC) — transition d'état
+
+```asm
+Anim_End_FC
+        inca
+        bne   Anim_End_FB
+        inc   routine,u                 ; passe à la routine suivante
+        lda   #0
+        sta   anim_frame_duration,u
+        inc   anim_frame,u
+        bra   Anim_Rts
+```
+
+Effet :
+- `inc routine,u` → l'objet passe à la routine suivante
+- Reset `anim_frame_duration` à 0
+- Incrémente `anim_frame` (pour ne pas revoir le tag à la prochaine frame de cette même animation)
+
+Usage :
+```properties
+animation.Ani_Die=3;Img_die_a;Img_die_b;Img_die_c;_nextRoutine
+```
+
+Quand `Ani_Die` finit, l'objet passe à `routine+1` (typiquement la routine de cleanup ou suppression). Permet de chaîner « animation puis logique » en mode déclaratif.
+
+## `_resetAnimAndSubRoutine` ($FB)
+
+```asm
+Anim_End_FB
+        inca
+        bne   Anim_End_FA
+        lda   #0
+        sta   anim_frame,u              ; reset frame 0
+        sta   routine_secondary,u       ; reset sous-routine
+        bra   Anim_Rts
+```
+
+Combinaison `_resetAnim` + reset de `routine_secondary,u`. Usage : terminer une sub-séquence et revenir à un état initial.
+
+```properties
+animation.Ani_AttackCombo_a=2;Img_atk_a;Img_atk_b;_resetAnimAndSubRoutine
+```
+
+Si l'attaque a été interrompue dans sa séquence (`routine_secondary=2` était utilisé pour tracker l'étape), reset à 0.
+
+## `_nextSubRoutine` ($FA)
+
+```asm
+Anim_End_FA
+        inca
+        bne   Anim_End                  ; (n'est pas un tag connu)
+        inc   routine_secondary,u
+        bra   Anim_Rts                  ; (via Anim_End)
+```
+
+Effet : `inc routine_secondary,u`. Animation finie → passe à la sous-routine suivante.
+
+```properties
+animation.Ani_AttackCombo_step1=2;Img_001;Img_002;_nextSubRoutine
+animation.Ani_AttackCombo_step2=2;Img_003;Img_004;_nextSubRoutine
+animation.Ani_AttackCombo_step3=2;Img_005;Img_006;_resetAnim
+```
+
+Permet une state-machine d'animation au niveau de la sub-routine, indépendante de `routine`.
+
+## Combinaisons
+
+Tu peux combiner plusieurs tags dans une animation, mais ils s'excluent mutuellement (le moteur lit le premier tag rencontré et n'évalue pas les suivants).
+
+```properties
+animation.Ani_Conditional=2;Img_a;Img_b;_nextRoutine;Img_c   ← Img_c jamais joué
+```
+
+`_nextRoutine` est exécuté après `Img_b`, l'objet passe à `routine+1` qui peut sélectionner une autre animation.
+
+## Tags v02
+
+En format v02, les tags sont placés **après** la dernière frame (5 octets/frame). Sémantique identique. Le moteur (`AnimateSpriteAdv`) détecte les tags par la valeur >= $FA après l'avancement.
+
+## Conventions de nommage
+
+L'équivalence asm est dans `engine/graphics/animation/constants-animation.equ` :
+
+```asm
+_resetAnim                    equ $FF
+_goBackNFrames                equ $FE
+_goToAnimation                equ $FD
+_nextRoutine                  equ $FC
+_resetAnimAndSubRoutine       equ $FB
+_nextSubRoutine               equ $FA
+```
+
+Ce fichier est inclus via `builder.constAnim=./engine/graphics/animation/constants-animation.equ` (cf. config-windows.properties).
+
+## Pitfalls
+
+- **Tag accidentel dans les données** : si l'animation déborde, le moteur peut tomber sur un octet $FA-$FF dans la mémoire suivante et déclencher un tag involontaire. Toujours terminer par un tag explicite.
+- **`_goBackNFrames` avec N > nb_frames** : sous-flow de `anim_frame`, comportement imprévisible. Toujours N < frame courante.
+- **`_goToAnimation` avec adresse invalide** : crash. Vérifier que `Ani_<X>` est bien défini.
+- **`_nextRoutine` sans routine suivante définie** : `routine,u` passe à un index hors range → jump indirect sur une mauvaise adresse → crash
+- **Tag dans une animation à 1 frame** : pas de réelle « fin » à atteindre, le tag s'exécute à chaque frame
+- **Mélange `_resetAnim` (boucle) et `_nextRoutine`** : choisir un seul ; le second est exécuté seulement si le `anim_frame` traverse le `_nextRoutine` et le `_resetAnim` est passé
+- **Convention « -1 » du builder** : `duration=2` dans .properties → stocké en mémoire comme `01` ; n'oublie pas que le `0` (1 frame d'affichage) est valide

--- a/skills/thomson-to8-engine-animation/references/movebyscript.md
+++ b/skills/thomson-to8-engine-animation/references/movebyscript.md
@@ -1,0 +1,236 @@
+# `moveByScript` — scripts de trajectoire
+
+`moveByScript` est un système d'animation **dirigé par script** où chaque pas du script définit :
+- une frame à afficher
+- une vélocité X
+- une vélocité Y
+- une vitesse d'animation (anim_frame_duration)
+
+Permet de programmer des trajectoires complexes (waves, courbes, patterns d'attaque) en mode déclaratif.
+
+## Vue d'ensemble
+
+```
+Script (en mémoire) = suite de SEGMENTS
+Chaque segment = "anim_frame_duration" + suite de STEPS
+Chaque step = bitfield + (optionnellement) frame, x_vel, y_vel, ...
+
+OST de l'objet pendant l'exécution :
+  anim,u           → pointeur vers le script global (ou LUT)
+  sub_anim,u       → pointeur vers le segment courant
+  anim_frame_duration,u → durée restante avant le pas suivant
+```
+
+## Format du script
+
+### Step
+
+Chaque step commence par un **bitfield** (1 octet) qui indique quels champs sont présents :
+
+```
+Bit | Champ      | Bytes
+----|------------|------
+7   | new frame  | 1
+6   | new x_vel  | 2
+5   | new y_vel  | 2
+4   | new ...    | ...
+0   | end-of-step (?)
+```
+
+Implémentation observée :
+```asm
+AnimateMove
+        ldy   sub_anim,u
+        beq   @rts
+        ldd   #0
+        std   x_vel,u
+        std   y_vel,u
+        ldb   ,y+                       ; read bitfield
+@frame  lslb
+        bcc   @xvel
+        lda   ,y+
+        sta   anim_frame,u
+@xvel   lslb
+        bcc   @yvel
+        ldx   ,y++
+        stx   x_vel,u
+@yvel   lslb
+        ; ...
+```
+
+Le bitfield est shifté (`lslb`) bit par bit ; chaque bit positif déclenche la lecture du champ correspondant.
+
+### Segment
+
+Un segment regroupe plusieurs steps avec une vitesse d'animation commune.
+
+```
+adresse_segment :
+  fcb   speed       ; anim_frame_duration pour ce segment (1 octet)
+  ; suite de steps...
+  fcb   $00         ; marqueur fin de segment
+adresse_segment_suivant : ...
+```
+
+Le moteur lit `speed` au début, puis joue chaque step en attendant `speed` frames entre.
+
+## Macros et équates
+
+```asm
+; Équates à définir dans le code utilisateur
+moveByScript.NEGXSTEP equ scale.XN1PX     ; valeur du déplacement X négatif
+moveByScript.POSXSTEP equ scale.XP1PX
+moveByScript.NEGYSTEP equ scale.YN1PX
+moveByScript.POSYSTEP equ scale.YP1PX
+
+; Variables internes
+moveByScript.callback       equ glb_a0
+moveByScript.anim.speed     equ glb_d0
+moveByScript.anim.end       equ glb_d0_b
+moveByScript.anim.loops     equ glb_d0_b+1
+```
+
+## Routines
+
+### `moveByScript.register`
+
+Enregistre l'objet contenant les données d'animation (typiquement l'objet `ObjID_animation` du game-mode) :
+
+```asm
+        ldb   #ObjID_animation
+        jsr   moveByScript.register
+```
+
+Sauvegarde la page+adresse pour usage ultérieur. À appeler une fois au boot du game-mode.
+
+### `moveByScript.initialize`
+
+Charge un script dans l'OST courant :
+
+```asm
+        ldx   #script_index             ; index dans la LUT
+        jsr   moveByScript.initialize
+```
+
+Effet :
+- `anim,u` = adresse du script
+- `sub_anim,u` = adresse du premier segment
+
+### `moveByScript.runByFrameDrop`
+
+Exécute le script en utilisant `gfxlock.frameDrop.count` pour compenser le drop :
+
+```asm
+        jsr   moveByScript.runByFrameDrop
+```
+
+Si `frameDrop.count = 2`, le script avance de 2 steps d'un coup.
+
+### `moveByScript.runByB`
+
+Exécute B fois (passé en registre B) :
+
+```asm
+        ldb   #1
+        jsr   moveByScript.runByB       ; 1 step
+```
+
+Permet un contrôle fin si on ne veut pas dépendre de frameDrop.
+
+## Algorithme `runByFrameDrop`
+
+```asm
+moveByScript.runByFrameDrop
+        ldb   gfxlock.frameDrop.count
+moveByScript.runByB
+        tstb
+        bne   >
+        ldb   #1                        ; cap à 1 minimum
+!       stb   moveByScript.anim.loops
+        _GetCartPageA
+        sta   @page
+@loop   lda   #0
+moveByScript.anim.page.2 equ *-1
+        _SetCartPageA
+        lda   anim_frame_duration,u
+        sta   moveByScript.anim.speed
+LAB_0000_f9c6
+        ldx   sub_anim,u
+        ldb   ,x+                       ; lit bitfield du step
+        ; ... applique chaque champ selon les bits ...
+```
+
+## Format complet d'un script
+
+```
+Script ($0000) :
+  fdb segment_1                         ; adresse premier segment
+  
+Segment 1 ($0002) :
+  fcb 4                                 ; speed = 4 frames par step
+  fcb %11000000                         ; bitfield : new_frame + new_x_vel
+    fcb 5                               ; new frame = 5
+    fdb $0100                           ; new x_vel = $0100 (= +1.0)
+  fcb %01000000                         ; new_x_vel seul
+    fdb $0080                           ; +0.5
+  fcb %10000000                         ; new_frame seul
+    fcb 6
+  ; ... autres steps
+  fcb 0                                 ; fin de segment
+  fdb segment_2                         ; adresse segment suivant
+
+Segment 2 ($XXXX) :
+  fcb 2                                 ; speed plus rapide
+  ; ...
+```
+
+## Usage typique
+
+```asm
+; Au boot du game-mode
+        ldb   #ObjID_animation
+        jsr   moveByScript.register
+
+; Init d'un objet ennemi
+Init
+        ldx   #5                        ; index du script "pattern_5"
+        jsr   moveByScript.initialize
+        inc   routine,u
+        rts
+
+; Main de l'objet
+Main
+        jsr   moveByScript.runByFrameDrop
+        jsr   ObjectMoveSync            ; applique x_vel/y_vel (modifiés par le script)
+        jsr   AnimateSprite             ; affiche la frame (anim_frame,u modifié par le script)
+        jmp   DisplaySprite
+```
+
+## Cas d'usage
+
+- **Patterns d'ennemis** : un ennemi qui suit une trajectoire en zig-zag, en cercle, en S
+- **Cinématiques** : objet qui traverse l'écran selon un parcours scénarisé
+- **Animations complexes** : changement de frame ET de position simultané (e.g. un personnage qui saute)
+- **Réutilisation** : un script peut être réutilisé par plusieurs objets (chaque objet ouvre le même script avec son propre `sub_anim`)
+
+## Différence avec animation v02
+
+| Aspect | Animation v02 | moveByScript |
+|--------|---------------|--------------|
+| Pilote | Frame + flags | Frame + x_vel + y_vel + ... |
+| Mouvement | Géré par l'objet (logique) | **Inclus dans le script** |
+| Callbacks | Via `anim_flags` LUT | Via `moveByScript.callback` |
+| Format | 5 octets/frame fixe | Bitfield variable (1-7 octets/step) |
+
+`moveByScript` est plus **puissant** mais aussi plus **complexe**. Pour de simples animations cycliques, préférer v00/v02. Pour des trajectoires complexes (boss patterns), `moveByScript` est plus adapté.
+
+## Pitfalls
+
+- **`moveByScript.register` non appelé** : `anim.page.2` non init, page random mountée → crash
+- **`moveByScript.initialize` avec un index invalide** : pointe hors LUT, `anim,u` invalide
+- **Script sans fin de segment ($00)** : le moteur continue de lire la mémoire → comportement erratique
+- **`anim_frame_duration` modifié par autre chose** : la vitesse d'animation change
+- **Bitfield mal compris** : si on inverse l'ordre des champs dans le script, le moteur lit la mauvaise séquence
+- **Mélanger `moveByScript` avec `ObjectMove`** : OK ; `moveByScript` modifie `x_vel`/`y_vel`, `ObjectMove` applique
+- **Sans `ObjectMoveSync` après `moveByScript.runByFrameDrop`** : `x_vel`/`y_vel` mis à jour mais position pas changée → l'objet est figé visuellement
+- **`moveByScript` consulté depuis l'IRQ** : pas re-entrant, ne pas appeler depuis UserIRQ

--- a/skills/thomson-to8-engine-audio/SKILL.md
+++ b/skills/thomson-to8-engine-audio/SKILL.md
@@ -1,0 +1,434 @@
+---
+name: thomson-to8-engine-audio
+description: "Décrit l'architecture audio du Thomson TO8/TO9 game engine (Bento8/wide-dot) : matériel YM2413 OPLL FM 9 voies (6 mélodie + 3 percussion via DAM) et SN76489 PSG 4 voies (3 mélodie + 1 bruit) accessibles via $E7F4-$E7F7 (sound card prototype SOUND_CARD_PROTOTYPE) ou $E7F8 (jumper SN76489_JUMPER_LOW), objet engine ymm (YM2413vgm player avec ymm.command.PLAY/STOP/RESTART, YVGM_MusicData/Page/Status, ym2413zx0_decompress), objet engine vgc (VGC compressed VGM player avec vgcplayer.h.asm/vgcplayer.asm, vgc_init, vgc_update, exomiser support), macros _MusicInit_objymm / _MusicInit_objvgc / _MusicFrame_objymm / _MusicFrame_objvgc (paramètres : track number, MUSIC_LOOP/MUSIC_NO_LOOP, fade), macro _MountObject pour mounter l'objet avant l'appel, ChiP réinitialisation ym2413.reset / sn76489.reset, system Smps (Sega Sample Music Playback System pour 6809, Smps.asm/Smps_S1.asm/SmpsMidi.asm/SmpsObj.asm/Smidi.asm, SMPS_VOICE/NB_FM/NB_PSG/TEMPO/DELAY headers), MusicFrame routine, IrqObjSmps integration, Svgm small VGM player, YM2413vgm player direct, samples PCM/DPCM via PlayDPCM16kHz / PlayDPCM8kHz / PlayPCM, DAC drums dans engine/sound/dac/, soundFX system avec _soundFX.play (sound id + priority, soundFX.newSound, soundFX.curSound), PSGlib librairie SN76489, déclaration des objets sound dans game-mode (object.ymm=engine/objects/sound/ymm/ymm.properties, object.vgc=engine/objects/sound/vgc/vgc.properties), pattern UserIRQ avec _ymm.processFrame et _MusicFrame_objvgc, formats binaires (VGC, VGM, .ymm.zx0, .dmf source). Utiliser pour intégrer une musique, jouer un effet sonore, choisir entre YM2413 et SN76489, configurer SMPS pour port Mega Drive, gérer DAC pour percussion, comprendre les players VGC/VGM, mettre en place l'audio engine via gameModeCommon. Mots-clés : YM2413, SN76489, OPLL, PSG, FM, vgc, ymm, ym2413vgm, vgcplayer, Smps, SMPS_S1, SmpsMidi, SmpsObj, Smidi, Svgm, YM2413vgm, soundFX, PSGlib, PlayDPCM16kHz, PlayDPCM8kHz, PlayPCM, sn76489.reset, ym2413.reset, vgc_init, vgc_update, ym2413zx0_decompress, YVGM_MusicData, YVGM_MusicPage, YVGM_MusicStatus, YVGM_WaitFrame, YVGM_loop, YVGM_callback, YM2413_buffer, YM2413.A, YM2413.D, SN76489.D, $E7F4, $E7F5, $E7F6, $E7F7, $E7F8, ymm.command, ymm.command.PLAY, ymm.command.STOP, ymm.command.RESTART, _MusicInit_objvgc, _MusicInit_objymm, _MusicFrame_objvgc, _MusicFrame_objymm, _ymm.processFrame, _ymm.play, _ymm.stop, _ymm.restart, _soundFX.play, soundFX.newSound, soundFX.curSound, MUSIC_LOOP, MUSIC_NO_LOOP, SOUND_CARD_PROTOTYPE, SN76489_JUMPER_LOW, MusicFrame, IrqObjSmps, SMPS_VOICE, SMPS_NB_FM, SMPS_NB_PSG, SMPS_TEMPO, SMPS_DELAY, SMPS_TEMPO_DELAY, DAC drums, vgmconverter, vgmpacker, ymvgm, vgc compression, dpcm, pcm."
+machines: [to8, to8d, to9, to9+]
+user-invocable: false
+---
+
+# Audio — Thomson TO8/TO9 Game Engine
+
+L'engine fournit plusieurs systèmes audio cohabitant :
+
+| Système | Type | Utilisation |
+|---------|------|-------------|
+| **ymm** (YM2413vgm) | Player FM (YM2413) | Musique mélodique riche |
+| **vgc** | Player VGM compressé (SN76489) | Musique PSG |
+| **Smps** | SMPS Sega port (multi-driver) | Compatible Sonic 2 / Mega Drive |
+| **Svgm** | Small VGM | Lecture VGM brut (moins compressé) |
+| **soundFX** | Effets sonores | One-shot SFX |
+| **DAC/PCM/DPCM** | Samples | Drums, voix |
+
+Hardware ciblé :
+- **YM2413** (OPLL) : 9 voies FM (ou 6+3 percussion), via `$E7F4-$E7F5`
+- **SN76489** (PSG) : 4 voies (3 mélodie + 1 bruit), via `$E7F6` ou `$E7F8`
+
+---
+
+## Hardware audio
+
+```asm
+YM2413.A         equ   $E7F4            ; address register
+YM2413.D         equ   $E7F5            ; data register
+
+SN76489.D        equ   $E7F6            ; data (SOUND_CARD_PROTOTYPE)
+; OR
+SN76489.D        equ   $E7F8            ; data (jumper low)
+```
+
+Le `SOUND_CARD_PROTOTYPE` est défini au début du `main.asm` pour signaler quelle carte son est utilisée (ancien prototype vs version finale) :
+
+```asm
+SOUND_CARD_PROTOTYPE equ 1              ; ancien port SN79486
+SN76489_JUMPER_LOW   equ 1              ; jumper bas
+```
+
+Ces flags conditionnent les `IFDEF` dans les routines engine.
+
+### Reset des chips
+
+```asm
+        jsr   sn76489.reset             ; coupe le PSG
+        jsr   ym2413.reset              ; coupe le FM
+```
+
+À appeler au boot ou à la fin d'un game-mode pour silence garanti.
+
+---
+
+## Objet `ymm` (YM2413vgm)
+
+Player YM2413 utilisant un format compressé (.ymm.zx0).
+
+### Déclaration
+
+```properties
+object.ymm=./engine/objects/sound/ymm/ymm.properties
+```
+
+Génère `ObjID_ymm`.
+
+### Commandes
+
+```asm
+ymm.command.PLAY           equ $80
+ymm.command.STOP           equ $81
+ymm.command.RESTART        equ $82
+```
+
+### Macros
+
+```asm
+_MusicInit_objymm MACRO
+        lda   \1                        ; param 1 : track number
+        ldy   \3                        ; param 3 : fade (typiquement 0)
+        ldb   \2                        ; param 2 : MUSIC_LOOP / MUSIC_NO_LOOP
+        jsr   ,x                        ; entry point de l'objet ymm
+        ENDM
+
+_MusicFrame_objymm MACRO
+        ldb   #$80                      ; PLAY tick
+        jsr   ,x
+        ENDM
+```
+
+### Pattern d'usage
+
+```asm
+; Init au boot
+        _MountObject ObjID_ymm
+        _MusicInit_objymm #0,#MUSIC_LOOP,#0     ; track 0, en boucle, fade 0
+
+; Tick à chaque VBL (UserIRQ)
+UserIRQ
+        ; ...
+        _MountObject ObjID_ymm
+        _ymm.processFrame                ; macro qui lit ymm.command + jsr ,x
+        rts
+```
+
+`_ymm.processFrame` est défini dans `ymm.macro.asm` :
+```asm
+_ymm.processFrame MACRO
+        ldb   ymm.command
+        jsr   ,x
+        ENDM
+```
+
+### Macros de contrôle dynamique
+
+```asm
+_ymm.play MACRO
+        lda   #ymm.command.PLAY
+        sta   ymm.command
+        ENDM
+
+_ymm.stop MACRO
+        lda   #ymm.command.STOP
+        sta   ymm.command
+        ENDM
+
+_ymm.restart MACRO
+        lda   #ymm.command.RESTART
+        sta   ymm.command
+        ENDM
+```
+
+À appeler pour changer l'état du player en cours.
+
+### Variables internes
+
+```asm
+YVGM_MusicData    fdb 0       ; pointeur vers les data musique
+YVGM_MusicPage    fcb 0       ; page mémoire
+YVGM_MusicStatus  fcb 0       ; 0/1
+YVGM_WaitFrame    fcb 0       ; compteur d'attente
+YVGM_loop         fcb 0       ; flag boucle
+YVGM_callback     fdb 0       ; routine callback fin
+YM2413_buffer                 ; buffer de décompression
+```
+
+Voir [references/ymm-player.md](references/ymm-player.md).
+
+---
+
+## Objet `vgc` (VGC compressed)
+
+Player VGM compressé (SN76489). Plus compact que VGM brut, lecture rapide.
+
+### Déclaration
+
+```properties
+object.vgc=./engine/objects/sound/vgc/vgc.properties
+```
+
+Génère `ObjID_vgc`.
+
+### Macros (idem ymm)
+
+```asm
+_MusicInit_objvgc MACRO
+        lda   \1
+        ldy   \3
+        ldb   \2
+        jsr   ,x
+        ENDM
+
+_MusicFrame_objvgc MACRO
+        ldb   #$80
+        jsr   ,x
+        ENDM
+```
+
+### Usage
+
+```asm
+        _MountObject ObjID_vgc
+        _MusicInit_objvgc #0,#MUSIC_LOOP,#0
+
+UserIRQ
+        ; ...
+        _MountObject ObjID_vgc
+        _MusicFrame_objvgc
+        rts
+```
+
+### Player interne
+
+L'objet `vgc` s'appuie sur `engine/sound/vgc/lib/vgcplayer.asm` (et `.h.asm`). Player optimisé 6809 par Bentoc.
+
+Variables :
+```asm
+vgc_port_01..04                ; auto-modif pour les écritures SN76489
+```
+
+Voir [references/vgc-player.md](references/vgc-player.md).
+
+---
+
+## SMPS (Sonic Mega Player System)
+
+Port 6809 du driver musical Sonic 2 (basé sur la disassembly Z80 par Xenowhirl/RAS/Flamewing).
+
+Fichiers :
+- `Smps.asm` — driver principal
+- `Smps_S1.asm` — variante Sonic 1
+- `SmpsMidi.asm` — MIDI integration
+- `SmpsObj.asm` — wrapper objet
+- `Smidi.asm` — Small MIDI
+
+### Header SMPS
+
+```asm
+SMPS_VOICE                   equ   0   ; offset vers les voices FM
+SMPS_NB_FM                   equ   2   ; nb tracks FM
+SMPS_NB_PSG                  equ   3   ; nb tracks PSG
+SMPS_TEMPO                   equ   4
+SMPS_TEMPO_DELAY             equ   4
+SMPS_DELAY                   equ   5
+```
+
+### Usage
+
+```asm
+        lda   #$01
+        sta   Smps.60HzData             ; force 60 Hz playback
+        jsr   YM2413_DrumModeOn
+
+        ; ... load song ...
+
+; UserIRQ
+UserIRQ_Pal_Smps
+        jsr   PalUpdateNow
+        jmp   MusicFrame                ; routine SMPS de tick
+```
+
+Utilisé exclusivement par sonic-2.
+
+Voir [references/smps-player.md](references/smps-player.md).
+
+---
+
+## soundFX — effets sonores
+
+Système séparé pour les effets sonores **one-shot** (saut, tir, explosion).
+
+### Macro
+
+```asm
+_soundFX.play MACRO
+        ; param 1 : sound id
+        ; param 2 : priority (0-127)
+        ; Check prio nouvelle vs précédente
+        lda   soundFX.newSound+1
+        anda  #$7F
+        sta   @prevPri
+        lda   #\2
+        anda  #$7F
+        cmpa  #0
+@prevPri equ   *-1
+        blo   @exit                     ; nouvelle prio < ancienne → skip
+        bhi   @set                      ; nouvelle > ancienne → set
+        lda   soundFX.curSound+1
+        bmi   @exit                     ; si current locked, skip
+@set
+        ldd   #((\1)*256)+\2
+        std   soundFX.newSound
+@exit
+        ENDM
+```
+
+Système de priorité :
+- bit 7 = lock (le son ne peut pas être interrompu)
+- bits 0-6 = priorité (0-127)
+
+```asm
+        _soundFX.play SND_jump,5         ; priorité 5
+        _soundFX.play SND_die,127        ; priorité max
+        _soundFX.play SND_explosion,$87  ; priorité 7 + lock
+```
+
+### Variables
+
+```asm
+soundFX.newSound    fdb 0       ; demandé
+soundFX.curSound    fdb 0       ; en cours
+```
+
+Le tick (à appeler depuis UserIRQ) consulte `newSound`, le compare au current, puis joue.
+
+Utilisé exclusivement par r-type.
+
+Voir [references/soundfx-system.md](references/soundfx-system.md).
+
+---
+
+## Samples PCM/DPCM
+
+Pour les drums et voix, l'engine fournit des routines de lecture de samples :
+
+- `PlayDPCM16kHz.asm` : Differential PCM 16 kHz
+- `PlayDPCM8kHz.asm` : DPCM 8 kHz (moins de qualité, plus de samples)
+- `PlayPCM.asm` : PCM brut
+
+Les samples sont dans `engine/sound/dac/` :
+```
+DAC_81.bin ... DAC_87.bin       ; 7 samples drums
+DefDrum.txt                     ; définitions
+sample_rates.txt                ; détail kHz
+dpcm2pcm.exe                    ; outil conversion
+```
+
+Outil `dpcm2pcm.exe` pour convertir PCM → DPCM.
+
+Voir [references/dac-pcm-samples.md](references/dac-pcm-samples.md).
+
+---
+
+## Patterns d'intégration
+
+### MainLoop avec ymm + vgc
+
+```asm
+; Init au boot
+        _MountObject ObjID_ymm
+        _MusicInit_objymm #0,#MUSIC_LOOP,#0
+        _MountObject ObjID_vgc
+        _MusicInit_objvgc #0,#MUSIC_LOOP,#0
+
+; UserIRQ
+UserIRQ
+        jsr   gfxlock.bufferSwap.check
+        jsr   PalUpdateNow
+        _MountObject ObjID_ymm
+        _ymm.processFrame
+        _MountObject ObjID_vgc
+        _MusicFrame_objvgc
+        rts
+```
+
+### Partage via gameModeCommon
+
+Audio engine partagé entre tous les game-modes (cf. skill `engine-new-game/references/gamemode-properties.md`) :
+
+```properties
+# global/common-audio.properties
+object.ymm=./engine/objects/sound/ymm/ymm.properties
+object.vgc=./engine/objects/sound/vgc/vgc.properties
+
+# game-mode/X/main.properties
+gameModeCommon.0=./global/common-audio.properties
+```
+
+Économie ROM T2 : le code audio n'est écrit qu'une fois.
+
+### Changement de musique
+
+```asm
+        ; Stop current
+        _ymm.stop
+        
+        ; Wait some frames for fade-out
+        ; ...
+        
+        ; Init new track
+        _MountObject ObjID_ymm
+        _MusicInit_objymm #5,#MUSIC_LOOP,#$60   ; track 5, fade in $60
+```
+
+### Désactiver YM (force silence)
+
+bubble-bobble fait :
+```asm
+        ; disable ym soundtrack temporarily
+        ldd   #$E7F4
+        std   DYN.YM2413.A              ; redirige les writes vers RAM
+        std   DYN.YM2413.D
+
+        ; ... plus tard, restaurer ...
+        ldd   #YM2413.A
+        std   DYN.YM2413.A
+        ldd   #YM2413.D
+        std   DYN.YM2413.D
+```
+
+Astuce : auto-modif les adresses cible pour qu'elles écrivent en RAM (sans effet) au lieu du chip.
+
+---
+
+## Conversion de formats
+
+| Format source | Outil | Cible |
+|---------------|-------|-------|
+| .vgm (raw VGM) | `vgmpacker.py` | .vgc (VGC compressé) |
+| .vgm | (direct) | Svgm input |
+| .ymm.zx0 | (déjà compressé) | ymm input |
+| .dmf (DefleMask) | (export ext) | .vgm puis .vgc |
+
+Pipeline goldorak observé : `bb-sn.vgc`, `bb-ym-ym2413.ymm.zx0`, `bubbleBubble2024.dmf` (source DefleMask).
+
+---
+
+## Pitfalls
+
+- **`SOUND_CARD_PROTOTYPE` mal défini** : adresses hardware fausses, son inaudible ou crash
+- **`_MountObject` avant l'init** : page non set, lecture random
+- **YMM et VGC initialisés mais pas tickés** : pas de son après quelques frames
+- **`ym2413.reset` oublié** au changement de game-mode : drone résiduel
+- **Multiples `_soundFX.play` avec même priorité** : seule la dernière jouée (lock requis pour persister)
+- **Tick audio dans MainLoop au lieu d'UserIRQ** : timing musical incorrect, tempo qui dérive
+- **`_MountObject ObjID_X`** dans le code utilisateur sans restaurer la page : si l'objet est appelé depuis RunObjects, crash au retour
+- **VGC sans `vgc_init`** : crash à la première frame
+- **DAC drum mode pas activé** : drums YM2413 inaudibles (`YM2413_DrumModeOn`)
+- **Mélange ymm et vgc sur même channel** : conflits hardware (le SN76489 ne peut faire qu'un seul truc à la fois)
+
+---
+
+## Références détaillées
+
+- [references/audio-architecture.md](references/audio-architecture.md) — Hardware YM2413+SN76489 : adresses $E7F4-$E7F8, SOUND_CARD_PROTOTYPE vs SN76489_JUMPER_LOW, registres FM (instruments/feedback/key on), registres PSG (volume/freq/noise), drum mode, schéma fonctionnel
+- [references/ymm-player.md](references/ymm-player.md) — Objet ymm complet : YVGM_MusicData/Page/Status/WaitFrame/loop/callback, ym2413zx0_decompress, commandes PLAY/STOP/RESTART, format .ymm.zx0, intégration avec UserIRQ, exemples de callback
+- [references/vgc-player.md](references/vgc-player.md) — Objet vgc : vgcplayer.asm/.h.asm, vgc_init/vgc_update, format VGC, exomiser support, vgc_port_01..04 auto-modif, format binaire compressé, conversion .vgm → .vgc via vgmpacker.py
+- [references/smps-player.md](references/smps-player.md) — SMPS Mega Drive : Smps.asm/Smps_S1.asm/SmpsMidi.asm/SmpsObj.asm/Smidi.asm, header SMPS_VOICE/NB_FM/NB_PSG/TEMPO/DELAY, MusicFrame, IrqObjSmps, 60Hz/50Hz, intégration avec Sonic 2 disassembly, Smps.60HzData
+- [references/soundfx-system.md](references/soundfx-system.md) — soundFX : _soundFX.play macro, système de priorité (0-127 + bit lock), soundFX.newSound vs curSound, queue, tick depuis UserIRQ, intégration avec ymm/vgc, exemples (saut, tir, explosion)
+- [references/dac-pcm-samples.md](references/dac-pcm-samples.md) — Samples : PlayDPCM16kHz vs DPCM8kHz vs PCM, format DPCM (différentiel), conversion via dpcm2pcm.exe, drums DAC_81-87.bin, intégration avec ym2413 drum mode, taux d'échantillonnage et qualité
+- [references/audio-via-common.md](references/audio-via-common.md) — Pattern de partage via gameModeCommon : structure common-audio.properties, économie ROM T2, intégration avec d'autres game-modes, transition de musique entre game-modes

--- a/skills/thomson-to8-engine-audio/references/audio-architecture.md
+++ b/skills/thomson-to8-engine-audio/references/audio-architecture.md
@@ -1,0 +1,213 @@
+# Architecture audio — hardware YM2413 + SN76489
+
+## Vue d'ensemble
+
+Le TO8 utilise typiquement **deux chips audio** ajoutés via une carte d'extension :
+
+- **YM2413 (OPLL)** : synthèse FM 9 voies (ou 6 mélodie + 3 percussion en drum mode)
+- **SN76489 (DCSG)** : PSG 4 voies (3 mélodie + 1 bruit)
+
+Les deux peuvent jouer simultanément (chacun a son propre canal de sortie).
+
+## Adresses hardware
+
+```asm
+YM2413.A         equ   $E7F4            ; address register (sélection registre)
+YM2413.D         equ   $E7F5            ; data register
+
+SN76489.D        equ   $E7F6            ; data (SOUND_CARD_PROTOTYPE défini)
+; OR
+SN76489.D        equ   $E7F8            ; data (jumper low = SN76489_JUMPER_LOW)
+```
+
+### `SOUND_CARD_PROTOTYPE`
+
+```asm
+SOUND_CARD_PROTOTYPE equ 1
+```
+
+Indique l'utilisation de l'ancienne carte son prototype (port SN76489 en `$E7F6`). Si absent ou commenté, la carte finale est utilisée (`$E7F8`).
+
+Conditionne les `IFDEF` dans les routines engine pour pointer le bon registre.
+
+### `SN76489_JUMPER_LOW`
+
+```asm
+SN76489_JUMPER_LOW equ 1
+```
+
+Variante : jumper bas du SN76489. Modifie l'adresse cible.
+
+À déterminer selon la carte son réelle utilisée (ancienne prototype vs version finale).
+
+## YM2413 — synthèse FM
+
+### Registres
+
+| Range | Rôle |
+|-------|------|
+| `$00-$07` | Custom instrument (8 octets) |
+| `$0E` | Rhythm mode + drums on/off |
+| `$0F` | Test (à 0) |
+| `$10-$18` | Voice 0-8 frequency low |
+| `$20-$28` | Voice 0-8 freq high + key on + sustain |
+| `$30-$38` | Voice 0-8 instrument + volume |
+
+### Init (silence)
+
+```asm
+ym2413.reset
+        ldd   #$200E
+        stb   YM2413.A                  ; sélectionne $0E
+        nop                             ; tempo
+        ldb   #0
+        sta   YM2413.D                  ; data = 0 → drums off
+        
+        lda   #$20                      ; start at register $20
+        brn   *                         ; tempo
+@c      exg   a,b                       ; tempo
+        exg   a,b
+        sta   YM2413.A
+        nop
+        inca
+        stb   YM2413.D                  ; data = 0 → key off + freq=0
+        cmpa  #$29                      ; jusqu'à voice 8
+        bne   @c
+        rts
+```
+
+Met toutes les voices à 0 (key off, freq 0) → silence.
+
+### Drum mode
+
+Le YM2413 a 9 voies normales OU 6 mélodie + 3 drums (kick + snare + hi-hat). Activé via bit 5 de `$0E` :
+
+```asm
+        lda   #$0E
+        sta   YM2413.A
+        lda   #$20                      ; bit 5 = rhythm mode on
+        sta   YM2413.D
+```
+
+Pour les drums individuelles :
+- bit 4 (`$10`) : BD (kick)
+- bit 3 (`$08`) : SD (snare)
+- bit 2 (`$04`) : TOM
+- bit 1 (`$02`) : TC (top cymbal)
+- bit 0 (`$01`) : HH (hi-hat)
+
+```asm
+        lda   #$0E
+        sta   YM2413.A
+        lda   #$3F                      ; rhythm on + tous les drums frappés
+        sta   YM2413.D
+```
+
+### Instruments preset (1-15)
+
+Le YM2413 a 15 instruments preset + 1 custom :
+1. Violin
+2. Guitar
+3. Piano
+4. Flute
+5. Clarinet
+6. Oboe
+7. Trumpet
+8. Organ
+9. Horn
+10. Synthesizer
+11. Harpsichord
+12. Vibraphone
+13. Synthesizer Bass
+14. Wood Bass
+15. Electric Guitar
+
+Sélectionnés via les 4 bits hauts du registre `$30-$38`.
+
+## SN76489 — PSG
+
+### Registres
+
+Le SN76489 a 8 registres internes pilotés par le **byte écrit** sur le data port :
+
+```
+Byte : 1 R R R T D D D D    ; latch + register + type + data
+```
+
+Où :
+- bit 7 (`1`) : latch (le byte est une commande)
+- bits 6-4 : register (0-7) :
+  - 0/1 : Voice 0 freq
+  - 2/3 : Voice 1 freq
+  - 4/5 : Voice 2 freq
+  - 6/7 : Voice 3 noise/freq
+- bit 4 : type (0 = freq, 1 = attenuation)
+- bits 3-0 : data (4 bits)
+
+Pour des fréquences complètes (10 bits), il faut 2 écritures (latch puis data sans bit 7).
+
+### Reset
+
+```asm
+sn76489.reset
+        lda   #$9F                      ; voice 0 atten = max (silence)
+        sta   SN76489.D
+        nop
+        nop
+        lda   #$BF                      ; voice 1 silence
+        sta   SN76489.D
+        nop
+        nop
+        lda   #$DF                      ; voice 2 silence
+        sta   SN76489.D
+        nop
+        nop
+        lda   #$FF                      ; voice 3 (noise) silence
+        sta   SN76489.D
+        rts
+```
+
+Met toutes les voices à atténuation max (= silence).
+
+Les `nop` sont là pour respecter le temps minimum entre écritures (le chip a besoin de cycles pour traiter).
+
+## Schéma fonctionnel
+
+```
+6809 (CPU)
+   │
+   ├── $E7F4 / $E7F5 ──→ YM2413 (FM 9 voies) ──→ Audio Out
+   │
+   └── $E7F6 (ou $E7F8) ──→ SN76489 (PSG 4 voies) ──→ Audio Out
+                                                      │
+                                                      └→ Mix → Sortie audio Thomson (6 bits)
+```
+
+Le mix est analogique (sur la carte son).
+
+## Players engine vs hardware direct
+
+Quasi-tous les game-projects utilisent les **players engine** (ymm, vgc, Smps) plutôt que d'écrire directement aux registres. Les players :
+- Gèrent le décodage de format (VGM, VGC, .ymm.zx0, SMPS)
+- Synchronisent avec le tempo
+- Optimisent les écritures (compression, batch)
+
+Les écritures directes (`sta YM2413.D`) sont réservées à :
+- Reset (silence)
+- Test hardware (debugging)
+- Effets sonores très simples (1-2 voices, durée fixe)
+
+## Performance
+
+Le YM2413 et SN76489 sont **passive** : ils n'interrompent pas le CPU, c'est le CPU qui écrit à chaque frame les valeurs (~50 Hz pour la musique, jusqu'à 200 Hz pour les drums DPCM).
+
+Budget par frame pour audio : ~3000-5000 cycles (15-25% du budget total à 50 Hz).
+
+## Pitfalls
+
+- **Mauvais `SOUND_CARD_PROTOTYPE`** : écriture sur la mauvaise adresse, silence
+- **Sans `nop` entre écritures SN76489** : le chip rate des commandes → notes fausses
+- **Drums mode sans `bit 5` de `$0E`** : drums attendus mais c'est 9 voices mélodie
+- **Mix YM/SN** : les deux chips peuvent jouer en même temps, mais attention à la balance volume
+- **Reset au boot mais pas après transition** : drone résiduel
+- **Écriture pendant un VBL ou pas** : si on écrit pendant l'affichage, possible bruit

--- a/skills/thomson-to8-engine-audio/references/smps-and-soundfx.md
+++ b/skills/thomson-to8-engine-audio/references/smps-and-soundfx.md
@@ -1,0 +1,268 @@
+# SMPS et soundFX
+
+## SMPS — port 6809 du Sample Music Playback System
+
+SMPS est le driver musical de Sonic the Hedgehog (Mega Drive). Le port 6809 par Bentoc (juin 2021) reprend la disassembly Z80 de Xenowhirl/RAS/Flamewing.
+
+Utilisé exclusivement par **sonic-2**.
+
+### Fichiers
+
+| Fichier | Rôle |
+|---------|------|
+| `Smps.asm` | Driver principal |
+| `Smps_S1.asm` | Variante Sonic 1 |
+| `SmpsMidi.asm` | Lecture MIDI |
+| `SmpsObj.asm` | Wrapper objet |
+| `Smidi.asm` | Small MIDI |
+| `ChangesFromOriginalSmpsFormat.txt` | Notes de port |
+
+### Header SMPS
+
+```asm
+SMPS_VOICE                   equ   0      ; offset vers définition des voices FM
+SMPS_NB_FM                   equ   2      ; nb tracks FM
+SMPS_NB_PSG                  equ   3      ; nb tracks PSG
+SMPS_TEMPO                   equ   4      ; tempo (BPM)
+SMPS_TEMPO_DELAY             equ   4      ; alias
+SMPS_DELAY                   equ   5      ; delay
+```
+
+### Init
+
+```asm
+        lda   #$01
+        sta   Smps.60HzData             ; force 60Hz playback mode
+        jsr   YM2413_DrumModeOn         ; drum mode YM2413
+
+        ; charger une chanson
+        ldx   #my_smps_song
+        jsr   SmpsLoadSong              ; (à vérifier)
+```
+
+### MusicFrame — tick
+
+```asm
+UserIRQ_Pal_Smps
+        jsr   PalUpdateNow
+        jmp   MusicFrame                ; SMPS tick (= jsr puis rts via jmp)
+```
+
+`MusicFrame` est l'entry point standard du driver. Lit la chanson, applique les commandes au YM2413 + SN76489.
+
+### IrqObjSmps
+
+Wrapper pour intégrer SMPS dans le système d'objet :
+
+```asm
+        INCLUDE "./engine/irq/IrqObjSmps.asm"
+```
+
+Permet d'avoir SMPS comme un objet avec son propre OST. Plus complexe que ymm/vgc mais cohérent avec l'architecture engine.
+
+### 50 Hz vs 60 Hz
+
+Le SMPS original est conçu pour Mega Drive (60 Hz). Le port 6809 supporte les deux :
+- `Smps.60HzData = 1` : compatibilité Mega Drive (1.2× plus rapide)
+- `Smps.60HzData = 0` : 50 Hz natif
+
+À choisir selon que la musique a été composée pour Mega Drive ou pour Thomson.
+
+### Format SMPS
+
+Le format SMPS est complexe (cf. doc disassembly Sonic 2). Compose des morceaux SMPS demande un éditeur spécialisé.
+
+Sonic-2 utilise des morceaux pré-existants extraits de la cartouche originale, adaptés au YM2413+SN76489 du Thomson.
+
+### Pattern UserIRQ avec SMPS + raster
+
+```asm
+UserIRQ_Raster_Smps
+        jsr   PalRaster_1c              ; effet raster palette
+        jmp   MusicFrame                ; SMPS tick
+
+UserIRQ_Pal_Smps
+        jsr   PalUpdateNow              ; pal update standard
+        jmp   MusicFrame
+```
+
+Plusieurs UserIRQ selon le besoin (raster vs normal). Bascule par modification de `Irq_user_routine`.
+
+### Comparaison avec ymm/vgc
+
+| Aspect | SMPS | ymm + vgc |
+|--------|------|-----------|
+| Hardware | YM2413 + SN76489 | YM2413 (ymm) + SN76489 (vgc) |
+| Format | SMPS (Sega) | .ymm.zx0 + .vgc |
+| Complexité | Élevée (multi-track, jingles, FX) | Modérée |
+| CPU | ~2000-3000 cycles/frame | ~2500 cycles/frame |
+| Capacité | Drums multi, jingles, fadeouts | Single track + boucle |
+| Cas d'usage | Sonic 2 (ré-arrangement portage) | Composition originale |
+
+Pour un nouveau projet, **ymm + vgc** est recommandé (plus simple, mieux documenté).
+
+---
+
+## soundFX — effets sonores prioritaires
+
+Système séparé pour les **effets sonores one-shot** (saut, tir, explosion, bonus). Indépendant de la musique en cours.
+
+Utilisé exclusivement par r-type.
+
+### Fichiers
+
+| Fichier | Rôle |
+|---------|------|
+| `soundFX.asm` | Driver |
+| `soundFX.data.asm` | Données (sons compilés) |
+| `soundFX.macro.asm` | Macros utilisateur |
+
+### Macro `_soundFX.play`
+
+```asm
+_soundFX.play MACRO
+        ; param 1 : sound id
+        ; param 2 : priority (0-127) — bit 7 = lock
+        
+        lda   soundFX.newSound+1
+        anda  #$7f
+        sta   @prevPri
+        
+        lda   #\2
+        anda  #$7f
+        cmpa  #0
+@prevPri equ *-1
+        blo   @exit                     ; nouvelle prio < ancienne → skip
+        bhi   @set                      ; nouvelle > ancienne → set
+        
+        lda   soundFX.curSound+1
+        bmi   @exit                     ; current locked → skip
+        
+@set
+        ldd   #((\1)*256)+\2            ; sound id (haut) + priority (bas)
+        std   soundFX.newSound
+@exit
+        ENDM
+```
+
+### Système de priorité
+
+```
+Priority value (1 byte) :
+   Bit 7  : Lock — si 1, le son ne peut pas être interrompu
+   Bits 6-0 : Priority 0-127 (plus haut = plus prioritaire)
+```
+
+Exemples :
+- `$01` (1) : priorité basse, can be replaced
+- `$7F` (127) : priorité max, can be replaced by another 127
+- `$87` (135 = 7+lock) : priorité 7 mais lockée, can't be replaced
+
+### Variables
+
+```asm
+soundFX.newSound    fdb 0       ; demande pendante (sound_id high, priority low)
+soundFX.curSound    fdb 0       ; en cours (idem)
+```
+
+Format : MSB = sound id, LSB = priority.
+
+### Tick (depuis UserIRQ)
+
+```asm
+UserIRQ
+        ; ...
+        jsr   soundFX.tick               ; (à vérifier le nom exact)
+        rts
+```
+
+Le tick :
+1. Si `newSound` != current : consume nouveau son, copie vers `curSound`
+2. Tick le son courant (avance dans son script)
+3. Si fini : reset `curSound`, prêt pour le prochain
+
+### Exemples d'usage
+
+```asm
+; Player saute
+        _soundFX.play SND_jump,5
+
+; Player tir
+        _soundFX.play SND_shoot,10
+
+; Player meurt — priorité max + lock (rien ne peut interrompre)
+        _soundFX.play SND_death,$FF
+
+; Explosion grosse (lock)
+        _soundFX.play SND_bigExplosion,$87
+```
+
+### Conventions de priorité
+
+Pratique pour les jeux d'arcade :
+
+| Priorité | Type de son |
+|----------|-------------|
+| 1-9 | Sons ambiance (pas, eau, vent) |
+| 10-19 | Tirs réguliers |
+| 20-29 | Bonus collecte |
+| 30-49 | Tirs puissants, explosions petites |
+| 50-79 | Explosions importantes |
+| 80-99 | Sons de hit (joueur touché) |
+| 100-126 | Critiques (game over, boss) |
+| 127 | Priorité max, peut être remplacée par un autre 127 |
+| 128-255 (avec lock) | Locked, ne peut pas être interrompue |
+
+### Compilation des sons
+
+Les sons sont compilés en code asm (pas en data) par le builder. Voir `soundFX.data.asm` pour les définitions.
+
+Pattern :
+```asm
+SND_jump
+        ; séquence d'écritures YM2413/SN76489 pour reproduire le son
+        fcb   $30, $40                  ; reg YM, value
+        fcb   $20, $10                  ; ...
+        fcb   $FF                       ; fin
+```
+
+### Pattern d'intégration
+
+```asm
+; main.asm
+        INCLUDE "./engine/sound/soundFX.asm"
+        INCLUDE "./engine/sound/soundFX.data.asm"
+        INCLUDE "./engine/sound/soundFX.macro.asm"
+
+; Dans MainLoop
+MainLoop
+        ; ...
+        jsr   RunObjects
+        ; (les objets peuvent appeler _soundFX.play)
+        ; ...
+
+; Dans UserIRQ
+UserIRQ
+        jsr   gfxlock.bufferSwap.check
+        jsr   PalUpdateNow
+        jsr   soundFX.tick               ; consume + tick
+        ; (puis ymm + vgc si présents)
+        rts
+```
+
+## Pitfalls
+
+### SMPS
+- **`Smps.60HzData` mal configuré** : tempo incorrect (musique trop lente ou trop rapide)
+- **`YM2413_DrumModeOn` oublié** : drums silencieux
+- **Mélange SMPS et ymm** : conflit sur YM2413, sons cassés
+- **MusicFrame non appelé** : pas de musique
+- **MIDI sans SmpsMidi** : symbol undefined
+
+### soundFX
+- **Priorité < lock courant** : son skipé silencieusement (peut surprendre en debug)
+- **Priorité 0** : son effectivement désactivé
+- **Plus de 1 son simultané** : soundFX n'a qu'1 voice, le nouveau remplace l'ancien (sauf si lock)
+- **Conflit avec musique sur SN76489** : si soundFX utilise le SN, peut couper momentanément la musique
+- **Sons mal compilés** : crash ou bruit aléatoire
+- **`_soundFX.play` depuis IRQ** : possible race condition

--- a/skills/thomson-to8-engine-audio/references/ymm-and-vgc-players.md
+++ b/skills/thomson-to8-engine-audio/references/ymm-and-vgc-players.md
@@ -1,0 +1,279 @@
+# Players `ymm` et `vgc` — objets engine
+
+Les players `ymm` et `vgc` sont les deux mécanismes principaux pour jouer de la musique dans l'engine. Tous deux sont **packagés en objets** (avec ObjID, dans engine/objects/sound/), permettant un usage uniforme via `_MountObject` et les macros `_MusicInit_*`/`_MusicFrame_*`.
+
+## Objet `ymm` — YM2413vgm player
+
+### Localisation
+
+```
+engine/objects/sound/ymm/
+├── ymm.asm                              # code de l'objet
+├── ymm.const.asm                        # constantes (commandes)
+├── ymm.data.asm                         # données (buffer, état)
+├── ymm.macro.asm                        # macros utilisateur
+└── ymm.properties                       # déclaration objet
+```
+
+### Variables internes
+
+```asm
+YVGM_MusicData    fdb 0                  ; pointeur vers les données de musique
+YVGM_MusicPage    fcb 0                  ; page mémoire des données
+YVGM_MusicStatus  fcb 0                  ; 0 = stop, 1 = playing
+YVGM_WaitFrame    fcb 0                  ; compteur d'attente entre commandes
+YVGM_loop         fcb 0                  ; flag boucle (0 ou 1)
+YVGM_callback     fdb 0                  ; routine à appeler à la fin (ou 0)
+YVGM_MusicDataPos fdb 0                  ; position courante dans les données
+
+YM2413_buffer                            ; buffer décompressé
+```
+
+### Format des données
+
+`ymm` lit des données compressées **ZX0** (.ymm.zx0). La décompression se fait au boot via `ym2413zx0_decompress` :
+
+```asm
+; Init de l'objet
+        bmi   @update                   ; commande négative = update
+        pshs  u
+        ldx   #Snd_index
+        asla
+        ldx   a,x                       ; charge l'adresse du morceau
+@init
+ IFDEF ymm.command
+        lda   #ymm.command.PLAY
+        sta   ymm.command
+ ENDC
+        stb   YVGM_loop
+        stx   YVGM_MusicData
+        sty   YVGM_callback
+        _GetCartPageA
+        sta   YVGM_MusicPage
+        lda   #1
+        sta   YVGM_MusicStatus
+        sta   YVGM_WaitFrame
+        ldu   #YM2413_buffer
+        stu   YVGM_MusicDataPos
+        leax  2,x                       ; skip 2 octets (offset loop)
+        jsr   ym2413zx0_decompress
+        puls  u,pc
+```
+
+Stratégie : décompression **streaming** dans le buffer YM2413_buffer, lecture au fur et à mesure.
+
+### Cycle de tick
+
+À chaque appel `_ymm.processFrame` :
+1. Décrémente `YVGM_WaitFrame`
+2. Si 0, lit la prochaine commande du buffer
+3. Applique sur le YM2413 (`sta YM2413.A` + `sta YM2413.D`)
+4. Si buffer épuisé, re-decompresse depuis YVGM_MusicData
+5. Si fin de musique : loop ou stop (selon YVGM_loop)
+
+### Macros utilisateur
+
+```asm
+; Définies dans ymm.macro.asm
+
+_ymm.processFrame MACRO
+        ldb   ymm.command
+        jsr   ,x                        ; appelle l'objet
+        ENDM
+
+_ymm.play MACRO
+        lda   #ymm.command.PLAY
+        sta   ymm.command
+        ENDM
+
+_ymm.stop MACRO
+        lda   #ymm.command.STOP
+        sta   ymm.command
+        ENDM
+
+_ymm.restart MACRO
+        lda   #ymm.command.RESTART
+        sta   ymm.command
+        ENDM
+```
+
+### Commandes
+
+```asm
+ymm.command.PLAY      equ $80
+ymm.command.STOP      equ $81
+ymm.command.RESTART   equ $82
+```
+
+`ymm.command` (variable RAM) stocke la commande courante. Le tick lit cette variable et agit.
+
+### Pattern d'usage complet
+
+```asm
+; Au boot
+        _MountObject ObjID_ymm
+        _MusicInit_objymm #0,#MUSIC_LOOP,#0     ; track 0, loop, fade 0
+
+; UserIRQ
+UserIRQ
+        jsr   gfxlock.bufferSwap.check
+        jsr   PalUpdateNow
+        _MountObject ObjID_ymm
+        _ymm.processFrame                ; tick
+        rts
+
+; Plus tard : pause
+        _ymm.stop
+
+; Plus tard : reprise
+        _ymm.restart
+
+; Changer de morceau
+        _MountObject ObjID_ymm
+        _MusicInit_objymm #5,#MUSIC_NO_LOOP,#0  ; track 5, no loop
+```
+
+## Objet `vgc` — VGC compressed VGM player
+
+### Localisation
+
+```
+engine/objects/sound/vgc/
+└── vgc.asm                              # code de l'objet
+engine/sound/vgc/
+├── lib/
+│   ├── vgcplayer.asm                    # player core
+│   ├── vgcplayer.h.asm                  # header (constantes, vars)
+│   ├── vgcplayer_bass.asm               # variante avec basse
+│   ├── vgcplayer_config.h.asm           # config
+│   ├── exomiser.asm                     # support Exomizer
+│   ├── exomiser.h.asm
+│   ├── irq.asm                          # gestion IRQ
+│   ├── fx.asm                           # effets
+│   └── vgmplayer.asm                    # player VGM brut
+└── modules/
+    └── *.py                             # outils Python
+```
+
+### Player
+
+`vgc_init` et `vgc_update` sont les routines exposées :
+
+```asm
+        ldx   #my_vgc_data
+        ldb   #MUSIC_LOOP
+        ldy   #0                        ; fade
+        jsr   vgc_init                  ; initialise le player
+
+        ; Dans UserIRQ :
+        jsr   vgc_update                ; tick une frame
+```
+
+### Format VGC
+
+VGC = VGM **compressé** via `vgmpacker.py`. Format pensé pour décodage rapide sur 6809 :
+- Indexation par track
+- Compression huffman + LZ4
+- Lookup tables précalculées
+
+### Conversion .vgm → .vgc
+
+```bash
+python vgmpacker.py input.vgm output.vgc
+```
+
+Outils dans `engine/sound/vgc/modules/`.
+
+### Auto-modif `vgc_port_01..04`
+
+Le player utilise du code auto-modifié pour optimiser les écritures SN76489 :
+
+```asm
+sn76489.reset
+        lda   #$9F
+        sta   SN76489.D
+vgc_port_01 equ *-1                     ; adresse du sta SN76489.D
+        ; ...
+```
+
+`vgc_port_01..04` sont les **adresses où le port SN76489 est écrit** dans la routine reset. Le player peut les patcher pour rediriger vers d'autres ports (test, désactivation).
+
+### Cycle de tick
+
+`vgc_update` :
+1. Lit la prochaine commande compressée
+2. Décompresse (LZ4 + huffman si nécessaire)
+3. Écrit sur SN76489 via les ports auto-modifiés
+4. Gère le sub-tick (les commandes peuvent avoir une durée fractionnaire)
+
+### Pattern d'usage
+
+Idem que ymm (via macros) :
+
+```asm
+        _MountObject ObjID_vgc
+        _MusicInit_objvgc #0,#MUSIC_LOOP,#0
+
+UserIRQ
+        ; ...
+        _MountObject ObjID_vgc
+        _MusicFrame_objvgc
+        rts
+```
+
+## ymm vs vgc — choix
+
+| Aspect | ymm | vgc |
+|--------|-----|-----|
+| Hardware cible | YM2413 (FM) | SN76489 (PSG) |
+| Format | .ymm.zx0 (YM2413vgm + ZX0) | .vgc (VGM compressé) |
+| Compression | ZX0 (streaming) | Huffman + LZ4 |
+| Qualité | Riche (FM 9 voies) | Limitée (4 voies PSG) |
+| Taille typique | 5-20 Ko | 2-10 Ko |
+| CPU usage / frame | ~1500 cycles | ~1000 cycles |
+
+**Recommandation** : utiliser **les deux ensemble** pour profiter des 9 voies YM + 4 voies PSG = 13 voies simultanées.
+
+Pattern observé : YM2413 pour la mélodie/harmonie, SN76489 pour les drums/effets.
+
+## Pipeline .dmf → .vgm → .vgc
+
+Outils :
+- **DefleMask** (DAW) : compose la musique, export .dmf
+- **DefleMask export VGM** : .dmf → .vgm (raw VGM)
+- **vgmpacker.py** : .vgm → .vgc
+- **(autre outil ?) → .ymm.zx0** pour YM2413
+
+Convention de naming observée dans bubble-bobble :
+```
+music/
+├── bubbleBubble2024.dmf                ; source DefleMask
+├── bubbleBubble2024.vgm                ; export raw VGM
+├── bubbleBubble2024.vgm.sn76489.loop.vgm   ; VGM ciblé SN76489
+├── bb-sn.vgc                            ; SN76489 compressé pour vgc player
+└── bb-ym-ym2413.ymm.zx0                 ; YM2413 compressé pour ymm player
+```
+
+## Callback
+
+Les deux players supportent un **callback** appelé en fin de morceau (utile pour transition automatique) :
+
+```asm
+        _MusicInit_objymm #0,#MUSIC_NO_LOOP,#OnMusicEnd
+
+OnMusicEnd
+        ; ... e.g. lancer le morceau suivant ...
+        rts
+```
+
+Si `MUSIC_LOOP`, le callback n'est jamais appelé (la musique reboucle).
+
+## Pitfalls
+
+- **`_MusicInit_obj*` avant `_MountObject`** : la page n'est pas chargée, init crash
+- **Track number > nb tracks** : lecture aléatoire, possible plantage
+- **Décompression sans buffer alloué** : crash
+- **Mélange ymm sur SN76489 ou vgc sur YM2413** : impossible (chaque player a son hardware cible)
+- **vgc.asm utilisé sans vgcplayer.asm inclus** : symbols undefined
+- **Plusieurs init du même player** : double-mount, comportement imprévisible
+- **Callback à une adresse invalide** : crash en fin de morceau

--- a/skills/thomson-to8-engine-bm16-pixel-blit/SKILL.md
+++ b/skills/thomson-to8-engine-bm16-pixel-blit/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: thomson-to8-engine-bm16-pixel-blit
+description: "Affichage horizontal à la granularité d'1 pixel en mode BM16 sur Thomson TO8/TO9, malgré l'entrelacement RAMA/RAMB byte-par-byte qui ne donne nativement que 2 px d'alignement. Technique des 4 buffers pré-compilés indexés par intra=(x&3) : 2 buffers (un par banque) sélectionnés sur 4 à chaque rendu selon le variant. Combine ordre d'écriture des banques (RAMA-first vs RAMB-first = ±2 px) et shift de contenu source (s0 vs s1 par rotation droite 1 px = ±1 px). Couvre la spécificité Thomson : les plans RAMA/RAMB sont physiquement inversés dans la zone $A000-$DF3F (RAMB à $A000, RAMA à $C000). Utile pour : sprites au pixel près, scrolling fluide horizontal, road rendering 3D (Pole Position / OutRun / Lotus / Power Drift-likes), HUD précis. Pour des positions x > 4 px, byte_x=(x>>2) ajoute un décalage entier de bytes au curseur U. Mots-clés : pixel-precise, pixel-perfect, 1px, BM16, RAMA, RAMB, entrelacement, byte interlace, 4 variants, content shift, s0, s1, RAMA-first, RAMB-first, bank order, plane_to_chunks, pixels_to_bm16, U cursor, pshu, pre-compiled buffers, $A000, $C000, plans inversés."
+machines: [to8, to8d, to9, to9+]
+user-invocable: false
+---
+
+# Affichage horizontal au pixel près en BM16 — Thomson TO8/TO9
+
+## Le problème
+
+En BM16 (160×200×16 couleurs), la VRAM est divisée en deux banques **RAMA** et **RAMB** entrelacées **byte par byte**. 1 byte (= 2 nibbles) = 2 pixels écran.
+
+```
+Pixels screen   : p0 p1 p2 p3 p4 p5 p6 p7
+RAMA bytes      : [p0|p1]       [p4|p5]        ; high nibble | low nibble
+RAMB bytes      :       [p2|p3]       [p6|p7]
+```
+
+**L'alignement byte natif d'un blitter = 2 px**. Pour positionner au pixel près, il faut un mécanisme additionnel.
+
+### Spécificité Thomson — plans physiquement inversés en zone donnée
+
+Dans la zone `$A000-$DF3F` (= zone donnée vidéo), les adresses physiques RAMA/RAMB sont **inversées** vs le nommage logique :
+
+```
+$A000-$BF3F : banque physique RAMB     (40 oct/ligne × 200 lignes)
+$C000-$DF3F : banque physique RAMA     (40 oct/ligne × 200 lignes)
+```
+
+Le pack logique du contenu reste inchangé (= RAMA bytes encodent la paire gauche, RAMB bytes la paire droite de chaque groupe de 4). Seul le mapping vers les adresses physiques est inversé.
+
+## Mécanisme — 4 buffers, 2 utilisés par rendu
+
+Deux leviers **orthogonaux** combinés donnent 4 sous-positions de 1 px chacune :
+
+| Levier | Effet | Pas |
+|---|---|---|
+| **Ordre des banques** | RAMA-first vs RAMB-first | ±2 px |
+| **Shift contenu source** | s0 vs s1 (= rotation droite 1 px en content) | ±1 px |
+
+Pour chaque unité (= scanline, ligne de sprite, etc.) on pré-compile **4 buffers** mono-banque :
+
+```asm
+UnitXXX_table
+        fdb   UnitXXX_RAMA_s0       ; offset 0
+        fdb   UnitXXX_RAMA_s1       ; offset 2
+        fdb   UnitXXX_RAMB_s0       ; offset 4
+        fdb   UnitXXX_RAMB_s1       ; offset 6
+```
+
+À chaque rendu, le variant `intra = x & 3` (0..3) sélectionne **2 buffers sur 4** :
+
+| intra | bank order | buffer pour banque RAMB ($A000) | buffer pour banque RAMA ($C000) | RAMA cursor +1 |
+|:-:|:-:|:-:|:-:|:-:|
+| 0 | RAMA-first s0 | RAMB_s0 (off 4) | RAMA_s0 (off 0) | non |
+| 1 | RAMA-first s1 | RAMB_s1 (off 6) | RAMA_s1 (off 2) | non |
+| 2 | RAMB-first s0 | RAMA_s0 (off 0) | RAMB_s0 (off 4) | **oui** |
+| 3 | RAMB-first s1 | RAMA_s1 (off 2) | RAMB_s1 (off 6) | **oui** |
+
+Pour intra 2/3, les deux buffers sont **swappés** entre banques + le curseur d'écriture U de la banque RAMA est avancé d'1 byte (= 2 px) pour aligner le décalage.
+
+## Build pipeline — Python
+
+```python
+def compile_variants(content_pixels):
+    buffers = {}
+    for shift_name, content in [
+        ('s0', content_pixels),
+        ('s1', content_pixels[-1:] + content_pixels[:-1]),  # rotate right 1 px
+    ]:
+        rama, ramb = pixels_to_bm16(content)
+        buffers[f'RAMA_{shift_name}'] = plane_to_chunks(rama)
+        buffers[f'RAMB_{shift_name}'] = plane_to_chunks(ramb)
+    return buffers   # 4 buffers de bytes mono-banque
+
+def pixels_to_bm16(content):
+    rama, ramb = [], []
+    for k in range(len(content) // 4):
+        rama.append((content[4*k]   << 4) | content[4*k+1])
+        ramb.append((content[4*k+2] << 4) | content[4*k+3])
+    return bytes(rama), bytes(ramb)
+
+def plane_to_chunks(plane_bytes):
+    """4 bytes/chunk, rightmost en premier (= ordre pshu d,x)."""
+    return [plane_bytes[i-4:i] for i in range(len(plane_bytes), 0, -4)]
+```
+
+Chaque buffer émet inline une séquence `ldd / ldx / pshu d,x` qui écrit 4 bytes à `U-4..U-1` puis décrémente U.
+
+## Runtime — `BlitAtXY` optimisée
+
+```asm
+* ==============================================================================
+* BlitAtXY — rend une unité au pixel près à la position (x, y)
+* ------------------------------------------------------------------------------
+* Sélectionne 2 buffers sur 4 (= variant intra=x&3) et appelle un par banque.
+*
+* Inputs :
+*   A = x (pixel position, 0..max)
+*   B = y (scanline, 0..199)
+*   X = ptr table 4-buffer (fdb RAMA_s0, RAMA_s1, RAMB_s0, RAMB_s1)
+*
+* Trashes : A, B, D, X, Y, U
+* ==============================================================================
+
+UNIT_WIDTH      equ   40              ; W = bytes/scanline/banque
+
+BlitAtXY
+        stx   <bx_tbl                   ; save 4-buf table ptr
+        pshs  a,b                       ; sauve x et y sur stack (B=y, A=x intacts)
+
+        * --- D = y * 40 + W (offset rightmost+1 dans la scanline) ---
+        lda   #40                       ; B = y déjà en register depuis l'entrée
+        mul                             ; D = y * 40
+        addd  #UNIT_WIDTH               ; D = y * 40 + W
+
+        * --- D += byte_x (= x >> 2) ---
+        pshs  d                         ; sauve D (y*40+W)
+        ldb   3,s                       ; B = x (à S+3 après pshs d)
+        lsrb
+        lsrb                            ; B = byte_x
+        clra                            ; D = 00:byte_x
+        addd  ,s++                      ; D = byte_x + (y*40+W), pop saved
+        std   <bx_scanl_off             ; sauve pour les 2 passes
+
+        * --- A = intra, lookup variant_tbl (entrées 4 oct = intra<<2) ---
+        lda   1,s                       ; A = x
+        anda  #3                        ; A = intra
+        leas  2,s                       ; pop x, y
+        asla
+        asla                            ; A = intra * 4
+        ldx   #variant_tbl
+        leax  a,x                       ; X -> entry [ramb_off, rama_off, rama_shift, _]
+        stx   <bx_variant               ; sauve (sous-routine buffer peut clobber X)
+
+        * ===== Passe banque RAMB ($A000-$BF3F) =====
+        ldu   <bx_scanl_off             ; (LDU+LEAU plus rapide que LDD+ADDD+TFR)
+        leau  $A000,u                   ; U = $A000 + y*40 + W + byte_x
+
+        ldy   <bx_tbl                   ; Y = 4-buf table
+        ldb   ,x                        ; B = ramb_off (X reste = variant entry)
+        jsr   [b,y]                     ; jsr vers *(Y+B) = ptr buffer RAMB pass
+
+        * ===== Passe banque RAMA ($C000-$DF3F, +1 byte si RAMB-first) =====
+        ldx   <bx_variant               ; recharge entry
+        ldu   <bx_scanl_off
+        leau  $C000,u                   ; U = $C000 + y*40 + W + byte_x
+        ldb   2,x                       ; B = rama_shift (0 ou 1)
+        leau  b,u                       ; U += rama_shift
+
+        ldy   <bx_tbl
+        ldb   1,x                       ; B = rama_off
+        jmp   [b,y]                     ; tail call vers *(Y+B) = ptr buffer RAMA pass
+
+* --- Table 4 entrées × 4 oct (intra*4 = leax direct) ---
+*       ramb_off  rama_off  rama_shift  _
+variant_tbl
+        fcb       4,        0,         0, 0    ; intra 0 : RAMA-first s0
+        fcb       6,        2,         0, 0    ; intra 1 : RAMA-first s1
+        fcb       0,        4,         1, 0    ; intra 2 : RAMB-first s0 (swap + RAMA +1)
+        fcb       2,        6,         1, 0    ; intra 3 : RAMB-first s1 (swap + RAMA +1)
+```
+
+Une seule mul (y × 40), une seule lecture du variant_tbl, indexation 4-aligned sans calcul, tail call sur la 2ᵉ passe. Les 2 passes partagent `bx_scanl_off` en DP pour éviter de recomputer.

--- a/skills/thomson-to8-engine-build-pipeline/SKILL.md
+++ b/skills/thomson-to8-engine-build-pipeline/SKILL.md
@@ -1,0 +1,382 @@
+---
+name: thomson-to8-engine-build-pipeline
+description: "Décrit le pipeline de build Java du Thomson TO8/TO9 game engine (Bento8/wide-dot) : application Java `java-generator/` qui produit les images disquette .fd / cartouche .t2 / .t2flash à partir des sources ASM 6809 et des fichiers .properties, classe principale BuildDisk avec main() qui charge le config via Game.java, parse les game-modes via GameMode.java et leurs game-mode communs via GameModeCommon.java, charge les objets via Object.java avec leurs sprites/animations/sounds/data/tilesets, charge les palettes via Palette.java + PaletteTO8, charge les acts via Act.java (screenBorder/backgroundSolid/backgroundImage/objectPlacement/palette), gestion des sprites compilés (compiledSprite/) avec variants NB/ND/XB/etc, encoders MapRleEncoder (DMAP) et ZX0Encoder (DZX0), compilation via LWASM avec pragma/includeDirs/define paramétrables, knapsack packing (util.knapsack.Knapsack + Item + Solution) pour optimiser le placement des objets en pages RAM, générateurs writeObjIndex/writeAniIndex/writeImgIndex pour les tables d'index, génération de LoadAct depuis Act, génération des constants ObjID_X / GmID_X / Bgi_X / Pal_X / Img_X / Ani_X dans les .glb (SHARED_ASSETS, ObjectId.glb, Game.glb, MainEngine.glb), dédup T2 (un même blob écrit une seule fois si plusieurs game-modes le partagent), parallel build via builder.parallel=Y, compression ZX0 (default) ou Exomizer (builder.exobin), création image fd via FdUtil + image t2 via T2Util + ROM image RamImage, propriétés OrderedProperties pour préserver l'ordre, PropertyList helper pour les listes object./palette./animation./sprite./etc. Utiliser pour comprendre les étapes de build, débugger une erreur de compilation, optimiser le placement des pages, contribuer au builder Java, comprendre la génération des constantes, ajuster les paramètres LWASM. Mots-clés : BuildDisk, BuildT2CheckDisk, Game, GameMode, GameModeCommon, Object, ObjectBin, ObjectCode, Act, Palette, AsmSourceCode, PropertyList, OrderedProperties, FileNames, ChecksumUtils, DynamicContent, Globals, knapsack, Knapsack, Item, ItemBin, Solution, compiledSprite, AssemblyGenerator, SimpleAssemblyGenerator, Encoder, MapRleEncoder, ZX0Encoder, SpriteSheet, Sprite, SubSprite, SubSpriteBin, ImageSetBin, AnimationBin, Animation, TileBin, Tileset, PngToBottomUpB16Bin, PaletteTO8, Sound, SoundBin, RamImage, DataIndex, RAMLoaderIndex, FdUtil, SdUtil, T2Util, LWASMUtil, FileUtil, ZX0Compressor, Optimizer, generated-code directory, debug directory, .glb files, ObjectId.glb, Game.glb, MainEngine.glb, FileIndex.asm, _ImageSet.asm, _Animation.asm, _TileSet.asm, SHARED_ASSETS, writeObjIndex, writeAniIndex, writeImgIndex, writeLoadActIndex, writePalIndex, builder.lwasm, builder.lwasm.pragma, builder.lwasm.includeDirs, builder.lwasm.define, builder.parallel, builder.compilatedSprite.useCache, builder.compilatedSprite.maxTries, builder.exobin, builder.hxcfe, builder.constAnim, --pragma, --includedir, --define, lwasm, exomizer, maven, mvn clean compile assembly:single."
+machines: [to8, to8d, to9, to9+]
+user-invocable: false
+---
+
+# Build pipeline — Thomson TO8/TO9 Game Engine
+
+Le **java-generator** (`java-generator/` du repo) est l'application Java qui produit les images disquette/cartouche à partir des sources ASM 6809 et des fichiers `.properties`. Classe principale : **`BuildDisk`**.
+
+Ce skill couvre : les étapes de build, le knapsack packing, la génération des constantes, l'intégration LWASM, la dédup T2.
+
+---
+
+## Architecture des classes
+
+```
+fr.bento8.to8.build/
+├── BuildDisk.java               # main() — pipeline principal
+├── BuildT2CheckDisk.java        # validation post-build T2
+├── Game.java                    # config racine (game)
+├── GameMode.java                # un game-mode
+├── GameModeCommon.java          # objets communs partagés
+├── Object.java                  # un objet avec sprites/anims/data
+├── ObjectBin.java               # binaire compilé d'un objet
+├── ObjectCode.java              # code asm d'un objet
+├── Act.java                     # un acte (palette/border/bg)
+├── Palette.java                 # palette
+├── AsmSourceCode.java           # builder de fichiers asm
+├── PropertyList.java            # helper pour parsing prop.X.Y
+├── OrderedProperties.java       # Properties qui préserve l'ordre
+└── FileNames.java               # constantes de noms de fichiers
+
+fr.bento8.to8.image/
+├── Sprite.java
+├── SpriteSheet.java
+├── SubSprite.java
+├── SubSpriteBin.java
+├── Animation.java
+├── AnimationBin.java
+├── ImageSetBin.java
+├── Tileset.java
+├── TileBin.java
+├── PngToBottomUpB16Bin.java     # PNG → BM16 format
+├── PaletteTO8.java              # extraction palette PNG
+└── encoder/
+    ├── Encoder.java             # interface
+    ├── MapRleEncoder.java       # DMAP
+    └── ZX0Encoder.java          # DZX0
+
+fr.bento8.to8.util.knapsack/
+├── Knapsack.java                # algorithme packing
+├── Item.java                    # élément à packer
+├── ItemBin.java
+└── Solution.java                # solution trouvée
+
+fr.bento8.to8.audio/
+├── Sound.java
+└── SoundBin.java
+
+fr.bento8.to8.ram/
+└── RamImage.java                # image RAM 32 pages
+
+fr.bento8.to8.storage/
+├── FdUtil.java                  # image disquette
+├── T2Util.java                  # image T2 megarom
+├── SdUtil.java                  # SDDRIVE
+├── DataIndex.java
+└── RAMLoaderIndex.java
+
+fr.bento8.to8.util/
+├── LWASMUtil.java               # invocation LWASM
+├── FileUtil.java
+└── knapsack/ (cf. dessus)
+
+fr.bento8.to8.compiledSprite/
+├── backupDrawErase/
+│   └── AssemblyGenerator.java   # génère le code asm d'un sprite NB
+└── draw/
+    └── SimpleAssemblyGenerator.java   # ND seul
+
+fr.bento8.to8.boot/
+└── Bootloader.java
+```
+
+---
+
+## Pipeline de build — étapes
+
+### 1. Chargement du config
+
+```java
+Game game = new Game(args[0]);          // config-windows.properties
+```
+
+`Game` parse :
+- engine.asm.boot.fd/t2/t2flash
+- engine.asm.RAMLoader/Manager
+- gameModeBoot + gameMode.X (liste)
+- builder.* (LWASM, debug, parallel, etc.)
+
+### 2. Chargement des game-modes
+
+Pour chaque `gameMode.X` :
+```java
+gameModes.put(name, new GameMode(name, fileName));
+```
+
+`GameMode` parse :
+- engine.asm.mainEngine
+- gameModeCommon.X (objets partagés)
+- object.X (objets)
+- palette.X (palettes)
+- actBoot + act.X.Y (acts)
+
+### 3. Chargement des objets
+
+Pour chaque objet (unique par nom), `Object` parse :
+- code= (ou common-code=)
+- sprite.X (avec variants)
+- animation.X (v00 ou v02)
+- animation-data (1 max)
+- sound.X / data.X (alias)
+- tileset.X
+
+Réutilisation : si le même nom d'objet est référencé par plusieurs game-modes, l'objet n'est créé qu'une fois (cf. `Game.allObjects` HashMap).
+
+### 4. Compilation des sprites
+
+Pour chaque sprite, pour chaque variant (NB0, NB1, XB0, etc.) :
+- Lit le PNG
+- Génère le code asm pour ce variant (boucle d'écritures pixels)
+- Mode B : génère aussi le code d'erase (sauvegarde + restore)
+- Mode D : code de draw seul
+- DMAP : encodage RLE map
+- DZX0 : compression ZX0
+
+Cache : si `builder.compilatedSprite.useCache=Y`, le builder réutilise les `.asm`/`.bin`/`.lst` déjà générés (gros gain sur builds incrémentaux).
+
+`maxTries` (typiquement 500000) : nombre d'essais aléatoires pour optimiser les permutations de pixels (> 10 éléments). Plus = meilleure compression mais plus lent.
+
+### 5. Génération des fichiers .glb
+
+```java
+// Pour chaque game-mode :
+//   ObjectId.glb (ObjID_X et adresses)
+//   <gameMode>.glb (constantes générées)
+
+// Globaux :
+//   Game.glb
+//   MainEngine.glb
+
+// Communs partagés :
+//   SHARED_ASSETS/<common>.glb
+```
+
+Ces `.glb` sont inclus automatiquement dans le code asm pour fournir les constantes (ObjID_X, GmID_X, Pal_X, Img_X, Ani_X, Bgi_X).
+
+### 6. Knapsack packing — placement RAM
+
+Le builder doit décider sur quelle page RAM placer chaque objet (chacun a un code de taille variable, doit tenir dans 16 Ko par page).
+
+`fr.bento8.to8.util.knapsack.Knapsack` résout ce problème (variante du **bin packing**) :
+- Items = chaque objet (avec sa taille)
+- Bins = pages RAM (16 Ko chacune, jusqu'à 32 pages selon `builder.to8.memoryExtension`)
+- Solution = affectation item → bin minimisant le nombre de bins utilisés
+
+Si trop d'items pour les bins disponibles : abort avec message « Plus de place en RAM ».
+
+### 7. Génération de `LoadAct`
+
+Depuis les properties `act.X.*` (cf. `Act.java`), le builder génère le code asm de `LoadAct` :
+
+```java
+private static void writeLoadActIndex(AsmSourceCode asmBuilder, GameMode gameMode) {
+    asmBuilder.add("LoadAct");
+    Act act = gameMode.acts.get(gameMode.actBoot);
+    if (act != null) {
+        if (act.bgColorIndex != null || act.bgFileName != null) {
+            asmBuilder.add("        ldb   #$02");
+            asmBuilder.add("        stb   $E7E5");
+        }
+        if (act.bgColorIndex != null) {
+            asmBuilder.add("        ldx   #$XXXX");
+            asmBuilder.add("        jsr   ClearDataMem");
+        }
+        if (act.bgFileName != null) {
+            asmBuilder.add("        ldx   #Bgi_" + act.name);
+            asmBuilder.add("        jsr   DrawFullscreenImage");
+        }
+        // ... screenBorder, palette, etc.
+    }
+}
+```
+
+### 8. Invocation LWASM
+
+`LWASMUtil` lance LWASM avec :
+- `--pragma=` + `builder.lwasm.pragma`
+- `--includedir=` + `builder.lwasm.includeDirs` (séparés par virgules)
+- `--define=` + `builder.lwasm.define`
+- Source : `engine.asm.mainEngine` ou autre
+
+Sortie : `.bin` (binaire) + `.lst` (listing) dans `generated-code/`.
+
+### 9. Compression ZX0 ou Exomizer
+
+Pour chaque page RAM, compresse le binaire :
+- ZX0 (défaut) via `zx0.Compressor` + `zx0.Optimizer` (lib Java intégrée)
+- Exomizer via `builder.exobin` (outil externe Windows)
+
+### 10. Création de l'image
+
+- **Disquette** : `FdUtil` assemble les pages compressées en image `.fd`
+- **Cartouche T2** : `T2Util` assemble en `.t2`
+- **T2 Flash** : `SdUtil` génère les 4 disquettes SDDRIVE en `.t2flash`
+
+### 11. Validation T2
+
+`BuildT2CheckDisk` vérifie l'intégrité de l'image T2 (checksums via `ChecksumUtils`).
+
+---
+
+## Constantes générées
+
+Le builder génère des **constantes** asm que le code utilise :
+
+| Préfixe | Source property | Exemple |
+|---------|-----------------|---------|
+| `ObjID_<X>` | `object.<X>=...` | `ObjID_Player` |
+| `GmID_<X>` | `gameMode.<X>=...` | `GmID_TitleScreen` |
+| `Pal_<X>` | `palette.<X>=...` | `Pal_game` |
+| `Img_<X>` | `sprite.Img_<X>=...` | `Img_Player_001` |
+| `Ani_<X>` | `animation.Ani_<X>=...` | `Ani_Idle` |
+| `Bgi_<X>` | `act.<X>.backgroundImage=...` | `Bgi_default` |
+| `Obj_Index_Page` | (tables auto-générées) | (table 1 octet/objet = page) |
+| `Obj_Index_Address` | (idem) | (table 2 octets/objet = adresse) |
+
+Les `Obj_Index_Page` et `Obj_Index_Address` sont **résidentes** (page 1) pour être accessibles depuis n'importe quelle page.
+
+Voir [references/build-stages.md](references/build-stages.md).
+
+---
+
+## Knapsack — détails
+
+```java
+public class Knapsack {
+    private List<Item> items;
+    private int binSize;
+    
+    public Solution solve() {
+        // Algorithme First-Fit Decreasing ou variant
+        // Trie items par taille décroissante
+        // Place chacun dans le premier bin où il rentre
+        // Sinon crée un nouveau bin
+        // Retourne le placement optimal
+    }
+}
+```
+
+Item = un objet avec sa taille en octets.
+Bin = une page RAM (16 Ko).
+
+L'objectif : **minimiser le nombre de bins** pour économiser l'espace cartouche T2 et le temps de chargement disquette.
+
+Pour T2 avec mémoire = 128 pages : limite hard.
+Pour FD : limite hard liée à la taille disquette (~320 Ko).
+
+Voir [references/knapsack-packing.md](references/knapsack-packing.md).
+
+---
+
+## Dédup T2
+
+En cartouche T2, si plusieurs game-modes ont la **même page** (même contenu, même page logique), le builder ne l'écrit **qu'une fois** dans le ROM cartouche.
+
+Comparaison via :
+```java
+if (commons.containsKey(di.gmc)) {
+    for (RAMLoaderIndex dic : commons.get(di.gmc)) {
+        if (dic.ram_page == di.ram_page && 
+            dic.ram_address == di.ram_address && 
+            dic.ram_endAddress == di.ram_endAddress && 
+            Arrays.equals(di.encBin, dic.encBin)) {
+            fdic = dic;
+            break;
+        }
+    }
+}
+```
+
+Si fdic trouvé → **partage** la même position ROM. Économie.
+
+C'est ce qui rend `gameModeCommon` si efficace : 1 seul write au lieu de N.
+
+Voir [references/t2-deduplication.md](references/t2-deduplication.md).
+
+---
+
+## Compilation parallèle
+
+Si `builder.parallel=Y`, certaines étapes utilisent des Java Streams parallel :
+
+```java
+forEach(game.gameModes.entrySet(), gameMode -> {
+    // processBackgroundImages...
+});
+```
+
+`forEach` peut être séquentiel (`forEachSeq`) ou parallèle (`forEach`) selon le flag.
+
+Gain : compile sprites en parallèle (utilise tous les cores). Réduit de moitié le temps de build sur multi-core.
+
+---
+
+## Invocation Maven
+
+```bash
+cd java-generator
+mvn clean compile assembly:single
+```
+
+Produit : `target/build-disk-*-jar-with-dependencies.jar`.
+
+Exécution :
+```bash
+java -jar target/build-disk-*-jar-with-dependencies.jar <chemin/config.properties>
+```
+
+---
+
+## Fichiers générés
+
+Dans `<game-project>/generated-code/` :
+```
+<objet>/
+├── <sprite_variant>.asm         # code compilé du sprite
+├── <sprite_variant>.bin         # binaire
+├── <sprite_variant>.lst         # listing LWASM
+├── _ImageSet.asm                # index des images
+├── _Animation.asm               # index des animations
+└── _TileSet.asm                 # tilesets (si applicable)
+
+debug/
+├── <fichiers>.lst               # versions debug avec symbols
+└── <fichiers>.sym               # symboles
+
+Game.glb                         # constantes globales
+ObjectId.glb                     # ObjID_X
+MainEngine.glb                   # constantes main engine
+SHARED_ASSETS/                   # communs partagés
+```
+
+Dans `dist/` :
+```
+<diskName>.fd                    # image disquette
+<t2Name>.t2                      # image cartouche T2
+<t2Name>.t2flash                 # image SDDRIVE
+```
+
+---
+
+## Pitfalls
+
+- **`builder.lwasm.includeDirs` incorrect** : LWASM ne trouve pas les `INCLUDE` → erreur de compilation
+- **`builder.compilatedSprite.useCache=Y` avec PNG modifiés** : utilise l'ancien sprite → image incorrecte. Mettre `=N` pour force recompile
+- **`maxTries` trop bas** : compression sub-optimale. Augmenter pour des sprites complexes
+- **Plus d'items que de bins** : abort avec "Plus de place en RAM". Réduire ou paginer
+- **Cache stale** : supprimer `generated-code/` et rebuild si comportement incohérent
+- **`builder.parallel=Y` avec build instable** : bug rare de concurrence. Mettre `N` pour debug
+- **Pages T2 dépassant 128** : aborts. Réduire ou utiliser `gameModeCommon` pour mutualiser
+- **PNG palette non indexée** : palette extraite incorrecte
+- **Sprite trop gros** (> 1 page après compilation) : impossible à allouer en RAM
+- **Confusion index PNG / index runtime palette Thomson** : `PaletteTO8.java` lit le PNG sur les index 1..16 (le 0 du PNG est implicitement la transparence) et écrit dans les slots Thomson 0..15. Donc PNG idx N → Thomson slot (N−1). Quand on écrit du code asm qui adresse la palette via `$E7DB` ou des tables raster, il faut utiliser l'index **runtime Thomson** (PNG idx − 1). Commenter un fcb « idx 1 = HERBE » d'après ce qu'on voit dans GIMP et écrire `fcb $01,...` adresse en fait la 2ème couleur — bug visuel silencieux. Cf. [thomson-to8-engine-palette/references/palette-system.md](../thomson-to8-engine-palette/references/palette-system.md) section "Index couleur : PNG vs runtime Thomson".
+
+## Références détaillées
+
+- [references/build-stages.md](references/build-stages.md) — Étapes détaillées du pipeline : load config, parse game-modes, charge objets, compile sprites avec variants, génère .glb (Game/ObjectId/MainEngine/SHARED_ASSETS), invoque LWASM, compresse, assemble image. Fichiers intermédiaires dans generated-code/. Constantes générées (ObjID_X, GmID_X, Pal_X, Img_X, Ani_X, Bgi_X)
+- [references/knapsack-packing.md](references/knapsack-packing.md) — Algorithme knapsack/bin-packing : Item / Bin / Solution, première-fit decreasing, contraintes 16 Ko/page et 32 pages max (avec builder.to8.memoryExtension), gestion d'échec ("Plus de place en RAM"), optimisation via gameModeCommon
+- [references/t2-deduplication.md](references/t2-deduplication.md) — Dédup ROM T2 : comparaison par page+adresse+contenu, économie via gameModeCommon, HashMap commons, RAMLoaderIndex.encBin, impact sur taille finale .t2, validation BuildT2CheckDisk

--- a/skills/thomson-to8-engine-collision/SKILL.md
+++ b/skills/thomson-to8-engine-collision/SKILL.md
@@ -1,0 +1,353 @@
+---
+name: thomson-to8-engine-collision
+description: "Décrit le système de collision du Thomson TO8/TO9 game engine (Bento8/wide-dot) : système AABB (Axis-Aligned Bounding Box) avec macros _Collision_AddAABB / _Collision_RemoveAABB / _Collision_CleanLinksAABB / _Collision_Do / _Collision_AddAABB_x, structure AABB (potential p, radius rx/ry, center cx/cy, chaînage prev/next — 9 octets), listes typées AABB_list_friend / AABB_list_enemy / AABB_list_player / AABB_list_bonus / AABB_list_foefire / AABB_list_forcepod, déclaration dans ram-data.asm via AABB_lists / AABB_endLists, routines Collision_AddAABB / Collision_RemoveAABB / Collision_Do (test all-pairs entre 2 listes), calcul de collision en center-radius (distance abs centre vs somme rayons), système de potentiel (hitbox invincible -128 à -1, désactivée 0, normale 1-126, weak 127), système terrainCollision pour shoot'em up r-type (init via _terrainCollision.init avec page+address dynamique, terrainCollision.do, terrainCollision.xAxis.doRight/doLeft, terrainCollision.update, terrainCollision.sensor.x/y, terrainCollision.impact.x), pattern de placement de la routine de collision dans MainLoop (entre RunObjects et CheckSpritesRefresh), AABB sur ext_variables_size>=9 dans ram-data.asm. Utiliser pour gérer des collisions entre joueur/ennemis/projectiles, implémenter un système de potentiel HP, organiser les listes de collision par type, configurer une AABB sur un objet, gérer les collisions terrain pour un shoot'em up, choisir entre AABB et terrainCollision. Mots-clés : AABB, AABB_struct, AABB.p, AABB.rx, AABB.ry, AABB.cx, AABB.cy, AABB.prev, AABB.next, _Collision_AddAABB, _Collision_AddAABB_x, _Collision_RemoveAABB, _Collision_CleanLinksAABB, _Collision_Do, Collision_AddAABB, Collision_RemoveAABB, Collision_Do, Collision_Remove_1, Collision_Remove_2, Collision_Remove_3, Collision_Do_1, Collision_Do_2, AABB_list_friend, AABB_list_enemy, AABB_list_ennemy, AABB_list_player, AABB_list_bonus, AABB_list_foefire, AABB_list_forcepod, AABB_list_bubble, AABB_lists, AABB_endLists, AABB_lists.nb, ext_variables, struct_AABB.equ, potential hitbox, center-radius, terrainCollision, terrainCollision.do, terrainCollision.xAxis.doRight, terrainCollision.xAxis.doLeft, terrainCollision.update, terrainCollision.sensor.x, terrainCollision.sensor.y, terrainCollision.impact.x, _terrainCollision.init, terrainCollision.main.page, terrainCollision.main.address, room.checkSolid, hitbox, shoot'em up, plateformer, axis-aligned bounding box, doubly linked list."
+machines: [to8, to8d, to9, to9+]
+user-invocable: false
+---
+
+# Collision — Thomson TO8/TO9 Game Engine
+
+Le système de collision repose sur deux mécanismes complémentaires :
+
+1. **AABB** (Axis-Aligned Bounding Box) — collision entre **objets** via boîtes englobantes alignées, organisées en listes typées
+2. **terrainCollision** — collision avec un **terrain statique** (cf. r-type pour les murs et sols de niveau)
+
+Ce skill couvre les deux mécanismes.
+
+---
+
+## Vue d'ensemble — AABB
+
+```
+Objet A avec AABB_0 (rx=4, ry=8) dans ext_variables
+Objet B avec AABB_0 (rx=6, ry=6) dans ext_variables
+
+Liste AABB_list_player ──→ A
+Liste AABB_list_enemy  ──→ B
+
+_Collision_Do AABB_list_player, AABB_list_enemy
+   → teste toutes les paires (cross-product)
+   → pour chaque paire : 
+     - |cx_A - cx_B| < rx_A + rx_B ?
+     - |cy_A - cy_B| < ry_A + ry_B ?
+     - Si oui : collision → décrement de potential
+```
+
+---
+
+## Structure `AABB` (9 octets)
+
+```asm
+AABB struct
+p       rmb   1                         ; potential (hitbox HP)
+rx      rmb   1                         ; radius X (demi-largeur)
+ry      rmb   1                         ; radius Y (demi-hauteur)
+cx      rmb   1                         ; center X (à l'écran ou playfield)
+cy      rmb   1                         ; center Y
+prev    rmb   2                         ; chaînage liste (engine)
+next    rmb   2                         ; chaînage liste (engine)
+ endstruct
+```
+
+Total : 9 octets dans `ext_variables`.
+
+### Potential
+
+| Valeur | Sémantique |
+|--------|------------|
+| -128 à -1 | Invincible (potential ne change jamais) |
+| 0 | Hitbox désactivée (pas de collision) |
+| 1 à 126 | HP restants (décrémenté à chaque collision) |
+| 127 | Weak hitbox (désactivée immédiatement à la 1ère collision) |
+
+```asm
+        lda   #-1                       ; hitbox invincible
+        sta   AABB_0+AABB.p,u
+        
+        ; OU
+        lda   #5                        ; hitbox avec 5 HP
+        sta   AABB_0+AABB.p,u
+```
+
+### Coordonnées center-radius
+
+L'AABB est définie par **centre + rayons** :
+- `cx`, `cy` : centre (en pixels, **mis à jour par le moteur** à partir de `x_pos`/`y_pos` via le rendering)
+- `rx`, `ry` : rayons (demi-largeur, demi-hauteur)
+
+La box couvre `[cx-rx, cx+rx]` × `[cy-ry, cy+ry]`.
+
+> **Important** : `cx`/`cy` sont en **coord écran** (1 octet), mis à jour pendant le rendu (DrawSprites/CheckSpritesRefresh). Pour que les collisions soient cohérentes avec l'affichage, le test doit être appelé **après** RunObjects et **avant** EraseSprites/DrawSprites (cf. position dans MainLoop).
+
+---
+
+## Listes typées
+
+Déclarées dans `ram-data.asm` :
+
+```asm
+AABB_lists.nb                 equ   (AABB_endLists-AABB_lists)/2
+AABB_lists
+AABB_list_player              fdb   0,0
+AABB_list_enemy               fdb   0,0
+AABB_list_bonus               fdb   0,0
+AABB_list_foefire             fdb   0,0
+AABB_list_forcepod            fdb   0,0
+AABB_endLists
+```
+
+Chaque liste = `fdb 0,0` (2 mots = head + tail des chaînages doublement liés). Le bloc `AABB_lists` à `AABB_endLists` permet à l'engine de connaître le nombre de listes.
+
+Convention : noms `AABB_list_<type>` pour clarifier le rôle. Le rôle exact (qui attaque qui) est applicatif.
+
+---
+
+## Macros pour le code utilisateur
+
+### `_Collision_AddAABB`
+
+```asm
+        _Collision_AddAABB AABB_0,AABB_list_player
+```
+
+Inscrit l'AABB de l'objet courant (`u`) dans la liste. Le moteur prend `u + AABB_0` comme adresse de la struct AABB.
+
+À appeler dans `Init` :
+```asm
+Init
+        lda   #-1                       ; potential infini
+        sta   AABB_0+AABB.p,u
+        _ldd  4,8                       ; rx=4, ry=8
+        std   AABB_0+AABB.rx,u
+        _Collision_AddAABB AABB_0,AABB_list_player
+        inc   routine,u
+```
+
+### `_Collision_AddAABB_x`
+
+Version avec `x` au lieu de `u`. Utile depuis une routine qui a déjà besoin de `u`.
+
+### `_Collision_RemoveAABB`
+
+```asm
+        _Collision_RemoveAABB AABB_0,AABB_list_player
+```
+
+Retire l'AABB de la liste. À appeler avant `UnloadObject_u` ou avant de basculer dans une autre liste.
+
+### `_Collision_CleanLinksAABB`
+
+```asm
+        _Collision_CleanLinksAABB AABB_0
+```
+
+Reset `prev` et `next` à 0. **Obligatoire** entre un Remove et un Add (pour passer d'une liste à une autre) :
+
+```asm
+        ; Joueur passe de mode normal à invincible :
+        _Collision_RemoveAABB AABB_0,AABB_list_player
+        _Collision_CleanLinksAABB AABB_0
+        _Collision_AddAABB AABB_0,AABB_list_player_invincible
+```
+
+### `_Collision_Do`
+
+```asm
+        _Collision_Do AABB_list_player,AABB_list_enemy
+```
+
+Teste **toutes les paires** entre les deux listes. Pour chaque paire en collision :
+- Décrémente le potential des deux AABBs (-1 chacun)
+- Si potential atteint 0 : hitbox désactivée
+
+À appeler depuis MainLoop, **après** RunObjects (qui a mis à jour cx/cy via DisplaySprite).
+
+---
+
+## Algorithme `Collision_Do`
+
+```asm
+Collision_Do
+        ldu   #0                        ; (auto-modif par macro : adresse liste 1)
+Collision_Do_1 equ *-2
+        beq   @rts                      ; liste vide → fin
+@loopu  ldb   AABB.p,u
+        beq   @skipu                    ; potential = 0 → skip
+        ldx   #0
+Collision_Do_2 equ *-2                  ; (adresse liste 2)
+        beq   @rts
+@loopx  ldb   AABB.p,x
+        beq   @skipx
+        
+        ; calcul collision
+        lda   AABB.rx,u
+        adda  AABB.rx,x                 ; somme des rayons X
+        asla
+        sta   @rx
+        asra
+        adda  AABB.cx,u
+        suba  AABB.cx,x
+        cmpa  #0
+@rx     equ *-1
+        bhi   @continue                 ; |dx| > sum_rx → pas de col
+        
+        lda   AABB.ry,u
+        adda  AABB.ry,x
+        asla
+        sta   @ry
+        asra
+        adda  AABB.cy,u
+        suba  AABB.cy,x
+        cmpa  #0
+@ry     equ *-1
+        bhi   @continue                 ; |dy| > sum_ry → pas de col
+        
+        ; COLLISION DÉTECTÉE
+        ; décrémenter les potentiels
+        ; ...
+```
+
+Complexité : O(N×M) où N et M = tailles des listes. Pour ~10 objets par liste, ~100 comparaisons = quelques centaines de cycles. OK pour 50 Hz.
+
+---
+
+## terrainCollision — collision avec un terrain
+
+Système plus complexe utilisé par r-type pour les collisions avec les murs/sols du niveau.
+
+### Macro d'init
+
+```asm
+        _terrainCollision.init ObjID_collision
+```
+
+Charge la page et l'adresse de l'objet `ObjID_collision` (qui contient les données du terrain) dans des variables auto-modifiées :
+- `terrainCollision.main.page` / `.address` → routine principale
+- `terrainCollision.main.xAxis.doRight.page` / `.address` → check à droite (+3 dans la table)
+- `terrainCollision.main.xAxis.doLeft.page` / `.address` → check à gauche (+6)
+- `terrainCollision.main.update.page` / `.address` → update (+9)
+
+L'objet `collision` exporte donc **4 entry points** consécutifs (espacés de 3 octets), accessibles via les routines wrapper.
+
+### Routines wrapper
+
+```asm
+terrainCollision.do                     ; check vertical (sol/plafond)
+        _GetCartPageA
+        sta   @page
+        lda   #0                        ; (modifié par init)
+terrainCollision.main.page equ *-1
+        _SetCartPageA
+        jsr   >0                        ; (modifié par init)
+terrainCollision.main.address equ *-2
+        ; restore page
+        rts
+
+terrainCollision.xAxis.doRight          ; check à droite
+terrainCollision.xAxis.doLeft           ; check à gauche
+terrainCollision.update                 ; update lookup tables
+```
+
+Pattern d'usage :
+```asm
+        ; Avant de bouger l'objet, on vérifie qu'il peut
+        ldd   x_pos,u
+        std   terrainCollision.sensor.x
+        ldd   y_pos,u
+        std   terrainCollision.sensor.y
+        jsr   terrainCollision.do
+        lda   terrainCollision.impact.x
+        bne   @blocked
+        ; ... peut bouger ...
+@blocked
+```
+
+Voir [references/terrain-collision.md](references/terrain-collision.md).
+
+---
+
+## Pattern d'utilisation typique (shoot'em up)
+
+```asm
+; Init objet ennemi
+Init
+        lda   #1                        ; HP de l'ennemi
+        sta   AABB_0+AABB.p,u
+        _ldd  8,8                       ; rx=8, ry=8
+        std   AABB_0+AABB.rx,u
+        _Collision_AddAABB AABB_0,AABB_list_enemy
+        inc   routine,u
+
+; MainLoop du game-mode
+MainLoop
+        jsr   RunObjects                ; objets bougent, cx/cy mis à jour à DisplaySprite
+        _Collision_Do AABB_list_player,AABB_list_enemy
+        _Collision_Do AABB_list_friend_fire,AABB_list_enemy
+        _Collision_Do AABB_list_player,AABB_list_foefire
+        ; ... autres paires ...
+        jsr   CheckSpritesRefresh
+        ; ... rendu ...
+```
+
+---
+
+## Pattern d'utilisation typique (plateformer)
+
+```asm
+; Player vs enemies (touche)
+_Collision_Do AABB_list_player,AABB_list_enemy
+
+; Player vs bonus (collecte)
+_Collision_Do AABB_list_player,AABB_list_bonus
+
+; Plus terrain collision pour le sol/murs (cf. terrainCollision)
+```
+
+---
+
+## Patterns avancés
+
+### Hitbox temporellement active
+
+```asm
+; Lors d'une attaque, activer une hitbox
+        lda   #1                        ; potential 1 (weak, à 1 hit)
+        sta   AABB_attack+AABB.p,u
+        ; ... 30 frames plus tard ...
+        lda   #0                        ; désactiver
+        sta   AABB_attack+AABB.p,u
+```
+
+### Plusieurs AABBs par objet
+
+```asm
+AABB_0     equ ext_variables             ; corps
+AABB_1     equ ext_variables+9           ; tête (zone critique)
+AABB_2     equ ext_variables+18          ; pied (slide)
+```
+
+Pré-requis : `ext_variables_size >= 27`. Chaque AABB peut être dans une liste différente.
+
+---
+
+## Pitfalls
+
+- **Ajouter une AABB sans nettoyer prev/next d'un précédent usage** : corruption de la liste précédente
+- **`ext_variables_size < 9`** : AABB déborde sur `rsv_*` → corruption
+- **Modifier `cx,cy` manuellement** : le moteur les met à jour à `DisplaySprite`, override possible mais à éviter
+- **Tester collision avant RunObjects** : `cx`/`cy` pas encore mis à jour pour la frame courante
+- **Tester collision après EraseSprites** : OK, mais le pattern conventionnel est avant
+- **Liste avec head=0 mais des AABBs encore référencées** : crash
+- **Potential = 127** (weak) : désactive à la 1ère collision même si la cible aurait pu prendre plus
+- **`_Collision_Do` sur la même liste** : possible (auto-collision), mais doit gérer le cas A=B (skip soi-même)
+- **Boîte plus grande que sprite** : collision déclenchée hors zone visible (peut être voulu pour gameplay)
+- **terrainCollision avec objet `collision` non chargé** : crash (page pas mountable)
+
+---
+
+## Références détaillées
+
+- [references/aabb-system.md](references/aabb-system.md) — Structure AABB détaillée (9 octets : p/rx/ry/cx/cy/prev/next), système de potentiel, algorithme `Collision_Do` complet (center-radius, complexity O(N×M)), patterns hitbox temporaire, plusieurs AABBs par objet, intégration avec cx/cy mis à jour par DisplaySprite
+- [references/aabb-lists.md](references/aabb-lists.md) — Listes typées AABB_list_<type>, déclaration dans ram-data.asm avec AABB_lists/AABB_endLists, conventions de nommage (friend/enemy/player/bonus/foefire), passage d'une liste à l'autre (Remove + CleanLinks + Add), choix des listes selon le genre de jeu
+- [references/terrain-collision.md](references/terrain-collision.md) — terrainCollision système complet (r-type) : objet `collision` avec 4 entry points (do/doRight/doLeft/update), `_terrainCollision.init` macro, variables sensor.x/sensor.y/impact.x, lookup tables de terrain, integration avec scroll horizontal, comparaison avec AABB pour terrain statique
+- [references/collision-patterns.md](references/collision-patterns.md) — Patterns par genre : shoot'em up (player vs enemy vs foefire), plateformer (player vs platform vs bonus), beat'em up (multiples hitbox attack/body), interaction avec scoring, animation de hit (clignotement via render_flags)

--- a/skills/thomson-to8-engine-collision/references/aabb-lists.md
+++ b/skills/thomson-to8-engine-collision/references/aabb-lists.md
@@ -1,0 +1,143 @@
+# Listes typées d'AABB
+
+Pour organiser les tests de collision, l'engine permet de regrouper les AABBs en **listes typées**. Chaque test `_Collision_Do A,B` croise toutes les paires entre 2 listes.
+
+## Déclaration dans `ram-data.asm`
+
+```asm
+* ===========================================================================
+* Collision lists
+* ===========================================================================
+AABB_lists.nb                 equ   (AABB_endLists-AABB_lists)/2
+AABB_lists
+AABB_list_player              fdb   0,0       ; head, tail
+AABB_list_enemy               fdb   0,0
+AABB_list_bonus               fdb   0,0
+AABB_list_foefire             fdb   0,0
+AABB_list_forcepod            fdb   0,0
+AABB_endLists
+```
+
+Chaque liste = `fdb 0,0` (2 mots = head + tail des chaînages doublement liés).
+
+Le bloc `AABB_lists` → `AABB_endLists` permet de calculer `AABB_lists.nb` (nombre de listes), utilisé par certaines routines de cleanup pour itérer sur toutes les listes (e.g. clear all à la transition de game-mode).
+
+## Conventions de nommage par genre
+
+### Shoot'em up (cf. r-type)
+
+```asm
+AABB_list_friend              fdb   0,0       ; entités amies (joueur, allié)
+AABB_list_enemy               fdb   0,0       ; entités ennemies (avions, ennemis)
+AABB_list_enemy_unkillable    fdb   0,0       ; ennemis qui font des dégâts mais sont invincibles (e.g. boss en charge)
+AABB_list_player              fdb   0,0       ; spécifique au joueur (zone critique)
+AABB_list_bonus               fdb   0,0       ; objets à collecter
+AABB_list_foefire             fdb   0,0       ; projectiles ennemis (font des dégâts au joueur)
+AABB_list_forcepod            fdb   0,0       ; le pod du joueur (peut bloquer les balles)
+```
+
+Paires testées :
+```asm
+        _Collision_Do AABB_list_player,AABB_list_foefire   ; joueur prend les tirs ennemis
+        _Collision_Do AABB_list_friend_fire,AABB_list_enemy ; tirs joueur sur ennemis
+        _Collision_Do AABB_list_player,AABB_list_enemy     ; collision physique
+        _Collision_Do AABB_list_player,AABB_list_bonus     ; collecte
+        _Collision_Do AABB_list_forcepod,AABB_list_foefire ; pod bloque les tirs
+```
+
+### Plateformer (cf. bubble-bobble)
+
+```asm
+AABB_list_player              fdb   0,0
+AABB_list_bubble              fdb   0,0       ; les bulles (de bubble-bobble)
+```
+
+Paires simples :
+```asm
+        _Collision_Do AABB_list_player,AABB_list_bubble    ; le joueur monte sur les bulles
+```
+
+### Beat'em up / fighting
+
+```asm
+AABB_list_player_body         fdb   0,0       ; corps du joueur (peut être touché)
+AABB_list_player_attack       fdb   0,0       ; hitbox d'attaque (temporaire)
+AABB_list_enemy_body          fdb   0,0
+AABB_list_enemy_attack        fdb   0,0
+```
+
+Paires :
+```asm
+        _Collision_Do AABB_list_player_attack,AABB_list_enemy_body  ; joueur tape ennemi
+        _Collision_Do AABB_list_enemy_attack,AABB_list_player_body  ; ennemi tape joueur
+```
+
+## Passage d'une liste à l'autre
+
+Cas typique : joueur normal → invincible (post-touche). Il faut :
+1. Retirer l'AABB de l'ancienne liste
+2. Nettoyer les liens (CleanLinks)
+3. Ajouter à la nouvelle liste
+
+```asm
+        _Collision_RemoveAABB AABB_0,AABB_list_player
+        _Collision_CleanLinksAABB AABB_0
+        _Collision_AddAABB AABB_0,AABB_list_player_invincible
+```
+
+> **Oublier `CleanLinks`** est l'erreur classique → corruption (les prev/next pointent vers l'ancienne liste).
+
+## Configuration du potential par liste
+
+Une convention pratique : configurer le potential selon le type de liste :
+
+| Liste | Potential typique |
+|-------|-------------------|
+| `AABB_list_player` | 1-5 (HP du joueur) |
+| `AABB_list_player_invincible` | -1 (invincible) |
+| `AABB_list_enemy` | 1-10 (HP des ennemis) |
+| `AABB_list_enemy_unkillable` | -128 (invincible mais fait des dégâts) |
+| `AABB_list_foefire` | 127 (weak, disparaît à 1 hit) |
+| `AABB_list_bonus` | 127 (weak, collecté à 1 hit) |
+| `AABB_list_friend_fire` | 1-5 selon arme |
+
+## Listes vs sub-types
+
+Alternative aux listes multiples : utiliser **une seule liste** + le champ `subtype,u` (8 bits dans l'OST) pour différencier. Le test de collision se fait depuis la routine de l'objet :
+
+```asm
+On_Collision
+        lda   subtype,u                 ; type de l'objet en collision
+        ; ... logique conditionnelle ...
+```
+
+Trade-off :
+- **Listes multiples** : moins de tests dans `Collision_Do` (filtrage à la source), plus rapide
+- **Une liste + subtype** : flexibilité (tout objet peut interagir avec tout objet), plus lent
+
+En pratique : utiliser des listes pour les **catégories majeures** (player/enemy/bonus), subtype pour les **variantes** dans une catégorie.
+
+## Limites
+
+Pas de limite hard sur le nombre de listes. Mais chaque liste = 4 octets en RAM + cycle CPU à `_Collision_Do`. Au-delà de ~10 listes, le management devient lourd.
+
+Limite par liste : O(N) sur la complexité du test. ~50 AABBs/liste reste tenable.
+
+## Patterns d'optimisation
+
+### Listes spatiales
+
+Diviser les ennemis en sous-listes selon leur position (e.g. `AABB_list_enemy_left`, `AABB_list_enemy_right`). Le joueur ne teste que celle de son côté.
+
+### Activation conditionnelle
+
+Mettre `p = 0` (désactivation) plutôt que retirer de la liste — la liste reste mais l'AABB est skipée par `Collision_Do`. Coûte cycles à l'iter mais évite Remove/Add coûteux.
+
+## Pitfalls
+
+- **Liste non-déclarée** mais référencée dans le code : symbol undefined au build
+- **AABB_endLists oublié** : `AABB_lists.nb` mal calculé
+- **Plusieurs AABBs sur la même AABB struct** dans plusieurs listes : corruption (warning explicite dans macros.asm : « Never use a single box in two or more lists »)
+- **Liste partagée entre game-modes** : OK si déclarée dans la zone résidente, mais attention à la pagination
+- **Reset de liste sans clear les AABBs** : les head/tail sont à 0 mais les objets contiennent encore des prev/next pointeurs → corruption à la prochaine Add
+- **Trop de listes** : maintenance lourde, moins clair

--- a/skills/thomson-to8-engine-collision/references/aabb-system.md
+++ b/skills/thomson-to8-engine-collision/references/aabb-system.md
@@ -1,0 +1,237 @@
+# AABB — système de collision objet-objet
+
+L'**AABB** (Axis-Aligned Bounding Box) est une boîte rectangulaire alignée sur les axes X et Y utilisée pour détecter les collisions entre objets. L'engine utilise la représentation **center-radius** : centre + demi-largeur/demi-hauteur.
+
+## Structure de l'AABB (9 octets)
+
+```asm
+AABB struct
+p       rmb   1                         ; potential (1 octet)
+rx      rmb   1                         ; radius X
+ry      rmb   1                         ; radius Y
+cx      rmb   1                         ; center X (à l'écran)
+cy      rmb   1                         ; center Y
+prev    rmb   2                         ; chaînage précédent
+next    rmb   2                         ; chaînage suivant
+ endstruct                              ; total = 9 octets
+```
+
+Convention d'inclusion :
+```asm
+        INCLUDE "./engine/collision/struct_AABB.equ"
+
+; Dans ext_variables de l'objet
+AABB_0  equ ext_variables               ; 9 octets
+```
+
+`AABB.p`, `AABB.rx`, ... sont des **offsets** dans la struct, à utiliser avec un offset de base.
+
+## Le système de potential
+
+Le champ `p` (1 octet signé) sert d'**HP de la hitbox** :
+
+```
+Valeur          | Sémantique
+----------------|---------------------------------------------------
+-128 à -1       | Invincible — potential ne change jamais
+0               | Désactivée — pas de collision détectée
+1 à 126         | HP — décrémenté à chaque collision (min 0)
+127             | Weak — désactivée après 1 seule collision
+```
+
+### Sémantique du décrément
+
+Quand `Collision_Do` détecte une collision entre A et B :
+- Si `A.p > 0` et `A.p < 128` : `A.p -= 1`
+- Si `B.p > 0` et `B.p < 128` : `B.p -= 1`
+- Si `A.p = -1..-128` : aucun changement (invincible)
+- Si `A.p = 127` : `A.p = 0` (désactivation)
+
+Quand `p = 0`, l'AABB est skipée par les tests suivants (cf. `beq @skipu` dans Collision_Do).
+
+### Exemples de configuration
+
+```asm
+; Joueur invincible (frames d'invincibilité après touche)
+        lda   #-1
+        sta   AABB_0+AABB.p,u
+
+; Ennemi avec 3 HP
+        lda   #3
+        sta   AABB_0+AABB.p,u
+
+; Projectile qui se détruit au 1er impact
+        lda   #127                      ; weak
+        sta   AABB_0+AABB.p,u
+
+; Bonus déjà ramassé (désactivé)
+        clr   AABB_0+AABB.p,u
+```
+
+## Coord center-radius
+
+```
+AABB couvre [cx - rx, cx + rx] × [cy - ry, cy + ry]
+```
+
+Exemples :
+- `cx=80, cy=100, rx=4, ry=8` → box de 9×17 pixels centrée en (80,100)
+- `cx=160, cy=100, rx=8, ry=4` → box de 17×9 pixels
+
+> **Mise à jour de cx/cy** : le moteur les met à jour automatiquement à `DisplaySprite` (à partir de `x_pos`/`y_pos`/`x_pixel`/`y_pixel`). Ne pas écrire `cx`/`cy` manuellement sauf cas particulier.
+
+## Algorithme `Collision_Do`
+
+```asm
+Collision_Do
+        ldu   #0                        ; auto-modif : adresse head liste 1
+Collision_Do_1 equ *-2
+        beq   @rts
+@loopu  ldb   AABB.p,u
+        beq   @skipu                    ; potential = 0 → skip
+        ldx   #0                        ; auto-modif : adresse head liste 2
+Collision_Do_2 equ *-2
+        beq   @rts
+@loopx  ldb   AABB.p,x
+        beq   @skipx
+        
+        ; Test collision X
+        lda   AABB.rx,u
+        adda  AABB.rx,x                 ; A = rx_u + rx_x
+        asla                            ; A = 2*(rx_u + rx_x)
+        sta   @rx                       ; auto-modif l'opérande de cmp
+        asra                            ; A = rx_u + rx_x (récupère)
+        adda  AABB.cx,u                 ; A = cx_u + (rx_u+rx_x) (= max boundary)
+        suba  AABB.cx,x                 ; A = (cx_u + rx_u + rx_x) - cx_x
+        cmpa  #0                        ; (modif par @rx)
+@rx     equ *-1
+        bhi   @continue                 ; pas de collision X
+        
+        ; Test collision Y (idem)
+        ; ...
+        
+        ; COLLISION
+        ; décrément A.p, B.p (si dans range 1-126)
+        ; ...
+
+@continue
+        ldx   AABB.next,x
+        bne   @loopx
+        ; ... boucle U ...
+```
+
+Mathématiquement, la collision X est :
+```
+|cx_u - cx_x| < rx_u + rx_x
+```
+
+Le code utilise une astuce : `(rx_u + rx_x)*2` permet de tester en signed avec `cmpa #0` après ajustement signé.
+
+### Complexité
+
+O(N × M) où N et M sont les tailles des deux listes. Pour deux listes de 10 AABBs : 100 paires testées.
+
+À 50 Hz, cycle budget par paire : 20000/100 = 200 cycles → largement suffisant (le test fait ~30 cycles).
+
+Pour 50 AABBs par liste : 2500 paires × 30 cycles = 75000 cycles → ne tient pas en 1 frame.
+
+**Mitigation** : segmenter en sous-listes (ex: ennemis proches de la caméra vs distants), prioritiser certaines paires.
+
+## Chaînage doublement lié
+
+Chaque AABB a `prev` et `next` (2 octets chacun). Une liste typée a un head et un tail :
+
+```
+AABB_list_player : [head, tail]
+   head ──→ AABB_A
+              prev = 0
+              next ──→ AABB_B
+                        prev ──→ AABB_A
+                        next = 0
+                        ←─── tail
+```
+
+`Collision_AddAABB` insère en queue. `Collision_RemoveAABB` délink l'AABB.
+
+## Macro `_Collision_AddAABB`
+
+```asm
+_Collision_AddAABB MACRO
+        pshs  u,x,y
+        leax  \1,u                      ; X = adresse de l'AABB
+        ldy   #\2                       ; Y = adresse de la liste
+        jsr   Collision_AddAABB
+        puls  u,x,y
+ ENDM
+```
+
+Préserve `u`, `x`, `y`. La routine `Collision_AddAABB` insère X dans la liste Y.
+
+## Macro `_Collision_RemoveAABB`
+
+Plus complexe car la routine modifie des adresses auto-modifiées :
+```asm
+_Collision_RemoveAABB MACRO
+        pshs  d,u,x,y
+        ldx   #\2
+        stx   Collision_Remove_1        ; adresse head pour cas @noPrev
+        stx   Collision_Remove_3        ; idem
+        leax  2,x
+        stx   Collision_Remove_2        ; adresse tail
+        leax  \1,u
+        jsr   Collision_RemoveAABB
+        puls  d,u,x,y
+ ENDM
+```
+
+C'est un peu intrusif (modification de mémoire engine) mais permet de gérer head/tail dynamiquement.
+
+## Patterns multi-AABBs
+
+Un objet peut avoir plusieurs AABBs (corps + tête + pied) :
+
+```asm
+AABB_body     equ ext_variables
+AABB_head     equ ext_variables+9
+AABB_feet     equ ext_variables+18
+
+Init
+        lda   #1
+        sta   AABB_body+AABB.p,u
+        sta   AABB_head+AABB.p,u
+        sta   AABB_feet+AABB.p,u
+        ; rayons différents par AABB
+        ; ...
+        _Collision_AddAABB AABB_body,AABB_list_enemy
+        _Collision_AddAABB AABB_head,AABB_list_enemy_crit
+        _Collision_AddAABB AABB_feet,AABB_list_enemy_slide
+        inc   routine,u
+```
+
+Pré-requis : `ext_variables_size >= 27`.
+
+## Décalage cx/cy par rapport à xy_pixel
+
+Par défaut, `cx = x_pixel` et `cy = y_pixel` (ou conversion depuis x_pos/y_pos). Si on veut une AABB **décalée** par rapport au centre du sprite, il faut écrire `cx`/`cy` manuellement après chaque mise à jour engine :
+
+```asm
+        ; Hitbox de la tête, 8 pixels au-dessus du centre sprite
+        lda   x_pixel,u
+        sta   AABB_head+AABB.cx,u
+        lda   y_pixel,u
+        suba  #8
+        sta   AABB_head+AABB.cy,u
+```
+
+À faire **après** `DisplaySprite` (qui a mis à jour `x_pixel`/`y_pixel`) et **avant** `_Collision_Do`.
+
+## Pitfalls
+
+- **`ext_variables_size < 9`** : la struct AABB déborde sur `rsv_*` → corruption
+- **Add sans Remove préalable** : double-link, la liste devient cyclique
+- **Remove sans CleanLinks puis Add dans une autre liste** : prev/next pointent vers la liste précédente → corruption
+- **Modifier `cx,cy` après DisplaySprite** : valide pour décalage, mais penser à le refaire chaque frame
+- **Plusieurs AABBs dans la même liste** : possible mais attention à l'auto-collision (`Collision_Do A,A`)
+- **Potential signed mal géré** : oublier que -1 = invincible, pas « -1 HP »
+- **`Collision_Do` avant que DisplaySprite ait mis à jour cx/cy** : collision basée sur l'ancienne frame
+- **AABB sur objet caché (`render_hide_mask`)** : si cx/cy ne sont plus mis à jour, la collision reste à l'ancienne position

--- a/skills/thomson-to8-engine-collision/references/terrain-collision.md
+++ b/skills/thomson-to8-engine-collision/references/terrain-collision.md
@@ -1,0 +1,214 @@
+# `terrainCollision` — collision avec un terrain statique
+
+Pour les jeux à scrolling avec un terrain solide (murs, sols, plateformes), l'engine fournit `terrainCollision` : un système qui consulte des **lookup tables** décrivant la structure du terrain. Utilisé exclusivement par r-type dans les game-projects observés.
+
+## Concept
+
+Le terrain est représenté par un **objet** (`ObjID_collision`) qui exporte **4 entry points** consécutifs en mémoire (espacés de 3 octets) :
+
+```asm
+ObjID_collision entry points :
+  offset 0  : terrainCollision.main          (check vertical)
+  offset 3  : terrainCollision.xAxis.doRight (check à droite)
+  offset 6  : terrainCollision.xAxis.doLeft  (check à gauche)
+  offset 9  : terrainCollision.update        (update tables)
+```
+
+L'engine fournit des **routines wrapper** (avec sauvegarde/restauration de page) qui appellent ces entry points via leurs adresses auto-modifiées.
+
+## Initialisation — `_terrainCollision.init`
+
+```asm
+        _terrainCollision.init ObjID_collision
+```
+
+Macro :
+```asm
+_terrainCollision.init MACRO
+        lda   Obj_Index_Page+\1
+        sta   terrainCollision.main.page
+        sta   terrainCollision.main.xAxis.doRight.page
+        sta   terrainCollision.main.xAxis.doLeft.page
+        sta   terrainCollision.main.update.page
+        ldd   Obj_Index_Address+2*\1
+        std   terrainCollision.main.address
+        addd  #3
+        std   terrainCollision.main.xAxis.doRight.address
+        addd  #3
+        std   terrainCollision.main.xAxis.doLeft.address
+        addd  #3
+        std   terrainCollision.main.update.address
+ ENDM
+```
+
+À appeler **une fois au boot** du game-mode (après les `_MountObject` initiaux).
+
+## Variables d'état
+
+```asm
+terrainCollision.sensor.x   fdb 0       ; coordonnée X du sensor (entrée)
+terrainCollision.sensor.y   fdb 0       ; coordonnée Y du sensor (entrée)
+terrainCollision.impact.x   fdb 0       ; coordonnée X impact (sortie)
+```
+
+`sensor.x/y` = point à tester. `impact.x` = position de collision retournée (0 = pas de collision).
+
+## Routines wrapper
+
+```asm
+terrainCollision.do                     ; check terrain (vertical typiquement)
+        _GetCartPageA
+        sta   @page                     ; sauve page courante
+        lda   #0                        ; (modif par init)
+terrainCollision.main.page equ *-1
+        _SetCartPageA                   ; mount page du terrain
+        jsr   >0                        ; appel routine du terrain
+terrainCollision.main.address equ *-2
+        lda   #0                        ; restore page
+@page   equ *-1
+        _SetCartPageA
+        rts
+
+terrainCollision.xAxis.doRight          ; check à droite
+        ; (même structure)
+
+terrainCollision.xAxis.doLeft           ; check à gauche
+        ; (même structure)
+
+terrainCollision.update                 ; update tables
+        sta   @a                        ; sauvegarde le paramètre A
+        ; ... mount page ...
+        lda   @a                        ; restore param
+        jsr   ...
+```
+
+## Implémentation côté objet `collision`
+
+L'objet `collision` doit exporter 4 entry points dans cet ordre, espacés de 3 octets :
+
+```asm
+        org   $A100                     ; (selon placement)
+Collision                               ; entry point 0 : main
+        jmp   Collision_Main
+        ; (occupe 3 octets : jmp + adresse 2 octets)
+
+Collision_doRight                       ; entry point +3
+        jmp   Collision_DoRight
+        ; (3 octets)
+
+Collision_doLeft                        ; entry point +6
+        jmp   Collision_DoLeft
+        ; (3 octets)
+
+Collision_update                        ; entry point +9
+        jmp   Collision_Update
+        ; (3 octets)
+
+; Implémentations ailleurs
+Collision_Main
+        ; Lit terrainCollision.sensor.x et sensor.y
+        ; Cherche dans la lookup table si la position est dans un mur
+        ; Si oui, écrit terrainCollision.impact.x
+        rts
+; ...
+```
+
+Chaque `jmp` fait 3 octets, ce qui matche l'espacement attendu par le wrapper.
+
+## Lookup tables — pattern r-type
+
+Dans r-type, le terrain est représenté par :
+- Une **table de hauteurs** indexée par X (pour le sol et le plafond)
+- Une **table de murs** pour les obstacles latéraux
+
+Le `Collision_Main` lit `sensor.x`, calcule l'index dans la table, lit la hauteur, et compare à `sensor.y`. Si collision, écrit `impact.x`.
+
+```asm
+Collision_Main
+        ldd   terrainCollision.sensor.x
+        ; ... convert to table index ...
+        ldx   #floor_height_table
+        ldb   d,x                       ; hauteur du sol à cette X
+        cmpb  terrainCollision.sensor.y+1
+        bls   @no_collision
+        ; ... compute impact ...
+        std   terrainCollision.impact.x
+        rts
+@no_collision
+        ldd   #0
+        std   terrainCollision.impact.x
+        rts
+```
+
+## Usage typique (pattern r-type)
+
+```asm
+; Avant de bouger le joueur, vérifier qu'on peut
+Player_TryMove
+        ldd   x_pos,u
+        std   terrainCollision.sensor.x
+        ldd   y_pos,u
+        std   terrainCollision.sensor.y
+        jsr   terrainCollision.do
+        ldd   terrainCollision.impact.x
+        bne   @blocked                  ; impact != 0 → collision
+        ; ... appliquer le mouvement ...
+        rts
+@blocked
+        ; ... bloquer ou rebondir ...
+        rts
+
+; Check ouvert/fermé latéralement
+        jsr   terrainCollision.xAxis.doRight
+        bne   @wall_right
+        jsr   terrainCollision.xAxis.doLeft
+        bne   @wall_left
+```
+
+## `terrainCollision.update`
+
+Permet de **modifier le terrain** à runtime (e.g. murs destructibles). Le paramètre A indique quoi modifier ; l'objet `collision` met à jour ses tables.
+
+Usage rare. Cf. r-type pour le cas spécifique (boss qui modifie le terrain).
+
+## Comparaison avec AABB
+
+| Aspect | AABB | terrainCollision |
+|--------|------|------------------|
+| Cibles | Objets dynamiques | Terrain statique |
+| Représentation | Box centre-radius | Lookup table |
+| Coût | O(N×M) | O(1) par check |
+| Précision | Sub-pixel | Tile-aligned |
+| Modification | Add/Remove dynamique | Update via routine |
+
+Les deux systèmes **coexistent** dans r-type : AABB pour player vs ennemis, terrainCollision pour player vs murs.
+
+## Patterns d'usage
+
+### Sensors multiples (plateformer)
+
+Pour un personnage de plateformer, on a typiquement 4-8 sensors :
+- Bas-gauche et bas-droit (détection sol)
+- Haut-gauche et haut-droit (détection plafond)
+- Gauche-haut et gauche-bas (détection mur gauche)
+- Droite-haut et droite-bas (détection mur droit)
+
+Chaque sensor positionne `sensor.x` et `sensor.y` puis appelle `terrainCollision.do`.
+
+### Intégration avec scroll
+
+Quand la caméra bouge, les positions sensor doivent être en **coord playfield** (cohérentes avec le terrain). L'objet `collision` doit faire la conversion playfield → table index.
+
+### Anti-stuck
+
+Si un objet est déjà dans le terrain (e.g. spawn en superposition), `terrainCollision.do` retourne `impact != 0` à chaque check. Pattern : tester la sortie possible (`xAxis.doRight`/`doLeft`) et pousser dans la direction libre.
+
+## Pitfalls
+
+- **`_terrainCollision.init` non appelé** : `terrainCollision.main.address = 0` → `jsr >0` → crash
+- **Object `collision` mal défini** (entry points pas espacés de 3 octets) : le wrapper jsr à la mauvaise adresse → comportement erratique
+- **Sensor.x/y non mis à jour** avant l'appel : utilise la valeur précédente
+- **Lookup table mal alignée avec scroll** : impact retourné incohérent avec ce qu'on voit à l'écran
+- **Update du terrain pendant que d'autres objets sont en train de check** : race condition potentiel (si test multi-frame)
+- **terrainCollision.do appelée pendant que la page de `collision` est mountée** : double mount, OK car wrapper sauve/restaure
+- **Confondre coord playfield et écran** dans `sensor.x/y` : le terrain est en coord playfield (le moteur ne fait pas de conversion automatique)

--- a/skills/thomson-to8-engine-dyncode/SKILL.md
+++ b/skills/thomson-to8-engine-dyncode/SKILL.md
@@ -1,0 +1,318 @@
+---
+name: thomson-to8-engine-dyncode
+description: "Décrit le système de code auto-modifié (DynCode) du Thomson TO8/TO9 game engine (Bento8/wide-dot) : routine DynCode_ApplyAToListX pour écrire une valeur dans une liste d'adresses (terminée par -1, $FFFF), pattern d'optimisation 6809 pour éviter les indirections, exemples d'usage dans engine (terrainCollision avec terrainCollision.main.page / terrainCollision.main.address auto-modifiés, _vscroll.setTileset_ qui modifie 16 instances de vscroll.tiles.nbLinesByPage.x2.XXXX, AnimateSprite avec Anim_End_FE_dyn qui modifie une opérande suba, vscroll.obj.map.page / vscroll.obj.map.address auto-modifiés par _vscroll.setMap, objectWave.data.page / objectWave.data.cursor, ObjectMove avec @a+1 modifié par sex pour propagation de signe, BankSwitch avec @page modifié, RunPgSubRoutine avec PSR_Page / PSR_Address / PSR_Param, gfxlock.screenBorder.color, gfxlock.backProcess.routine auto-modifiés), gain de cycles vs lecture variable (économise 1-2 cycles par accès), conventions de naming (equ *-1 ou equ *-2 pour pointer l'opérande), risques (re-entrée, IRQ pendant modification, page commutation). Utiliser pour comprendre le code engine qui apparaît étrange (jmp/jsr vers $0000 auto-modifiés), implémenter une optimisation de code auto-modifié, déboguer une routine avec valeur auto-modifiée, propager une valeur dans plusieurs instances. Mots-clés : DynCode, DynCode_ApplyAToListX, self-modifying code, auto-modif, equ *-1, equ *-2, jsr >0, lda #0, modif opérande, terrainCollision.main.page, vscroll.tiles.nbLinesByPage, PSR_Page, PSR_Address, PSR_Param, Anim_End_FE_dyn, optimization, cycle saving, dynamic code generation, code patching, runtime patch."
+machines: [to8, to8d, to9, to9+]
+user-invocable: false
+---
+
+# DynCode — code auto-modifié
+
+L'engine utilise massivement la technique du **code auto-modifié** (self-modifying code) pour optimiser les routines critiques. Le 6809 le permet trivialement (pas de cache, mémoire = mémoire).
+
+Cette technique consiste à **modifier les opérandes d'instructions à runtime** pour économiser une indirection (lecture de variable). Économie : ~2 cycles par accès.
+
+---
+
+## Pattern de base
+
+```asm
+        lda   #0                        ; valeur dynamique
+my_var  equ *-1                          ; pointe vers l'opérande de lda
+
+        ; ailleurs dans le code :
+        ldb   #42
+        stb   my_var                     ; modifie l'opérande
+        ; maintenant lda #42 sera exécuté
+```
+
+Au lieu de :
+```asm
+        lda   my_var                    ; lecture mémoire (3 cycles)
+my_var  fcb 0
+```
+
+L'auto-modif fait `lda #imm` (2 cycles) qu'on peut modifier en place.
+
+## `DynCode_ApplyAToListX` — utilitaire
+
+```asm
+DynCode_ApplyAToListX
+        pshs  u
+@loop   ldu   ,x++                      ; lit une adresse depuis la liste
+        cmpu  #-1                       ; -1 = fin
+        beq   @end
+        sta   ,u                        ; écrit A à cette adresse
+        bra   @loop
+@end    puls  u,pc
+```
+
+Usage :
+```asm
+        lda   #new_value
+        ldx   #targets
+        jsr   DynCode_ApplyAToListX
+        
+targets fdb   target_1                  ; liste d'adresses à modifier
+        fdb   target_2
+        fdb   target_3
+        fdb   $FFFF                     ; fin (= -1 en signed)
+```
+
+Permet de **propager une valeur dans plusieurs instances** d'un seul coup. Utile quand une valeur (e.g. page mémoire) est utilisée à plusieurs endroits du code.
+
+Voir [references/dyncode-utilities.md](references/dyncode-utilities.md).
+
+---
+
+## Exemples massifs dans l'engine
+
+### `terrainCollision` (r-type)
+
+```asm
+terrainCollision.do
+        _GetCartPageA
+        sta   @page
+        lda   #0
+terrainCollision.main.page equ *-1      ; opérande dynamique
+        _SetCartPageA
+        jsr   >0
+terrainCollision.main.address equ *-2   ; opérande dynamique (2 octets)
+```
+
+Le `lda #0` et `jsr >0` ont leurs opérandes modifiés à l'init par `_terrainCollision.init` :
+```asm
+_terrainCollision.init MACRO
+        lda   Obj_Index_Page+\1
+        sta   terrainCollision.main.page
+        ldd   Obj_Index_Address+2*\1
+        std   terrainCollision.main.address
+        ; ... idem pour doRight, doLeft, update ...
+ ENDM
+```
+
+Économie : pas de lookup à runtime, juste une instruction `jsr` directe.
+
+### `vscroll`
+
+```asm
+_vscroll.setUpdateRoutine_ MACRO
+        sta   vscroll.tiles.nbLinesByPage
+        asra
+        ldx   #vscroll.tiles.dyncall
+        ldx   a,x
+        stx   vscroll.tiles.updateTilesForNLines.address
+        lda   vscroll.tiles.nbLinesByPage
+        asla
+        sta   vscroll.tiles.nbLinesByPage.x2.0001    ; 16 instances
+        sta   vscroll.tiles.nbLinesByPage.x2.0010
+        sta   vscroll.tiles.nbLinesByPage.x2.0011
+        ; ... 16 fois ...
+ ENDM
+```
+
+Le même octet est propagé dans 16 endroits du code (un par mode de scroll selon la position).
+
+### `ObjectMove` — propagation du signe
+
+```asm
+ObjectMove
+        ldb   x_vel,u
+        sex                             ; sign extend : A = $00 si B+, $FF si B-
+        sta   @a+1                      ; auto-modif l'opérande qui suit
+        ldd   x_vel,u
+        addd  x_pos+1,u
+        std   x_pos+1,u
+        lda   x_pos,u
+@a
+        adca  #$00                      ; (modifié dynamiquement)
+        sta   x_pos,u
+        rts
+```
+
+Au lieu d'une branche conditionnelle (positif/négatif), on modifie l'opérande de `adca #imm` pour gérer la propagation signed. Économie : 4-5 cycles par appel.
+
+### `RunPgSubRoutine`
+
+```asm
+RunPgSubRoutine
+        _GetCartPageA
+        sta   @page                     ; sauve page sortante
+        lda   #0
+PSR_Page equ *-1                        ; modif par _RunObjectSwap
+        _SetCartPageA
+        lda   #0
+PSR_Param equ *-1                       ; param optionnel
+        jsr   >0
+PSR_Address equ *-2                     ; modif par _RunObjectSwap
+        lda   #0
+@page   equ *-1
+        _SetCartPageA                   ; restore
+        rts
+```
+
+Permet d'appeler n'importe quelle routine dans n'importe quelle page sans table de dispatch.
+
+### `gfxlock.bufferSwap.do`
+
+```asm
+gfxlock.bufferSwap.do
+        ldb   gfxlock.backBuffer.status
+        andb  #%01000000
+        orb   #%10000000
+gfxlock.screenBorder.color equ *-1      ; opérande modifiée par update
+        stb   map.CF74021.SYS2
+        ; ...
+```
+
+La couleur de bordure est l'opérande d'un `orb #imm`. Modifiée par `gfxlock.screenBorder.update`.
+
+### `AnimateSprite`
+
+```asm
+Anim_End_FE
+        ; ...
+        lda   anim_frame,u
+        stb   Anim_End_FE_dyn+1         ; auto-modif
+        suba  #$00                      ; (modifié dynamiquement)
+Anim_End_FE_dyn
+        ; ...
+```
+
+Le `suba #imm` a son opérande modifié par l'octet lu depuis le script d'animation.
+
+---
+
+## Conventions de naming
+
+### `equ *-1` / `equ *-2`
+
+```asm
+        lda   #0                        ; instruction lda #imm (2 octets)
+my_label equ *-1                         ; pointe vers le byte imm
+```
+
+`*` = position courante. `*-1` = adresse du byte d'opérande. C'est l'endroit où on écrit pour modifier.
+
+Pour `ldd #imm16` ou `jsr >abs16` (3 octets) :
+```asm
+        ldd   #0
+my_d_label equ *-2                       ; pointe vers les 2 octets opérande
+        jsr   >0
+my_jsr_label equ *-2                     ; idem pour jsr abs16
+```
+
+### Naming conventions
+
+- `<routine>.<purpose>.page` / `<routine>.<purpose>.address` pour mount cross-page
+- `@dyn`, `@dynb` (préfixe @) pour les noms locaux à une routine
+- `PSR_<X>` pour `RunPgSubRoutine`
+- `<routine>_dyn` pour des modifications dans la même routine
+
+---
+
+## Risques
+
+### Re-entrée
+
+Si une routine auto-modifiée est appelée depuis l'IRQ pendant qu'elle est en cours d'exécution dans MainLoop, l'IRQ peut modifier les opérandes en plein milieu. Comportement imprévisible.
+
+Mitigation :
+- Routines auto-modifiées **NON re-entrantes** : ne pas appeler depuis IRQ
+- Si nécessaire : `IrqPause` autour de l'appel
+
+### IRQ pendant modification
+
+Même problème dans l'autre sens : si on modifie une opérande pendant qu'une IRQ tire la routine, l'IRQ peut exécuter avec un opérande à moitié écrit (1 octet sur 2 modifié).
+
+Mitigation : modifier les opérandes 1 octet (rare) ou utiliser des couplages cohérents.
+
+### Mémoire ROM
+
+Le code auto-modifié **ne peut pas** vivre en ROM (ROM = read-only). Doit être en RAM.
+
+C'est pour ça que les routines auto-modifiées comme `RunPgSubRoutine`, `terrainCollision`, `gfxlock` sont placées dans des modules engine **inclus dans le code du game-mode** (pas en cartouche T2 read-only). En T2, le main engine est copié en RAM au boot.
+
+---
+
+## Quand utiliser DynCode
+
+- **Routines critiques** appelées des milliers de fois par frame (gain cumulé important)
+- **Valeurs stables** entre les appels (page mémoire, paramètre invariant pendant N frames)
+- **Pas re-entrant** (pas appelée depuis IRQ)
+- **Code en RAM** (impossible en ROM)
+
+## Quand NE PAS utiliser
+
+- Code re-entrant (IRQ + MainLoop)
+- Valeurs qui changent souvent (autant lire la variable)
+- Code partagé entre game-modes en ROM
+- Lisibilité critique (le code auto-modifié est plus dur à débugger)
+
+## Patterns avancés
+
+### Patch de plusieurs sites depuis un point
+
+```asm
+update_color
+        sta   target_1+2                ; modif opérande
+        sta   target_2+2
+        sta   target_3+2
+        ; ...
+        rts
+```
+
+Ou via `DynCode_ApplyAToListX` pour des listes longues.
+
+### Dispatch dynamique sans table
+
+```asm
+        ; Modifier directement le jmp pour basculer entre modes
+        ldx   #routine_a
+        stx   my_jmp+1                  ; modif l'opérande de jmp
+        ; ...
+my_jmp  jmp   >0                        ; (modifié dynamiquement)
+```
+
+Plus rapide qu'un `jmp [d,x]` indirect.
+
+### Combo avec page commutation
+
+```asm
+        ; Setup pour appeler une routine dans une autre page
+        lda   #page_target
+        sta   PSR_Page
+        ldd   #routine_target
+        std   PSR_Address
+        jsr   RunPgSubRoutine
+```
+
+Très efficace pour les appels cross-page.
+
+---
+
+## Débugging
+
+Le code auto-modifié est **difficile à débugger** :
+- Le listing LWASM montre les valeurs initiales (typiquement `0`)
+- Le runtime utilise les valeurs modifiées
+- Les outils statiques (grep, analyse de code) peuvent passer à côté
+
+Astuces :
+- Documenter les `equ *-1` clairement dans les commentaires
+- Tracer les écritures vers les opérandes
+- Utiliser un émulateur (DCMOTO) avec breakpoints sur écritures
+
+## Pitfalls
+
+- **Confondre opérande et instruction** : `lda #0` a son opérande à offset +1 (`*-1`), `ldd #0` à offset +1 sur 2 octets
+- **Modifier 1 octet sur 2** : si l'opérande fait 2 octets et qu'on n'écrit qu'un, valeur garbage
+- **Re-entrée IRQ** : modification écrasée par l'IRQ
+- **Code en ROM** : modification silencieusement ignorée (la write disparaît)
+- **Oublier le `*-2`** pour les opérandes 2 octets
+- **Modifier sans cleaner avant** : valeur résiduelle d'un usage précédent
+- **`DynCode_ApplyAToListX` sans `$FFFF` à la fin** : lecture infinie, crash
+
+## Références détaillées
+
+- [references/dyncode-utilities.md](references/dyncode-utilities.md) — DynCode_ApplyAToListX algorithm et usage, format liste $FFFF terminator, propagation de valeurs vers multiples sites
+- [references/selfmod-patterns.md](references/selfmod-patterns.md) — Patterns observés : `equ *-1` / `*-2`, propagation de signe (ObjectMove avec sex), dispatch dynamique sans table, page mounting cross-page (PSR_Page/Address), patch de plusieurs sites, cas terrainCollision/vscroll/gfxlock

--- a/skills/thomson-to8-engine-fonts-text/SKILL.md
+++ b/skills/thomson-to8-engine-fonts-text/SKILL.md
@@ -1,0 +1,360 @@
+---
+name: thomson-to8-engine-fonts-text
+description: "Décrit les routines d'affichage de texte du Thomson TO8/TO9 game engine (Bento8/wide-dot) : DrawText pour afficher des chaînes ASCII via une font compilée (font 3x5 et variantes 3x5_selected / 3x5_shaded / 3x5_shaded_disabled / 3x5_shaded_selected), DrawOneChar pour 1 caractère, indexation par offset 32 (caractère - 32 → index), variable DrawText_pos pour positionner à l'écran (auto-incrémenté), callbacks DrawText_0A / DrawText_0C / DrawText_0D pour gérer LF/FF/CR (par défaut rts), HexToText pour conversion hex→ascii 2 chiffres, PrintString pour afficher avec font 3x7-normal (utilise LOCATE_X / LOCATE_Y pour la position, RAM_A / RAM_B pour les plans, LETTER_X labels pour chaque lettre), USER_STACK pour fonctions imbriquées, format VRAM TO8 (VIDEO = $A000, RAM_A_OFFSET = $2000), génération des fonts via .txt source. Utiliser pour afficher un HUD (score, vies, time), un menu de sélection, des messages texte, des codes de couleurs, des dialogues, créer une nouvelle police, basculer entre fonts (normale vs sélectionnée pour menus), gérer les retours à la ligne automatiques. Mots-clés : DrawText, DrawOneChar, DrawText_pos, DrawText_0A, DrawText_0C, DrawText_0D, DrawText_start_pos, HexToText, PrintString, LOCATE_X, LOCATE_Y, RAM_A, RAM_B, RAM_VIDEO_SIZE, VIDEO $A000, RAM_A_OFFSET $2000, fnt_4x6_shd, font 3x5, 3x5_selected, 3x5_shaded, 3x5_shaded_disabled, 3x5_shaded_selected, font 3x7-normal, USER_STACK, RASTER_COLORS, COLOR, LETTER_, fcn ASCIIZ, fcb null-terminated, ascii 32 space, $A LF, $C FF, $D CR, sprite engine integration."
+machines: [to8, to8d, to9, to9+]
+user-invocable: false
+---
+
+# Fonts et texte — Thomson TO8/TO9 Game Engine
+
+L'engine fournit deux systèmes d'affichage de texte :
+
+1. **`DrawText`** (`engine/graphics/font/DrawText/`) — system moderne avec font 3×5 + variantes (sélectionnée, shaded, disabled). Utilisé par sonic-2.
+2. **`PrintString`** (`engine/graphics/font/PrintString/`) — system simple avec font 3×7 normale. Utilisé par sonic-2 et goldorak.
+
+---
+
+## `DrawText` — texte via font compilée
+
+### Signature
+
+```asm
+; X : pointeur vers la font (e.g. fnt_4x6_shd)
+; Y : pointeur vers le texte (chaîne ASCIIZ ou null-terminated)
+; DrawText_pos : position écran (variable auto-modif)
+        jsr   DrawText
+```
+
+### Algorithme
+
+```asm
+DrawText
+        pshs  d,u,y
+@loop   ldb   ,y+                       ; lit caractère
+        beq   @rts                      ; null = fin
+        cmpb  #32
+        bge   @r_char                   ; caractère normal
+        ; Caractère spécial (< 32)
+        cmpb  #$A                       ; LF
+        bne   >
+        jsr   [DrawText_0A]
+        bra   @loop
+!       cmpb  #$C                       ; FF
+        bne   >
+        jsr   [DrawText_0C]
+        bra   @loop
+!       cmpb  #$D                       ; CR
+        bne   @loop
+        jsr   [DrawText_0D]
+        bra   @loop
+@r_char
+        clra
+        subb  #32                       ; index dans la font (caractère - 32)
+        aslb                            ; *2 (table de fdb)
+        ldu   #0
+DrawText_pos equ *-2                    ; position écran (auto-modif)
+        jsr   [d,x]                     ; appel indirect — chaque char est une routine compilée
+        inc   DrawText_pos+1            ; avance position (+1 byte = +4 pixels en mode 160)
+        bne   @loop
+        inc   DrawText_pos
+        bra   @loop
+@rts    puls  d,u,y,pc
+```
+
+Chaque **caractère** est une **routine compilée** (pas un bitmap statique). C'est une **font sprite compilée** : chaque char a son code asm optimisé qui écrit ses pixels en VRAM.
+
+Avantage : très rapide à dessiner (~30 cycles/caractère).
+Inconvénient : taille en code (chaque caractère = ~30-50 octets de code).
+
+### Callbacks LF/FF/CR
+
+```asm
+DrawText_0A fdb @rts                    ; LF (Line Feed) — par défaut rts
+DrawText_0C fdb @rts                    ; FF (Form Feed)
+DrawText_0D fdb @rts                    ; CR (Carriage Return)
+```
+
+À redéfinir pour gérer les retours à la ligne :
+
+```asm
+DrawText_0A fdb MyLineFeed              ; LF custom
+
+MyLineFeed
+        ; reset position X, descend Y
+        lda   DrawText_pos              ; high byte = X
+        anda  #%11000000                ; clear X
+        ; ... add Y offset ...
+        sta   DrawText_pos
+        rts
+```
+
+### Variantes de font
+
+```
+3x5/                          # normale 3×5 pixels
+3x5_selected/                 # surlignée (pour menus)
+3x5_shaded/                   # avec ombre
+3x5_shaded_disabled/          # ombre + gris (option désactivée)
+3x5_shaded_selected/          # ombre + surlignée
+```
+
+Permet un look cohérent avec des variantes pour les menus.
+
+### `HexToText`
+
+```asm
+        lda   #$3F                      ; valeur à afficher (en hex)
+        ldy   #buffer                   ; buffer ASCIIZ 2 octets + null
+        jsr   HexToText
+        ; buffer = "3F", 0
+```
+
+Convertit un octet en 2 caractères ASCII hex.
+
+Voir [references/drawtext.md](references/drawtext.md).
+
+---
+
+## `PrintString` — texte simple avec font 3×7
+
+### Signature
+
+```asm
+        lda   #0
+        sta   LOCATE_X
+        sta   LOCATE_Y
+        ldx   #WELCOME
+        jsr   PrintString
+
+WELCOME
+        fcn   "Bienvenue dans le jeu !"  ; FCN = string ASCIIZ
+```
+
+### Variables
+
+```asm
+VIDEO           equ $A000
+RAM_A_OFFSET    equ $2000
+RAM_VIDEO_SIZE  equ 8000
+RAM_A           equ VIDEO+RAM_A_OFFSET   ; plan A (couleur)
+RAM_A_END       equ RAM_A+RAM_VIDEO_SIZE
+RAM_B           equ VIDEO                ; plan B (forme)
+RAM_B_END       equ RAM_B+RAM_VIDEO_SIZE
+
+LOCATE_X        fcb $00                  ; position X (caractère)
+LOCATE_Y        fcb $00                  ; position Y (ligne)
+
+COLOR           fcb $02                  ; couleur du texte
+RASTER_COLORS   fcb $01,$02,$03,$04,$05,$06,$07,$08   ; 8 couleurs (raster)
+```
+
+### Algorithme
+
+```asm
+PrintString
+        pshs  d,x,y,u
+        ldu   #USER_STACK               ; pile locale
+        
+        ; Calcul de l'adresse VRAM : Y_pixel = LOCATE_Y * 8, addr = (Y*40) + X
+        ldb   LOCATE_Y
+        lslb
+        lslb
+        lslb                            ; *8 lignes
+        lda   #40
+        mul                             ; *40 octets/ligne
+        tfr   d,y
+        lda   LOCATE_X
+        leay  a,y                       ; offset final
+        
+        ; Boucle sur chaque caractère
+!       ldb   ,x+                       ; lit caractère
+        beq   >                         ; null = fin
+        cmpb  #$20                      ; >= space ?
+        ; ... dessine le caractère via la table LETTER_<c> ...
+        bra   <
+!       puls  d,x,y,u,pc
+```
+
+### Définition des lettres
+
+```asm
+LETTER_<char>
+        fcb $00,$00                     ; ligne 0 : 2 octets (plan A + plan B)
+        fcb $01,$00                     ; ligne 1
+        ; ... 8 lignes au total ...
+```
+
+Format brut : 8 lignes × 2 octets (plan A + plan B). Total 16 octets/caractère.
+
+Exemples :
+```asm
+LETTER_<space>
+        fcb $00,$00 [...8 fois]         ; tout vide
+
+LETTER_!
+        fcb $00,$00
+        fcb $01,$00                     ; pixel
+        fcb $01,$00
+        fcb $01,$00
+        fcb $01,$00
+        fcb $00,$00
+        fcb $01,$00                     ; point
+        fcb $00,$00
+```
+
+Caractères supportés : ASCII de space ($20) jusqu'à 'Z' / 'z' + ponctuation. Le source `3x7-normal.txt` décrit la grille.
+
+Voir [references/printstring.md](references/printstring.md).
+
+---
+
+## Comparaison `DrawText` vs `PrintString`
+
+| Aspect | `DrawText` | `PrintString` |
+|--------|------------|---------------|
+| Font | 3×5 + variantes | 3×7 normale |
+| Stockage | Code compilé (routines) | Data brut (bitmap par lettre) |
+| Vitesse | Très rapide | Modéré |
+| Taille mémoire | Moyenne | Plus compact |
+| Variantes | Selected/Shaded/Disabled | Pas de variantes |
+| Position | `DrawText_pos` (auto-incr) | `LOCATE_X` / `LOCATE_Y` |
+| LF/FF/CR | Callbacks customisables | Pas de gestion |
+| Couleur | Implicite (via font) | `COLOR` variable |
+| Usage repo | sonic-2 | sonic-2, goldorak |
+
+### Quand utiliser quoi
+
+- **`DrawText`** :
+  - Menus avec items sélectionnés/désélectionnés
+  - HUD nécessitant plusieurs variantes (highlight, disabled)
+  - Performances critiques (50 chars / frame)
+
+- **`PrintString`** :
+  - Affichage simple (score, message)
+  - Faible variation de style
+  - Économie de mémoire
+
+---
+
+## Patterns d'usage
+
+### HUD score (DrawText)
+
+```asm
+DisplayScore
+        ldx   #fnt_3x5_shaded
+        ldy   #score_text
+        ldd   #$0000                    ; position $0000 = haut-gauche
+        std   DrawText_pos
+        jsr   DrawText
+        ; Conversion score → ASCII
+        lda   <globals.score
+        ldy   #score_buffer
+        jsr   HexToText
+        ldd   #$0010                    ; position après "Score: "
+        std   DrawText_pos
+        ldy   #score_buffer
+        jsr   DrawText
+        rts
+
+score_text fcn "Score: "                ; ASCIIZ
+score_buffer fcb 0,0,0,0
+```
+
+### Menu (DrawText avec variantes)
+
+```asm
+        ; Item 1 (sélectionné)
+        ldx   #fnt_3x5_selected
+        ldy   #menu_start
+        ldd   #$2020
+        std   DrawText_pos
+        jsr   DrawText
+
+        ; Item 2 (normal)
+        ldx   #fnt_3x5_shaded
+        ldy   #menu_options
+        ldd   #$2040
+        std   DrawText_pos
+        jsr   DrawText
+
+        ; Item 3 (désactivé)
+        ldx   #fnt_3x5_shaded_disabled
+        ldy   #menu_exit
+        ldd   #$2060
+        std   DrawText_pos
+        jsr   DrawText
+```
+
+### Message simple (PrintString)
+
+```asm
+        lda   #5
+        sta   LOCATE_X
+        lda   #10
+        sta   LOCATE_Y
+        ldx   #message
+        jsr   PrintString
+
+message fcn "GAME OVER"
+```
+
+---
+
+## Génération de fonts
+
+Le fichier `3x7-normal.txt` décrit chaque caractère sous forme ASCII art :
+
+```
+char ' '
+.........
+.........
+.........
+...
+
+char '!'
+.X.......
+.X.......
+.X.......
+.X.......
+.X.......
+.........
+.X.......
+.........
+```
+
+Un outil de génération (à identifier dans tools/) convertit ce txt en `fcb` asm.
+
+Pour `DrawText`, les caractères sont compilés en routines via le builder Java (cf. skill `build-pipeline`).
+
+---
+
+## Pitfalls
+
+### `DrawText`
+
+- **`DrawText_pos` non init** : caractères dessinés à la mauvaise adresse, possible crash hors VRAM
+- **Pointeur font invalide** : crash sur `jsr [d,x]` (saute à 0)
+- **Caractère < 32** non géré : callbacks `DrawText_0A/0C/0D` à `@rts` par défaut → ignore les LF/FF/CR
+- **Buffer texte non null-terminated** : DrawText continue de dessiner indéfiniment
+- **Caractère > 127** : index hors range de la font, lecture aléatoire
+
+### `PrintString`
+
+- **`LOCATE_X` > 39** : déborde sur la ligne suivante
+- **`LOCATE_Y` > 24** : hors écran (mode 200 lignes / 8 = 25 lignes max)
+- **`fcn` sans null final** : lecture infinie
+- **Caractère non défini** (e.g. accent) : crash ou dessine garbage
+- **`USER_STACK` chevauchant la pile système** : corruption
+
+### Communs
+
+- **Modifier la VRAM pendant l'affichage** : tearing visible
+- **Préférer écrire pendant VBL** ou via gfxlock pour éviter le tearing
+
+---
+
+## Références détaillées
+
+- [references/drawtext.md](references/drawtext.md) — `DrawText` complet : algorithme, callbacks LF/FF/CR customisation, variantes de font (3x5 + selected/shaded/disabled/shaded_selected), HexToText, intégration avec sprite engine, performance ~30 cycles/char
+- [references/printstring.md](references/printstring.md) — `PrintString` détails : algorithme, calcul adresse VRAM (LOCATE_X/Y → A000+offset), format LETTER_<c> (8 lignes × 2 plans), font 3x7-normal.txt source, USER_STACK pour appels imbriqués, RASTER_COLORS, génération via .txt

--- a/skills/thomson-to8-engine-graphics-pipeline/SKILL.md
+++ b/skills/thomson-to8-engine-graphics-pipeline/SKILL.md
@@ -1,0 +1,300 @@
+---
+name: thomson-to8-engine-graphics-pipeline
+description: "Décrit le pipeline graphique du Thomson TO8/TO9 game engine (Bento8/wide-dot) : double buffering avec gfxlock (gfxlock.status, gfxlock.bufferSwap.do/check/wait, _gfxlock.init/on/off/loop, backBuffer.id, frame.count, frameDrop.count_w), commutation des pages physiques 2/3 via map.CF74021.SYS2 et map.CF74021.DATA, swap demi-page écran via map.MC6846.PRC, sprite-packs (background-erase-pack, background-erase-ext-pack, overlay-pack) et leurs sous-modules (DrawSprites, EraseSprites, CheckSpritesRefresh, UnsetDisplayPriority, DisplaySprite, BgBufferAlloc, DeleteObject, BuildSprites), Display Priority Structure (DPS) avec priorités 1-8 (1=front, 8=back), file Lst_Priority_Unset_0/1, listes Tbl_Sub_Object_Erase/Draw, allocation des cellules d'effacement BBC (Background Backup Cells) à 64 octets de $4000 à $5FFF, Lst_FreeCell_0/1, rsv_render_flags bitfield (checkrefresh, erasesprite, displaysprite, outofrange, onscreen), glb_camera_x/y_offset, screen_left/top, InitDrawSprites, glb_force_sprite_refresh, choix entre coord playfield (render_playfieldcoord_mask) et coord écran, modes BM4 vs BM16 et leurs implications de rendu, intégration avec PalUpdateNow et l'IRQ raster. Utiliser pour comprendre la boucle de rendu, choisir entre les sprite-packs, débugger les artefacts de tearing/clipping, gérer les priorités d'affichage, optimiser le rendu en réduisant le nombre de sprites à redessiner, ajuster les paramètres de double buffering, ou comprendre la gestion des cellules de fond. Mots-clés : gfxlock, _gfxlock.init, _gfxlock.on, _gfxlock.off, _gfxlock.loop, gfxlock.bufferSwap.do, gfxlock.bufferSwap.check, gfxlock.bufferSwap.wait, gfxlock.bufferSwap.count, gfxlock.bufferSwap.status, gfxlock.backBuffer.id, gfxlock.backBuffer.status, gfxlock.frame.count, gfxlock.frame.lastCount, gfxlock.frameDrop.count, gfxlock.frameDrop.count_w, gfxlock.status, gfxlock.screenBorder.color, gfxlock.screenBorder.update, gfxlock.backProcess.on, gfxlock.backProcess.routine, gfxlock.backProcess.status, gfxlock.irq, map.CF74021.SYS2, map.CF74021.DATA, map.MC6846.PRC, $E7DD, page 2, page 3, InitDrawSprites, DrawSprites, EraseSprites, CheckSpritesRefresh, UnsetDisplayPriority, DisplaySprite, DisplaySprite2, DisplaySprite3, DisplaySprite_x, DisplaySprite_priority, BuildSprites, DeleteObject, BgBufferAlloc, Lst_FreeCellFirstEntry_0, Lst_FreeCell_0, nb_free_cells, cell_size, cell_start, cell_end, next_entry, entry_size, Background Backup Cells, BBC, Tbl_Sub_Object_Erase, Tbl_Sub_Object_Draw, Lst_Priority_Unset_0, DPS, Display Priority Structure, DPS_buffer_0, DPS_buffer_1, buf_Tbl_Priority_First_Entry, priority 1-8, render_flags, render_xmirror_mask, render_ymirror_mask, render_overlay_mask, render_playfieldcoord_mask, render_xloop_mask, render_todelete_mask, render_subobjects_mask, render_hide_mask, rsv_render_flags, rsv_render_checkrefresh_mask, rsv_render_erasesprite_mask, rsv_render_displaysprite_mask, rsv_render_outofrange_mask, rsv_render_onscreen_mask, glb_camera_x_offset, glb_camera_y_offset, glb_camera_x_pos, glb_camera_y_pos, glb_camera_x_pos_coarse, glb_camera_width, glb_camera_height, glb_camera_x_min_pos, glb_camera_y_max_pos, glb_force_sprite_refresh, glb_screen_location_1, glb_screen_location_2, glb_register_s, screen_left, screen_top, sprite-background-erase-pack, sprite-background-erase-ext-pack, sprite-overlay-pack, BM4, BM16, overlay mode, OverlayMode, double-buffer, dirty rendering, sprite priority, z-order."
+machines: [to8, to8d, to9, to9+]
+user-invocable: false
+---
+
+# Pipeline graphique — Thomson TO8/TO9 Game Engine
+
+Le pipeline graphique combine **double buffering** (deux pages vidéo qui s'échangent à chaque VBL), **gestion de priorités** (DPS), et **rendu différentiel** (« dirty rendering » — seuls les sprites modifiés sont redessinés/effacés). Le tout pour atteindre 50 Hz stables sur le matériel.
+
+Ce skill couvre : `gfxlock` (le double buffer), les trois **sprite-packs** disponibles, la **Display Priority Structure** (DPS), les **Background Backup Cells** (BBC) pour l'effacement, et la mécanique précise de la boucle de rendu.
+
+---
+
+## Vue d'ensemble — boucle de rendu
+
+```
+MainLoop
+   │
+   ├── RunObjects               ← exécute la logique des objets, ils peuvent
+   │                              modifier position/anim/priority/render_flags
+   │
+   ├── CheckSpritesRefresh      ← détermine quels sprites doivent être
+   │                              effacés/redessinés (dirty detection)
+   │
+   ├── _gfxlock.on              ← verrouille la phase rendu (attend si nécessaire
+   │                              que le swap précédent soit terminé)
+   │
+   ├── EraseSprites             ← efface les sprites du frame précédent en
+   │                              restaurant le background sauvegardé
+   │
+   ├── UnsetDisplayPriority     ← retire les sprites avec priority=0 de la DPS
+   │
+   ├── DrawSprites              ← dessine les sprites visibles dans l'ordre
+   │                              de priorité (back to front)
+   │
+   ├── _gfxlock.off             ← libère le verrou rendu
+   │
+   ├── _gfxlock.loop            ← gère le compteur de frames, bascule
+   │                              backBuffer.id pour la prochaine frame
+   │
+   └── bra   MainLoop
+
+UserIRQ (50 Hz, sur VBL)
+   │
+   ├── gfxlock.bufferSwap.check ← si rendu prêt, échange les pages visibles
+   │                              via map.CF74021.SYS2 = page 2 ou 3
+   │
+   ├── PalUpdateNow             ← applique les changements de palette
+   │
+   └── (audio frame)
+```
+
+---
+
+## `gfxlock` — double buffering
+
+`gfxlock` gère **deux pages physiques** comme buffers vidéo alternés :
+- Page 2 et page 3 (en zone donnée `$A000-$DFFF` via `map.CF74021.DATA = $E7E5`)
+- Une **visible** (lue par le hardware vidéo), une **écrite** (back-buffer)
+- À chaque VBL, si le rendu est complet, échange via `gfxlock.bufferSwap.do`
+
+### Variables d'état
+
+| Variable | Taille | Rôle |
+|----------|--------|------|
+| `gfxlock.status` | 1 | 1 = rendu en cours, 0 = inactif |
+| `gfxlock.bufferSwap.status` | 1 | -1 = swap effectué, 0 = pas swap |
+| `gfxlock.bufferSwap.count` | 2 | Compteur de swaps depuis init |
+| `gfxlock.backBuffer.id` | 1 | 0 ou 1 = index du back-buffer courant |
+| `gfxlock.backBuffer.status` | 1 | 0 ou -1 (flip/flop interne) |
+| `gfxlock.frame.count` | 2 | Frames 50 Hz écoulées depuis init |
+| `gfxlock.frame.lastCount` | 2 | Frame count au dernier render |
+| `gfxlock.frameDrop.count` | 1 | Nb de frames sautées depuis le dernier rendu |
+| `gfxlock.frameDrop.count_w` | 1 | (zero pad MSB) pour usage en 16-bit |
+
+### Macros principales
+
+```asm
+_gfxlock.init     → init de gfxlock (au boot, après IRQ on)
+_gfxlock.on       → verrou rendu (attend si swap pending)
+_gfxlock.off      → libère le verrou
+_gfxlock.loop     → bascule backBuffer.id, met à jour frameDrop.count
+_gfxlock.backProcess.on → enregistre une routine à appeler pendant le wait
+```
+
+### Routines (appelées par les macros)
+
+- `gfxlock.bufferSwap.do` : exécute le swap (écrit dans `map.CF74021.SYS2 = $E7E7`)
+- `gfxlock.bufferSwap.check` : appelée par UserIRQ, swap si rendu prêt
+- `gfxlock.bufferSwap.wait` : attente bloquante (avec back-process optionnel)
+- `gfxlock.screenBorder.update` : change la couleur de bordure (passe en `$E7DD`)
+
+Voir [references/gfxlock-internals.md](references/gfxlock-internals.md) pour le détail de chaque routine, le hardware mappé, et les patterns d'usage.
+
+---
+
+## Sprite-packs — choisir le bon
+
+Trois packs sont fournis dans `engine/graphics/sprite/` :
+
+### `sprite-background-erase-pack.asm`
+
+Pack par défaut. Inclut :
+- `DisplaySprite` (+ variantes `_x`, `_priority`)
+- `CheckSpritesRefresh`
+- `EraseSprites`
+- `UnsetDisplayPriority`
+- `DrawSprites`
+- `BgBufferAlloc`
+- `DeleteObject`
+
+Mode **backup/draw/erase** : chaque sprite mobile sauvegarde le fond avant de se dessiner, et le restaure quand il disparaît. Permet d'avoir des sprites animés sur un fond non-redessiné chaque frame (économie massive de cycles).
+
+Variants sprite requis : `NB0,NB1` + `XB0,XB1` si flip H, etc. (cf. skill `engine-new-game` references/object-properties.md).
+
+### `sprite-background-erase-ext-pack.asm`
+
+Identique mais remplace `DrawSprites.asm` par `DrawSpritesExtEnc.asm`. Permet les sprites avec **encodage RLE (`DMAP`) ou ZX0 (`DZX0`)** — utile pour les grands sprites ou backgrounds qui se déplacent.
+
+### `sprite-overlay-pack.asm`
+
+Pack legacy. Inclut :
+- `DisplaySprite` (overlay)
+- `BuildSprites`
+- `DeleteObject`
+
+Mode **overlay** : pas de sauvegarde de fond, les sprites sont fusionnés dans un buffer overlay. Plus simple, moins performant en cas de nombreux sprites mobiles. Nécessite `OverlayMode equ 1` en préambule, désactive certains bits de `render_flags` (`render_overlay_mask` n'existe pas).
+
+Voir [references/sprite-packs-comparison.md](references/sprite-packs-comparison.md) pour la comparaison détaillée et les critères de choix.
+
+---
+
+## DPS — Display Priority Structure
+
+Le rendu se fait dans l'ordre des **priorités** (8 niveaux). Chaque buffer (0 et 1) a sa propre DPS — c'est la liste **doublement chaînée ouverte** qui mémorise pour chaque niveau de priorité quels objets sont à afficher.
+
+```asm
+DPS_buffer_0+buf_Tbl_Priority_First_Entry+16    ; priorité 8 (back)
+DPS_buffer_0+buf_Tbl_Priority_First_Entry+14    ; priorité 7
+...
+DPS_buffer_0+buf_Tbl_Priority_First_Entry+2     ; priorité 1 (front)
+```
+
+Sémantique :
+- **priority 0** : non affiché
+- **priority 1** : front (dessiné en dernier, masque les autres)
+- **priority 2-7** : intermédiaires
+- **priority 8** : back (dessiné en premier)
+
+`DrawSprites` parcourt de **back vers front** (priorité 8 → 1), `EraseSprites` de **front vers back** (1 → 8) pour gérer la superposition correctement.
+
+Voir [references/display-priority-structure.md](references/display-priority-structure.md).
+
+---
+
+## BBC — Background Backup Cells
+
+Les sprites en mode `B` (backup) sauvegardent leur fond dans des **cellules** de 64 octets allouées dans la zone `$6000-...`.
+
+```asm
+nb_free_cells                 equ   128       ; nombre de cellules par buffer
+cell_size                     equ   64        ; taille d'une cellule (64 octets)
+cell_start_adr                equ   $6000     ; adresse de début des cellules
+```
+
+Chaque objet, lors de son affichage, demande N cellules via `BgBufferAlloc` (N = `(taille_sprite + 64 + 15) / 64`). Les cellules sont chaînées en liste libre.
+
+`BgBufferAlloc` retourne `Y = cell_end` ou 0 si pas de place.
+
+Voir [references/bbc-allocation.md](references/bbc-allocation.md) pour le détail de l'allocation, les listes de cellules libres, la fragmentation, et le sizing recommandé.
+
+---
+
+## `render_flags` et `rsv_render_flags`
+
+### `render_flags` (offset 2, modifiable par l'utilisateur)
+
+```
+Bit | Mask  | Symbole                       | Effet
+----|-------|-------------------------------|---------------------------------------------------
+0   | $01   | render_xmirror_mask           | Sprite miroir horizontal (combiné avec status_xflip)
+1   | $02   | render_ymirror_mask           | Sprite miroir vertical
+2   | $04   | render_overlay_mask           | Sprite sans backup de fond (mode B-E-pack)
+3   | $08   | render_playfieldcoord_mask    | x_pos/y_pos (1) vs x_pixel/y_pixel (0)
+4   | $10   | render_xloop_mask             | Loop X hors écran (en coord écran)
+5   | $20   | render_todelete_mask          | Marquer pour suppression engine
+6   | $40   | render_subobjects_mask        | Rendre les sous-objets
+7   | $80   | render_hide_mask              | Cacher (préserve priority/mapping)
+```
+
+### ⚠️ `render_overlay_mask` est OBLIGATOIRE pour les variants `D*` (Draw seul)
+
+Quand le sprite est compilé avec un variant `ND0`, `ND1`, `XD*`, `YD*`, `XYD*` (= sans backup du fond), `render_overlay_mask` doit **impérativement** être posé dans `render_flags,u` à l'`Init` de l'objet :
+
+```asm
+        lda   render_flags,u
+        ora   #render_overlay_mask
+        sta   render_flags,u
+```
+
+**Sinon** : l'engine traite le sprite comme un mode `B` (backup) et cherche le code d'erase compilé qui n'existe pas pour les variants D → **rien ne s'affiche**, aucun message d'erreur. Bug très piégeux.
+
+Pour les variants `NB*`/`XB*`/`YB*`/`XYB*` (mode Backup), `render_overlay_mask` doit **rester à 0** (sinon l'engine n'applique pas le mécanisme backup/restore et le sprite peut laisser des traces).
+
+### `rsv_render_flags` (zone réservée engine)
+
+```
+Bit | Mask  | Symbole                       | Effet
+----|-------|-------------------------------|---------------------------------------------------
+0   | $01   | rsv_render_checkrefresh_mask  | EraseSprite+DisplaySprite déjà traités cette frame
+1   | $02   | rsv_render_erasesprite_mask   | À effacer
+2   | $04   | rsv_render_displaysprite_mask | À redessiner
+3   | $08   | rsv_render_outofrange_mask    | Out of range (clipping)
+7   | $80   | rsv_render_onscreen_mask      | Rendu sur le dernier buffer
+```
+
+Ces flags sont gérés par `CheckSpritesRefresh`, `EraseSprites`, `DrawSprites`. Ne pas les toucher depuis le code utilisateur sauf cas spécifique.
+
+### Forcer le refresh global — `glb_force_sprite_refresh`
+
+```asm
+        lda   #1
+        sta   <glb_force_sprite_refresh
+```
+
+Force `CheckSpritesRefresh` à considérer tous les sprites comme dirty. Utile après un scroll ou un changement de fond.
+
+---
+
+## Camera — coordonnées playfield → écran
+
+```asm
+glb_camera_x_pos              ; position X de la caméra (playfield)
+glb_camera_y_pos              ; position Y de la caméra
+glb_camera_x_pos_coarse       ; ((x_pos - 64) / 64) * 64 — pour alignement
+glb_camera_x_offset           ; offset à appliquer (= screen_left initialement)
+glb_camera_y_offset           ; offset Y (= screen_top initialement)
+glb_camera_width              ; largeur du viewport
+glb_camera_height             ; hauteur du viewport
+glb_camera_x_min/max_pos      ; bornes de scroll
+```
+
+Conversion automatique faite par `DrawSprites` si le flag `render_playfieldcoord_mask` est mis :
+```
+x_pixel = x_pos - glb_camera_x_pos + glb_camera_x_offset
+y_pixel = y_pos - glb_camera_y_pos + glb_camera_y_offset
+```
+
+`InitDrawSprites` initialise `glb_camera_x_offset = screen_left` et `glb_camera_y_offset = screen_top`. À appeler au boot.
+
+---
+
+## Squelette d'une frame complète
+
+```asm
+MainLoop
+        jsr   RunObjects
+        jsr   CheckSpritesRefresh       ; détermine ce qui doit bouger
+        _gfxlock.on                     ; attend swap si nécessaire
+        jsr   EraseSprites              ; restaure les fonds
+        jsr   UnsetDisplayPriority      ; nettoie les sprites supprimés
+        jsr   DrawSprites               ; redessine dans l'ordre priorité
+        _gfxlock.off                    ; débloque pour le swap
+        _gfxlock.loop                   ; flip backBuffer.id, update frame count
+        bra   MainLoop
+
+UserIRQ
+        jsr   gfxlock.bufferSwap.check  ; swap si rendu prêt
+        jsr   PalUpdateNow              ; applique la palette
+        ; ... audio ...
+        rts
+```
+
+---
+
+## Pitfalls
+
+- **Sprite ND* sans `render_overlay_mask`** : sprite compilé en variant `ND*` (Draw seul, sans backup) sans le flag → **invisible**, échec silencieux. Toujours poser `render_overlay_mask` à l'init pour ces variants. Cf. section dédiée.
+- **Position d'un sprite calculée comme `taille/2`** : la règle est `ceil(taille/2)-1`. Sprite 160 px centré X = `x_pixel = 79`, pas 80. Si débordement et `render_xloop_mask` non posé → sprite non affiché.
+- **`InitDrawSprites` manqué** au boot : `BgBufferAlloc` opère sur des listes non-init → corruption mémoire ; `glb_camera_x/y_offset` à 0 → sprites mal placés
+- **`_gfxlock.init` après `IrqOn`** : status non initialisé, `gfxlock.bufferSwap.check` peut faire un swap involontaire
+- **Mélange sprite-pack overlay et background-erase** : signatures incompatibles, les sprites n'auront pas les bonnes variantes
+- **Trop de sprites en priorité identique** : pas de bug fonctionnel mais la DPS peut consommer beaucoup de RAM (chaque slot = 8 bytes)
+- **Variant `NB0` seulement (sans `NB1`)** : le sprite ne pourra bouger qu'aux positions paires X → saccade visuelle
+- **`render_playfieldcoord_mask` mis mais `x_pos`/`y_pos` non initialisés** : sprite affiché en (0,0) - camera, hors écran
+- **`UnsetDisplayPriority` oublié** : les sprites supprimés restent dans la DPS → corruption (ils dépointent vers de la mémoire libérée)
+- **Modifier `priority` directement sans passer par `DisplaySprite`** : la DPS n'est pas mise à jour, le sprite reste dans la mauvaise priorité
+
+---
+
+## Références détaillées
+
+- [references/gfxlock-internals.md](references/gfxlock-internals.md) — Mécanique précise de gfxlock : `bufferSwap.do`/`check`/`wait`, mappage hardware (`map.CF74021.SYS2`, `map.CF74021.DATA`, `map.MC6846.PRC`, `$E7E5`/`$E7E6`/`$E7E7`), variables d'état détaillées, sync VBL via IRQ, frame drop adaptatif, back-process pendant wait, intégration palette
+- [references/sprite-packs-comparison.md](references/sprite-packs-comparison.md) — `background-erase-pack` vs `-ext-pack` vs `overlay-pack` : sous-modules inclus, variants sprite requis, taille en RAM, performances comparées, conventions `OverlayMode equ 1`, conversion entre packs
+- [references/display-priority-structure.md](references/display-priority-structure.md) — DPS détaillée : `DPS_buffer_0/1`, `buf_Tbl_Priority_First_Entry`, chaînage open doubly linked list, `Lst_Priority_Unset_0/1`, sémantique des priorités 1-8, `DisplaySprite`/`_x`/`_priority` (variantes), `UnsetDisplayPriority` parcours
+- [references/bbc-allocation.md](references/bbc-allocation.md) — Background Backup Cells : `nb_free_cells = 128`, `cell_size = 64`, `cell_start_adr = $6000`, structure d'une cellule (`nb_cells`, `cell_start`, `cell_end`, `next_entry`), `Lst_FreeCellFirstEntry_0/1`, `Lst_FreeCell_0/1`, fragmentation, `BgBufferAlloc` algorithme, sizing
+- [references/dirty-rendering.md](references/dirty-rendering.md) — `CheckSpritesRefresh` algorithme : parcours `Tbl_Sub_Object_Erase`/`Draw` back to front, détection des changements via `rsv_render_flags`, `glb_force_sprite_refresh` pattern, gestion du double buffer (chaque buffer a son propre état refresh), interaction avec `EraseSprites` (front to back) et `DrawSprites` (back to front)
+- [references/coordinate-systems.md](references/coordinate-systems.md) — Coord playfield (`x_pos`/`y_pos` signed 16.8) vs coord écran (`x_pixel`/`y_pixel` 8-bit), conversion par caméra, `glb_camera_x_offset` / `glb_camera_y_offset` / `screen_left` / `screen_top`, flags `render_playfieldcoord_mask` et `render_xloop_mask`, dimensions du viewport, modes 160x200 (BM16) et 320x200 (BM4)

--- a/skills/thomson-to8-engine-graphics-pipeline/references/bbc-allocation.md
+++ b/skills/thomson-to8-engine-graphics-pipeline/references/bbc-allocation.md
@@ -1,0 +1,128 @@
+# Background Backup Cells (BBC)
+
+Quand un sprite mobile en mode `B` (Backup) est affiché, l'engine **sauvegarde le fond** qu'il va couvrir dans une « cellule » de 64 octets. À l'effacement, ce fond est restauré, laissant l'écran intact pour les autres sprites et le fond statique.
+
+## Constantes
+
+```asm
+nb_free_cells                 equ   128            ; nombre total de cellules
+cell_size                     equ   64             ; taille d'une cellule en octets
+cell_start_adr                equ   $6000          ; adresse de début des cellules
+```
+
+128 cellules × 64 octets = **8 Ko** par buffer, soit 16 Ko au total (deux buffers).
+
+L'adresse `$6000` (page système, non commutable) contient les cellules. La zone `$6000-$7FFF` est typiquement réservée à cet usage.
+
+## Structure d'une cellule
+
+```asm
+nb_cells                      equ   0              ; nb de cellules réservées (1 octet)
+cell_start                    equ   1              ; adresse de début (2 octets)
+cell_end                      equ   3              ; adresse de fin (2 octets)
+next_entry                    equ   5              ; chaînage vers cellule suivante (2 octets)
+entry_size                    equ   7              ; taille d'une entrée
+```
+
+Chaque cellule alloué contient :
+- `nb_cells` : combien de cellules contigues sont allouées (peut être 1, 2, ...)
+- `cell_start` / `cell_end` : intervalle d'adresses utilisé
+- `next_entry` : prochaine cellule dans la liste libre (0 = fin)
+
+## Liste libre
+
+```asm
+Lst_FreeCellFirstEntry_0      fdb   Lst_FreeCell_0 ; pointer vers la première cellule libre (buffer 0)
+Lst_FreeCell_0                fcb   nb_free_cells  ; init avec nb_free_cells cellules libres
+```
+
+Au démarrage, toutes les cellules sont libres et chaînées. `Lst_FreeCellFirstEntry_0` pointe vers le premier nœud.
+
+`Lst_FreeCellFirstEntry_1` / `Lst_FreeCell_1` : équivalent pour le buffer 1.
+
+## `BgBufferAlloc` — algorithme
+
+```asm
+BgBufferAlloc
+        ; input  : A = nb de cellules demandées
+        ; output : Y = cell_end ou 0 si pas de place
+        pshs  b,x
+        ldb   gfxlock.backBuffer.id
+        bne   BBA1
+BBA0
+        ldx   #Lst_FreeCellFirstEntry_0
+        ldy   Lst_FreeCellFirstEntry_0
+        bra   BBA_Next
+BBA1
+        ldx   #Lst_FreeCellFirstEntry_1
+        ldy   Lst_FreeCellFirstEntry_1
+BBA_Next
+        beq   BBA_rts                    ; fin de liste, pas trouvé
+        cmpa  nb_cells,y                 ; compare avec taille de la cellule libre
+        beq   BBA_FitCell                ; pile la taille → on prend tout
+        bls   BBA_DivideCell             ; cellule plus grande → on divise
+        leax  next_entry,y               ; sauve previous pour update
+        ldy   next_entry,y               ; passe à la suivante
+        bra   BBA_Next
+
+BBA_FitCell
+        ldd   next_entry,y
+        std   ,x                         ; relink previous → next (skip current)
+        ldd   cell_end,y                 ; retourne cell_end
+        ; ... efface la cellule réservée ...
+
+BBA_DivideCell
+        ; divise la cellule libre :
+        ; - alloue A cellules à partir du début
+        ; - reste = (taille - A) cellules au bout
+```
+
+## Comment l'objet utilise les cellules
+
+Pour chaque sprite affiché en mode `B`, l'engine :
+1. Détermine le nombre de cellules nécessaires : `nb_cell = (taille_sprite + 16 + 64 - 1) / 64` (le +16 pour IRQ + bckp registres, cf. `BuildDisk.java` lignes 506-509)
+2. Appelle `BgBufferAlloc` avec ce nombre
+3. Reçoit `Y = cell_end` (adresse où finir la sauvegarde du fond)
+4. Sauvegarde le fond avant de dessiner le sprite
+5. Au moment d'effacer (frame suivante), restaure depuis cell_start/cell_end
+6. Libère la cellule via `BgBufferRelease` (équivalent inverse de Alloc)
+
+## Sizing d'un sprite
+
+Le nombre de cellules dépend de la taille du sprite en pixels et de l'encodage :
+
+| Taille sprite | Octets compilés (estimés) | Nb cellules |
+|---------------|---------------------------|-------------|
+| 8×8 px | ~32 octets | 1 |
+| 16×16 px | ~128 octets | 3 (= ceil(128+16)/64) |
+| 24×24 px | ~280 octets | 5 |
+| 32×32 px | ~500 octets | 9 |
+| 16×32 px | ~256 octets | 5 |
+
+À retenir : un sprite de 16×16 typique consomme **3 cellules**. Avec 128 cellules par buffer, on peut afficher ~40 sprites de cette taille simultanément.
+
+`curSubSprite.nb_cell` est calculé par le builder Java au moment de la compilation du sprite (cf. `BuildDisk.java` ligne 506).
+
+## Fragmentation
+
+Les cellules sont allouées en **blocs contigus**. Si la liste libre se fragmente (alternance allocations/libérations), un grand sprite peut échouer même s'il y a assez de cellules au total.
+
+Mitigation :
+- Allouer les gros sprites en premier (au boot)
+- Limiter la rotation de sprites de tailles très variables
+- Augmenter `nb_free_cells` si la zone le permet
+
+## Pattern d'utilisation
+
+L'utilisateur **ne touche pas directement** à `BgBufferAlloc` — c'est l'engine (`DisplaySprite`) qui s'en charge. Ce qui compte :
+- Compiler les sprites avec variant `B` (`NB0,NB1`)
+- Dimensionner `nb_free_cells` si on a beaucoup de sprites
+- Surveiller la fragmentation en cas d'échecs visuels
+
+## Pitfalls
+
+- **Pas assez de cellules** : un sprite n'est pas affiché (silent fail). Détectable visuellement.
+- **Sprite avec variant `D` (Draw seul)** : ne consomme pas de cellule, mais ne sauvegarde pas le fond → laisse un trou à l'effacement
+- **Sprite trop gros** : un sprite >128 cellules est impossible à allouer (dépasse la zone). À découper en sous-sprites.
+- **Buffer 0 et 1 désynchronisés** : si un sprite est dans `Lst_FreeCell_0` mais pas `Lst_FreeCell_1`, il y a un bug d'allocation. Très rare.
+- **Modifier `cell_start_adr`** sans recompiler tout l'engine : risque de collision avec d'autres zones mémoire.

--- a/skills/thomson-to8-engine-graphics-pipeline/references/coordinate-systems.md
+++ b/skills/thomson-to8-engine-graphics-pipeline/references/coordinate-systems.md
@@ -1,0 +1,198 @@
+# Systèmes de coordonnées — playfield vs écran
+
+L'engine gère **deux systèmes de coordonnées** pour les sprites :
+
+| Système | Champs OST | Taille | Usage |
+|---------|------------|--------|-------|
+| Playfield | `x_pos` (16.8) + `y_pos` (16.8) | 3 octets chacun | Monde scrollé (jeu), positions absolues |
+| Écran | `x_pixel` + `y_pixel` (= `xy_pixel`) | 1 octet chacun | HUD, UI, sprites fixes |
+
+Le choix est fait via `render_flags` :
+
+```asm
+        lda   render_flags,u
+        ora   #render_playfieldcoord_mask   ; bit 3 = playfield
+        sta   render_flags,u
+```
+
+Si le bit 3 (`render_playfieldcoord_mask`) est :
+- **1** : le moteur utilise `x_pos`/`y_pos` et applique la conversion via caméra
+- **0** : le moteur utilise `x_pixel`/`y_pixel` directement
+
+## Coord playfield — fixed-point 16.8
+
+```
+x_pos = 2 octets (partie entière signée -32768..+32767)
+x_sub = 1 octet (partie fractionnaire 0..255 = 0..0.996)
+```
+
+Permet :
+- Une **map** allant de -32768 à +32767 pixels
+- Une précision **sub-pixel** (0.0039 pixel par incrément de x_sub)
+- Des **vitesses précises** : `x_vel = $0080` = 0.5 pixel/frame en moyenne
+
+`x_pos` et `x_sub` **doivent être contigus** en mémoire (offset 18-20) pour que `addd x_pos+1,u` mette à jour `x_sub+x_pos.low` ensemble.
+
+## Coord écran — 8 bits
+
+```
+x_pixel = 1 octet (position X à l'écran, 0..255 mais 0..159 visible en mode 160 colonnes)
+y_pixel = 1 octet (position Y à l'écran, 0..199 visible)
+```
+
+Plus simple, plus rapide, mais limité à 256×256 pixels. Pas de sub-pixel.
+
+### ⚠️ Règle de positionnement du centre d'un sprite (mode CENTER)
+
+Le `x_pixel`/`y_pixel` pointe le **centre interne du sprite**, mais ce centre n'est PAS `taille/2` — c'est `ceil(taille/2)-1` :
+
+```
+center_internal_offset = ceil(sprite_size / 2) - 1
+```
+
+Pour les tailles paires, c'est un pixel **avant** le milieu mathématique :
+
+| Taille sprite | center_internal_offset | Pour `x_pixel` du centre à 80 → top-left du sprite à |
+|---------------|------------------------|------------------------------------------------------|
+| 8 px | 3 | 80 - 3 = 77 |
+| 16 px | 7 | 80 - 7 = 73 |
+| 32 px | 15 | 80 - 15 = 65 |
+| 100 px | 49 | 80 - 49 = 31 |
+| 160 px | 79 | 80 - 79 = 1 |
+
+**Pour qu'un sprite 160 px occupe exactement les 160 colonnes (X=0..159)** : le top-left doit être à x=0, donc `x_pixel = 79` (et **pas 80**).
+
+**Risque si on se trompe d'un pixel** : le sprite peut déborder de la zone visible. Et si `render_xloop_mask` n'est PAS activé, l'engine peut **ne pas dessiner le sprite du tout** (clipping out total) → le sprite disparaît silencieusement, sans message d'erreur. Bug très piégeux.
+
+**Sécurité** : pour les sprites qui doivent pouvoir déborder (typique des fonds en perspective), poser explicitement `render_xloop_mask` à l'init pour permettre le wrap horizontal.
+
+## Caméra — conversion automatique
+
+Quand `render_playfieldcoord_mask` est mis, le moteur calcule à l'affichage :
+
+```
+x_pixel_effective = x_pos - glb_camera_x_pos + glb_camera_x_offset
+y_pixel_effective = y_pos - glb_camera_y_pos + glb_camera_y_offset
+```
+
+Variables globales caméra :
+```asm
+glb_camera_x_pos               ; position X caméra dans le playfield (s16.8)
+glb_camera_y_pos               ; position Y caméra (s16.8)
+glb_camera_x_pos_coarse        ; ((x_pos - 64) / 64) * 64 — pour alignement scroll
+glb_camera_x_offset            ; offset à appliquer (init = screen_left)
+glb_camera_y_offset            ; offset Y (init = screen_top)
+glb_camera_width               ; largeur du viewport visible
+glb_camera_height              ; hauteur
+glb_camera_x_min_pos           ; borne min de scroll caméra
+glb_camera_x_max_pos           ; borne max
+glb_camera_y_min_pos           ; idem Y
+glb_camera_y_max_pos
+```
+
+## `InitDrawSprites` — initialisation caméra
+
+```asm
+InitDrawSprites
+        ldd   #screen_left
+        std   glb_camera_x_offset
+        ldd   #screen_top
+        std   glb_camera_y_offset
+        rts
+```
+
+Initialise `glb_camera_x/y_offset` aux constantes `screen_left` / `screen_top` (définies dans `engine/constants.asm` selon la résolution choisie).
+
+**À appeler au boot** du game-mode, sinon les sprites en mode playfield sont mal placés.
+
+## `screen_left` / `screen_top`
+
+Définis dans `engine/constants.asm`. Valeurs typiques pour le mode 160×200 :
+- `screen_left = 48` (32+16, alignement wide-dot)
+- `screen_top = 28` ou 14 selon mode
+
+Ces constantes représentent le **décalage de la zone visible** par rapport au coin haut-gauche du buffer vidéo (qui inclut des bordures non visibles).
+
+## Pattern de choix
+
+### HUD / UI (coord écran)
+
+```asm
+Init
+        ; ... 
+        ldd   #$10A0                    ; x_pixel = $10, y_pixel = $A0
+        std   xy_pixel,u
+        ; render_playfieldcoord_mask non mis → utilise xy_pixel
+        inc   routine,u
+```
+
+Les éléments HUD ne bougent jamais avec la caméra. Coord écran direct.
+
+### Sprite dans le monde (coord playfield)
+
+```asm
+Init
+        ; ...
+        ldd   #200                      ; x_pos = 200 dans le playfield
+        std   x_pos,u
+        ldd   #100
+        std   y_pos,u
+        clr   x_sub,u                   ; sub-pixel 0
+        clr   y_sub,u
+        lda   render_flags,u
+        ora   #render_playfieldcoord_mask
+        sta   render_flags,u
+        inc   routine,u
+```
+
+Le sprite suit la caméra : si la caméra se déplace de 50 px à droite, le sprite reste « à sa place dans le monde » et apparaît 50 px plus à gauche à l'écran.
+
+## `render_xloop_mask`
+
+Bit 4 : **loop horizontal** quand le sprite est hors écran (en coord écran seulement).
+
+Permet à un sprite décor (étoile, particule de fond) de réapparaître de l'autre côté de l'écran quand il en sort. Utilisé pour fonds défilants infinis (starfield).
+
+```asm
+        ora   #render_xloop_mask
+```
+
+Ne fonctionne **qu'en coord écran** (pas playfield).
+
+## Modes graphiques et résolution
+
+Le TO8 a plusieurs modes :
+
+| Mode | Résolution | Couleurs | Mémoire VRAM |
+|------|------------|----------|--------------|
+| BM4 | 320×200 | 4 couleurs | 8 Ko + 8 Ko (couleur) = 16 Ko |
+| BM16 | 160×200 | 16 couleurs | 16 Ko |
+| 80 col | 80×200 texte | 8 couleurs | 16 Ko |
+
+L'engine utilise par défaut **BM16** (160×200, 16 couleurs). Les constantes `screen_left`/`screen_top` et la conversion caméra sont calibrées pour ce mode.
+
+Pour un autre mode, il faudrait recalibrer (pas standard dans le repo).
+
+## Conversion manuelle (rare)
+
+Si on veut convertir manuellement playfield → écran sans utiliser le bit `render_playfieldcoord_mask` :
+
+```asm
+        ldd   x_pos,u                   ; lire playfield
+        subd  glb_camera_x_pos
+        addd  glb_camera_x_offset       ; pas standard, plutôt ld + add direct
+        ; D = position écran
+        stb   x_pixel,u                 ; (low 8 bits)
+```
+
+Mais c'est rare ; le moteur le fait automatiquement.
+
+## Pitfalls
+
+- **Position calculée comme `taille/2`** au lieu de `ceil(taille/2)-1` : décalage d'un pixel, possible débordement, sprite invisible si `render_xloop_mask` absent. C'est l'erreur la plus piégeuse car silencieuse.
+- **Modifier `x_pos` sans `x_sub`** : la partie haute change sans la basse → l'objet « saute »
+- **`render_playfieldcoord_mask` mis mais `x_pos`/`y_pos` non initialisés** : sprite à (0,0) - camera → hors écran
+- **`InitDrawSprites` oublié** : `glb_camera_x/y_offset = 0` → sprites en haut-gauche du buffer (souvent invisibles à cause de la zone non-visible)
+- **Confondre `x_pixel` et `x_pos`** : `x_pixel,u` (offset 24) ≠ `x_pos,u` (offset 18). Toujours vérifier le mode (coord écran vs playfield)
+- **`x_pixel` > 159 en mode 160 colonnes** : sprite hors écran (clipped). `x_pixel` peut être 160-255 si `render_xloop_mask`, sinon caché
+- **`y_pixel` > 199** : sprite sous l'écran, clipped

--- a/skills/thomson-to8-engine-graphics-pipeline/references/dirty-rendering.md
+++ b/skills/thomson-to8-engine-graphics-pipeline/references/dirty-rendering.md
@@ -1,0 +1,174 @@
+# Dirty rendering — `CheckSpritesRefresh`
+
+L'engine optimise le rendu en ne redessinant que les sprites qui ont changé (« dirty rendering »). `CheckSpritesRefresh` est appelée chaque frame entre `RunObjects` et `EraseSprites` pour déterminer ce qui doit bouger.
+
+## Pourquoi ce mécanisme ?
+
+Un sprite immobile **n'a pas besoin** d'être effacé/redessiné chaque frame — c'est gaspillage. Le moteur détecte si position/animation/render_flags ont changé depuis la frame précédente, et marque seulement les sprites dirty.
+
+## `rsv_render_flags` — les flags engine
+
+```
+Bit | Mask  | Symbole                       | Sémantique
+----|-------|-------------------------------|---------------------------------------------
+0   | $01   | rsv_render_checkrefresh_mask  | déjà traité par CheckSpritesRefresh cette frame
+1   | $02   | rsv_render_erasesprite_mask   | doit être effacé
+2   | $04   | rsv_render_displaysprite_mask | doit être redessiné
+3   | $08   | rsv_render_outofrange_mask    | hors écran (cull)
+7   | $80   | rsv_render_onscreen_mask      | a été rendu sur le dernier buffer
+```
+
+Ces flags sont gérés par l'engine, dans la zone `rsv_*` (hors `ext_variables`).
+
+## Algorithme — `CheckSpritesRefresh`
+
+```asm
+CheckSpritesRefresh
+        ; Init buffers
+        ldd   #Tbl_Sub_Object_Erase
+        std   cur_ptr_sub_obj_erase
+        ldd   #Tbl_Sub_Object_Draw
+        std   cur_ptr_sub_obj_draw
+        
+        ; Choisir le buffer (0 ou 1)
+        lda   gfxlock.backBuffer.id
+        bne   CSR_SetBuffer1
+        
+CSR_SetBuffer0
+        lda   #rsv_buffer_0              ; offset pour rsv_*
+        sta   CSR_ProcessEachPriorityLevel+2
+        
+CSR_P8B0
+        ; Parcourir priorité 8 (back)
+        ldu   DPS_buffer_0+buf_Tbl_Priority_First_Entry+16
+        beq   CSR_P7B0
+        lda   #$08
+        sta   cur_priority
+        jsr   CSR_ProcessEachPriorityLevel
+CSR_P7B0
+        ; ... priorité 7 ... 6 ... 5 ... 4 ... 3 ... 2 ... 1 ...
+```
+
+Parcours **back to front** (priorité 8 → 1), construisant deux listes :
+- `Tbl_Sub_Object_Erase` : sprites à effacer (avaient été dessinés au tour précédent)
+- `Tbl_Sub_Object_Draw` : sprites à redessiner (encore visibles, ou nouveaux)
+
+Pour chaque sprite, la routine compare son état courant (`position`, `anim`, `render_flags`) avec son état au tour précédent (mémorisé dans `rsv_*`).
+
+## Décision dirty/clean
+
+Un sprite est marqué **dirty** si au moins une de ces conditions est vraie :
+- Sa position (`x_pos`/`y_pos` ou `x_pixel`/`y_pixel`) a changé
+- Son animation (`anim`, `image_set`) a changé
+- Ses `render_flags` ont changé (e.g. flip Y activé)
+- Son `status_flags` a changé
+- `glb_force_sprite_refresh = 1` (force refresh global)
+
+Si dirty : `rsv_render_erasesprite_mask` ET `rsv_render_displaysprite_mask` sont mis.
+Si clean : aucun des deux, le sprite n'est pas dans `Tbl_Sub_Object_Erase/Draw`.
+
+## `glb_force_sprite_refresh`
+
+Variable globale (dans la zone `glb_*`) qui force le refresh complet :
+
+```asm
+        lda   #1
+        sta   <glb_force_sprite_refresh
+```
+
+Utile après :
+- Un scroll (toute l'image bouge, tous les sprites doivent être redessinés)
+- Un changement de palette (les couleurs ont changé)
+- Une transition d'act ou de niveau
+
+`CheckSpritesRefresh` lit ce flag et marque tous les sprites comme dirty si à 1. Le flag est ensuite remis à 0 par le moteur.
+
+## Gestion du double buffer
+
+Chaque buffer (0 et 1) a son propre état dirty :
+- `rsv_buffer_0` : sprite a été rendu sur le buffer 0 au dernier tour qui utilisait 0
+- `rsv_buffer_1` : idem buffer 1
+
+Sur deux frames consécutifs, un sprite peut être :
+- Tour N : rendu sur buffer 0
+- Tour N+1 : il faut le rendre sur buffer 1 (le précédent rendu était sur buffer 1 il y a 2 frames)
+
+Donc même un sprite « immobile » doit être redessiné **alternativement** sur les deux buffers tant qu'il existe — car les buffers ne sont jamais nettoyés entre frames (sauf via Erase).
+
+C'est pour ça que `rsv_render_onscreen_mask` est dédoublé via `rsv_buffer_0`/`rsv_buffer_1`. Le moteur sait sur quel buffer le sprite a été rendu en dernier.
+
+## `Tbl_Sub_Object_Erase` / `Tbl_Sub_Object_Draw`
+
+Construites pendant `CheckSpritesRefresh`, consommées par `EraseSprites` et `DrawSprites` :
+
+```asm
+Tbl_Sub_Object_Erase   fill  0,nb_graphical_objects*2   ; entrées back to front
+Tbl_Sub_Object_Draw    fill  0,nb_graphical_objects*2   ; entrées back to front
+```
+
+Chaque entrée = 2 octets (pointeur OST).
+
+`EraseSprites` parcourt `Tbl_Sub_Object_Erase` **front to back** (l'inverse de Draw) pour gérer le z-order à l'effacement correctement.
+
+## Variables Direct Page
+
+```asm
+cur_priority                  equ dp_engine             ; 1 byte
+cur_ptr_sub_obj_erase         equ dp_engine+1           ; 2 bytes
+cur_ptr_sub_obj_draw          equ dp_engine+3           ; 2 bytes
+```
+
+Utilisées pendant `CheckSpritesRefresh` pour le bookkeeping. Allouées dans `dp_engine` (zone réservée moteur, $9F00 + offset).
+
+## Coût
+
+`CheckSpritesRefresh` est en O(N) où N = `nb_graphical_objects`. Pour N=64 (limite hard) c'est ~500-1000 cycles selon la complexité des comparaisons. Négligeable comparé à `DrawSprites` qui peut prendre des milliers de cycles.
+
+## Pattern d'usage
+
+```asm
+MainLoop
+        jsr   RunObjects                ; les objets bougent
+        jsr   CheckSpritesRefresh       ; détermine ce qui a changé
+        _gfxlock.on
+        jsr   EraseSprites              ; restaure les fonds des sprites dirty
+        jsr   UnsetDisplayPriority      ; supprime les sprites avec priority=0
+        jsr   DrawSprites               ; redessine les sprites dirty
+        _gfxlock.off
+        _gfxlock.loop
+        bra   MainLoop
+```
+
+## Cas spéciaux
+
+### Sprite qui ne bouge jamais
+
+Si un sprite est strictement immobile (animation non plus), `CheckSpritesRefresh` ne le marque dirty **qu'une fois sur deux** (alternance des buffers). Si on veut qu'il soit redessiné chaque frame, il faut soit le marquer manuellement, soit utiliser `glb_force_sprite_refresh = 1`.
+
+### Sprite teint dynamiquement (palette cycling)
+
+Si on change la palette sans toucher au sprite, le sprite **n'est pas marqué dirty** automatiquement. Mais visuellement les couleurs changent (car la palette est partagée). Pas besoin de refresh sprite, donc OK.
+
+Si on change le contenu d'un sprite (cas rare), il faut forcer le refresh :
+```asm
+        ; Modifier le sprite directement en RAM
+        ; ... 
+        lda   render_flags,u
+        ora   #render_subobjects_mask   ; ou autre flag de change détecté
+        sta   render_flags,u
+        ; (à la prochaine frame, CheckSpritesRefresh détectera le changement de render_flags)
+```
+
+ou plus simple :
+```asm
+        lda   #1
+        sta   <glb_force_sprite_refresh ; force tous les sprites
+```
+
+## Pitfalls
+
+- **Compter sur `rsv_*`** depuis le code utilisateur : ces flags sont **internes** au moteur, ne pas les modifier
+- **Modifier `cur_priority` / `cur_ptr_sub_obj_*`** : c'est de la mémoire engine, corrompt le rendu
+- **Lire `glb_force_sprite_refresh`** après l'avoir mis à 1 : il sera resetté à 0 par le moteur après `CheckSpritesRefresh`
+- **Modifier `priority`** sans redéclencher un cycle complet de refresh : la DPS sera désynchronisée
+- **Oublier `CheckSpritesRefresh`** dans MainLoop : aucun sprite ne sera dirty détecté, écran figé

--- a/skills/thomson-to8-engine-graphics-pipeline/references/display-priority-structure.md
+++ b/skills/thomson-to8-engine-graphics-pipeline/references/display-priority-structure.md
@@ -1,0 +1,210 @@
+# DPS — Display Priority Structure
+
+La DPS est la structure de données qui mémorise, pour chaque niveau de priorité (1 à 8), la **liste des objets à afficher**. Chaque buffer (0 et 1 du double buffering) a sa propre DPS.
+
+## Structure
+
+```asm
+DPS_buffer_0+buf_Tbl_Priority_First_Entry+0     ; (réservé)
+DPS_buffer_0+buf_Tbl_Priority_First_Entry+2     ; priorité 1 (front)
+DPS_buffer_0+buf_Tbl_Priority_First_Entry+4     ; priorité 2
+DPS_buffer_0+buf_Tbl_Priority_First_Entry+6     ; priorité 3
+DPS_buffer_0+buf_Tbl_Priority_First_Entry+8     ; priorité 4
+DPS_buffer_0+buf_Tbl_Priority_First_Entry+10    ; priorité 5
+DPS_buffer_0+buf_Tbl_Priority_First_Entry+12    ; priorité 6
+DPS_buffer_0+buf_Tbl_Priority_First_Entry+14    ; priorité 7
+DPS_buffer_0+buf_Tbl_Priority_First_Entry+16    ; priorité 8 (back)
+```
+
+Chaque entrée stocke un pointeur (2 octets) vers le **premier objet** de cette priorité. Les objets sont chaînés via une **liste doublement chaînée ouverte** dans des `rsv_*` fields de l'OST.
+
+## Sémantique des priorités
+
+| Priority | Nom | Ordre de rendu |
+|----------|-----|----------------|
+| 0 | (réservé, non affiché) | — |
+| 1 | Front | Dessiné en **dernier** (par-dessus tout) |
+| 2 | | |
+| 3 | | |
+| 4 | (milieu typique) | |
+| 5 | | |
+| 6 | | |
+| 7 | | |
+| 8 | Back | Dessiné en **premier** (en arrière-plan) |
+
+## Algorithme de rendu — `DrawSprites`
+
+Parcours **back to front** (priorité 8 → 1) pour la superposition correcte :
+
+```asm
+DrawSprites
+        lda   gfxlock.backBuffer.id
+        bne   DRS_P8B1
+        
+DRS_P8B0
+        ldx   DPS_buffer_0+buf_Tbl_Priority_First_Entry+16  ; prio 8
+        beq   DRS_P7B0
+        jsr   DRS_ProcessEachPriorityLevelB0
+DRS_P7B0
+        ldx   DPS_buffer_0+buf_Tbl_Priority_First_Entry+14  ; prio 7
+        beq   DRS_P6B0
+        jsr   DRS_ProcessEachPriorityLevelB0
+        ; ... (priorités 6, 5, 4, 3, 2, 1) ...
+```
+
+Pour chaque priorité, parcourir la liste chaînée des objets et appeler la routine de draw spécifique au sprite.
+
+## Algorithme d'effacement — `EraseSprites`
+
+Parcours **front to back** (priorité 1 → 8) — l'inverse de DrawSprites — pour restaurer les fonds dans le bon ordre :
+
+```
+EraseSprites :
+    Pour priorité 1 (front), 2, 3, ..., 8 (back) :
+        Pour chaque objet de cette priorité avec flag erase :
+            Restaurer le fond depuis sa cellule BBC
+            Libérer la cellule
+```
+
+## `DisplaySprite` — inscription dans la DPS
+
+Quand un objet est prêt à être affiché (typiquement en fin de `Main`), on l'inscrit dans la DPS via :
+
+```asm
+        jmp   DisplaySprite              ; U = OST, lit priority,u
+```
+
+Variantes :
+```asm
+        jmp   DisplaySprite_x            ; X = OST (préserve U)
+        jmp   DisplaySprite2             ; (alias de DisplaySprite_x)
+
+        jmp   DisplaySprite_priority     ; U = OST, A = priorité forcée
+        jmp   DisplaySprite3             ; (alias de _priority)
+```
+
+L'objet est inséré dans la liste de la priorité indiquée par `priority,u` (ou par A si `_priority`).
+
+## `UnsetDisplayPriority` — supprimer les sprites de la DPS
+
+Appelée chaque frame entre `EraseSprites` et `DrawSprites` :
+
+```asm
+UnsetDisplayPriority
+        lda   gfxlock.backBuffer.id
+        bne   UDP_B1
+UDP_B0
+        ldx   #Lst_Priority_Unset_0+2
+
+UDP_CheckEndB0
+        cmpx  Lst_Priority_Unset_0       ; end of priority unset list
+        ; ... délier les objets de la DPS ...
+```
+
+Parcourt `Lst_Priority_Unset_0/1` (liste des objets à délier) et les retire de la DPS. Cela arrive quand :
+- `priority,u` a été mis à 0 par le code utilisateur
+- L'objet a été marqué via `render_todelete_mask`
+
+## Listes par priorité — chaînage interne
+
+Chaque objet dans la DPS a (dans sa zone `rsv_*`) :
+- Un pointeur vers l'**objet précédent** dans sa priorité
+- Un pointeur vers l'**objet suivant**
+
+C'est une liste doublement chaînée **par priorité** (pas globale comme la run-list). L'objet peut donc être présent dans la DPS d'un buffer mais pas dans l'autre (cas où il vient d'apparaître et n'a été inscrit que dans la DPS du back-buffer).
+
+## Buffer 0 vs Buffer 1
+
+Le double buffering oblige à maintenir **deux DPS séparées** :
+- `DPS_buffer_0` : sprites à afficher quand backBuffer.id = 0
+- `DPS_buffer_1` : sprites à afficher quand backBuffer.id = 1
+
+À chaque frame, on alterne. Mais un sprite mobile doit être présent dans les **deux** DPS pour être affiché en continu — c'est `CheckSpritesRefresh` qui synchronise ça via les `rsv_*` flags.
+
+## `Tbl_Sub_Object_Erase` / `Tbl_Sub_Object_Draw`
+
+Listes auxiliaires utilisées par `CheckSpritesRefresh` :
+
+```asm
+Tbl_Sub_Object_Erase   fill  0,nb_graphical_objects*2  ; à effacer cette frame
+Tbl_Sub_Object_Draw    fill  0,nb_graphical_objects*2  ; à redessiner cette frame
+```
+
+Construites pendant `CheckSpritesRefresh` et consommées par `EraseSprites` / `DrawSprites`.
+
+## `cur_priority` et pointeurs DP
+
+Pendant `CheckSpritesRefresh`, des variables DP sont utilisées :
+
+```asm
+cur_priority                  equ dp_engine          ; priorité courante (1 octet)
+cur_ptr_sub_obj_erase         equ dp_engine+1        ; pointeur courant erase (2 octets)
+cur_ptr_sub_obj_draw          equ dp_engine+3        ; pointeur courant draw (2 octets)
+```
+
+Ces emplacements dans `dp_engine` sont **partagés** entre tous les modules engine. Ne pas y écrire depuis le code utilisateur.
+
+## Pattern d'utilisation
+
+### Inscription d'un objet
+
+```asm
+Init
+        ldb   #4                        ; priority 4 (milieu)
+        stb   priority,u
+        ; ...
+        inc   routine,u
+        rts
+
+Main
+        ; ... logique frame ...
+        jsr   AnimateSprite
+        jmp   DisplaySprite              ; inscrit dans la DPS (lit priority,u)
+```
+
+### Changement de priorité
+
+```asm
+        lda   #2                        ; passe en front
+        sta   priority,u
+        ; au prochain DisplaySprite, l'objet sera inscrit dans la liste prio 2
+```
+
+Si l'objet était déjà dans une autre priorité, l'engine le délie automatiquement avant de l'inscrire dans la nouvelle.
+
+### Cacher temporairement
+
+```asm
+        lda   render_flags,u
+        ora   #render_hide_mask         ; cache sans toucher à priority
+        sta   render_flags,u
+```
+
+Le sprite est dans la DPS mais ne sera pas dessiné. Cela évite de devoir re-inscrire au moment du show.
+
+### Suppression complète
+
+```asm
+        clr   priority,u                ; priority = 0
+        ; à la prochaine frame, UnsetDisplayPriority retirera l'objet de la DPS
+```
+
+ou via `render_todelete_mask` (qui aussi libère le slot et nettoie le sprite).
+
+## Dimensionnement
+
+`nb_graphical_objects` (déclaré dans `ram-data.asm`) détermine la taille de `Tbl_Sub_Object_Erase` et `Tbl_Sub_Object_Draw` :
+
+```asm
+nb_graphical_objects              equ 12              ; max 64
+```
+
+Limite hard : 64 (cf. constantes engine). En pratique, viser le **nombre max de sprites visibles simultanément**, pas le nombre total d'objets dans le pool (un objet sans sprite ne consomme pas de slot graphique).
+
+## Pitfalls
+
+- **`priority = 0`** dans l'init : l'objet existe mais n'est jamais affiché. Pas un bug si c'est voulu (objets purement logiques).
+- **Modifier `priority` sans rappeler `DisplaySprite`** : la DPS n'est pas mise à jour, le sprite reste dans la mauvaise priorité.
+- **Trop de sprites en même priorité** : ralentissement (parcours de liste long).
+- **`nb_graphical_objects > 64`** : crash au build (overflow des structures internes).
+- **Inscrire l'objet sans incrémenter `priority`** : si `priority,u = 0` à l'appel de `DisplaySprite`, l'objet est silencieusement non-inscrit.

--- a/skills/thomson-to8-engine-graphics-pipeline/references/gfxlock-internals.md
+++ b/skills/thomson-to8-engine-graphics-pipeline/references/gfxlock-internals.md
@@ -1,0 +1,269 @@
+# `gfxlock` — internals du double buffering
+
+`gfxlock` (engine/graphics/buffer/gfxlock.asm et gfxlock.macro.asm) gère le **double buffering vidéo** : deux pages physiques alternent, l'une affichée par le hardware vidéo et l'autre en cours d'écriture par la `MainLoop`. L'échange se fait pendant le **VBL** (Vertical Blank Interval) pour éviter le tearing.
+
+## Hardware mappé
+
+Le TO8 utilise deux registres hardware pour la sélection des pages :
+
+| Registre | Adresse | Rôle |
+|----------|---------|------|
+| `map.CF74021.SYS2` | `$E7E7` | Sélection du buffer **visible** (lu par hardware vidéo) |
+| `map.CF74021.DATA` | `$E7E5` | Sélection de la page en zone **donnée** (`$A000-$DFFF`) |
+| `map.CF74021.SYS1` | `$E7E6` | Sélection page en zone cartouche (utilisé par BankSwitch) |
+| `map.MC6846.PRC` | `$E7C3` | Bit de forme (swap demi-page écran $4000-$5FFF) |
+| `$E7DD` | (idem) | Couleur de bordure |
+
+Pour le double buffering :
+- `map.CF74021.SYS2 = $80 + (page << 6)` : choisit la page visible (2 ou 3) + couleur de bordure dans le bit 0-3
+- `map.CF74021.DATA` : sélectionne la page en `$A000-$DFFF` pour permettre d'y dessiner
+
+## Variables d'état complètes
+
+```asm
+gfxlock.status             fcb   0     ; 1 = rendu en cours, 0 = inactif
+gfxlock.bufferSwap.status  fcb   0     ; -1 = swap fait, 0 = pas swap
+gfxlock.backProcess.status fcb   0     ; 1 = back process actif pendant wait
+
+gfxlock.bufferSwap.count   fdb   0     ; compteur de swaps depuis init
+gfxlock.backBuffer.id      fcb   0     ; 0 ou 1, index back-buffer courant
+gfxlock.backBuffer.status  fcb   0     ; 0 ou -1, flip/flop interne
+
+gfxlock.frameDrop.count_w  fcb   0     ; zero pad (MSB de count)
+gfxlock.frameDrop.count    fcb   0     ; nb 50 Hz frames écoulées depuis main loop
+gfxlock.frame.count        fdb   0     ; total 50 Hz frames depuis init
+gfxlock.frame.lastCount    fdb   0     ; frame count au dernier render
+
+gfxlock.screenBorder.color fcb $80     ; couleur bordure courante (auto-modifié)
+gfxlock.backProcess.routine fdb 0     ; adresse routine back-process
+```
+
+## Cycle complet — étape par étape
+
+### 1. `_gfxlock.init` — au boot
+
+```asm
+_gfxlock.init MACRO
+        lda   #-1
+        sta   gfxlock.status            ; status = -1 (init)
+        lda   gfxlock.backBuffer.status
+        anda  #%00000001
+        sta   gfxlock.backBuffer.id     ; id = 0 ou 1 selon status
+ ENDM
+```
+
+À appeler **après IrqInit et IrqSync, avant IrqOn**. Place `gfxlock.status = -1` (état initial spécial qui empêche le premier `bufferSwap.check` de faire un swap accidentel).
+
+### 2. `_gfxlock.on` — début phase rendu
+
+```asm
+_gfxlock.on MACRO
+        lda   gfxlock.status
+        bne   >                         ; status != 0 → on a déjà rendu cette frame
+        jsr   gfxlock.bufferSwap.wait   ; on attend la prochaine VBL
+!       lda   #1
+        sta   gfxlock.status            ; status = 1 (rendu en cours)
+        ; bascule la page de données pour pointer vers le back-buffer
+        ldb   gfxlock.backBuffer.status
+        andb  #%00000001
+        orb   #%00000010                ; valeur 2 ou 3
+        stb   map.CF74021.DATA          ; map back-buffer en $A000-$DFFF
+        ldb   map.MC6846.PRC
+        eorb  #%00000001                ; swap half-page $4000-$5FFF
+        stb   map.MC6846.PRC
+ ENDM
+```
+
+Effet :
+- Si on a déjà rendu cette frame (status != 0), on attend (`gfxlock.bufferSwap.wait`) que l'IRQ fasse le swap
+- Une fois libre, on mount le back-buffer en zone donnée (`$A000-$DFFF`)
+- On swap aussi le bit de forme `map.MC6846.PRC` pour l'écran principal
+
+### 3. Phase rendu — `EraseSprites` / `DrawSprites` / ...
+
+Pendant ce temps, le hardware affiche **l'autre** page (la « visible »). Notre code écrit dans la « back ».
+
+### 4. `_gfxlock.off` — fin phase rendu
+
+```asm
+_gfxlock.off MACRO
+        clr   gfxlock.status            ; status = 0 (rendu terminé)
+ ENDM
+```
+
+Très simple : juste un clear. La signalisation au reste du système (l'IRQ qui va swap) se fait via cette variable.
+
+### 5. `_gfxlock.loop` — fin de l'itération
+
+```asm
+_gfxlock.loop MACRO
+        lda   gfxlock.backBuffer.id     ; flip l'id à la fin
+        eora  #%00000001
+        sta   gfxlock.backBuffer.id
+        ldd   gfxlock.frame.count
+        subd  gfxlock.frame.lastCount
+        stb   gfxlock.frameDrop.count   ; nb de frames écoulées (1-2 typiquement)
+        ldd   gfxlock.frame.count
+        std   gfxlock.frame.lastCount
+ ENDM
+```
+
+Effet :
+- Flip `backBuffer.id` (le buffer rendu cette frame deviendra visible à la prochaine VBL)
+- Met à jour `frameDrop.count` (combien de frames 50 Hz se sont écoulées depuis le dernier `_gfxlock.loop`)
+
+`frameDrop.count` est crucial pour les routines synchronisées (`AnimateSpriteSync`, `ObjectMoveSync`, `ObjectFallSync`).
+
+### 6. `gfxlock.bufferSwap.check` — appelé depuis UserIRQ
+
+```asm
+gfxlock.bufferSwap.check
+        lda   gfxlock.status
+        bne   >                         ; status != 0 → rendu en cours → pas de swap
+        jsr   gfxlock.bufferSwap.do     ; rendu fini → swap
+        lda   #-1
+        sta   gfxlock.status            ; status = -1 (post-swap, attend prochain on)
+!       rts
+```
+
+Appelée à chaque VBL via UserIRQ. Si le rendu est complet (status=0), fait le swap et marque -1.
+
+### 7. `gfxlock.bufferSwap.do` — exécute le swap hardware
+
+```asm
+gfxlock.bufferSwap.do
+        ldb   gfxlock.backBuffer.status
+        andb  #%01000000                ; bit 6 basé sur flip/flop
+        orb   #%10000000                ; bit 7 = 1, bits 0-3 = couleur frame
+gfxlock.screenBorder.color equ *-1      ; (modifié pour bordure)
+        stb   map.CF74021.SYS2          ; écrit dans $E7E7 → swap visible buffer
+        com   gfxlock.backBuffer.status ; flip status
+        inc   gfxlock.bufferSwap.count+1 ; incrémente compteur
+        bne   >
+        inc   gfxlock.bufferSwap.count
+!
+        com   gfxlock.bufferSwap.status  ; marque swap fait (-1)
+        rts
+```
+
+L'écriture dans `$E7E7` est ce qui **change instantanément** la page visible côté hardware.
+
+### 8. `gfxlock.bufferSwap.wait` — attente bloquante
+
+```asm
+gfxlock.bufferSwap.wait
+        clr   gfxlock.bufferSwap.status
+@loop   tst   gfxlock.backProcess.status
+        beq   >
+        jsr   $1234                     ; do back processing
+gfxlock.backProcess.routine equ *-2     ; (modifié par _gfxlock.backProcess.on)
+!       lda   gfxlock.status
+        bne   >                         ; status != 0 → out
+        tst   gfxlock.bufferSwap.status
+        beq   @loop                     ; loop jusqu'à swap (status négatif)
+!       rts
+```
+
+Attente active jusqu'à ce que l'IRQ ait fait un swap. Si une back-process routine est enregistrée, elle est appelée pendant l'attente (utile pour faire du travail asynchrone — décompression, chargement de données).
+
+### 9. `_gfxlock.backProcess.on` — back process
+
+```asm
+_gfxlock.backProcess.on MACRO
+        ; param 1 : routine address
+        ldd   #\1
+        std   gfxlock.backProcess
+        lda   #1
+        sta   gfxlock.backProcess.status
+ ENDM
+```
+
+Enregistre une routine à appeler pendant `bufferSwap.wait`. Permet de profiter de l'attente pour des opérations en arrière-plan.
+
+## Couleur de bordure — `gfxlock.screenBorder`
+
+```asm
+gfxlock.screenBorder.update
+        andb  #$0F
+        orb   #%10000000
+        stb   gfxlock.screenBorder.color
+```
+
+Modifie la couleur de bordure (bits 0-3 dans `$E7E7`). Appelée typiquement depuis le code utilisateur pour matcher une palette spécifique :
+
+```asm
+        ldb   #15                       ; couleur 15 (blanc en palette par défaut)
+        jsr   gfxlock.screenBorder.update
+```
+
+## Pattern d'usage canonique
+
+```asm
+; Au boot du game-mode
+        jsr   InitGlobals
+        jsr   InitDrawSprites
+        jsr   InitStack
+        ; ... autres inits ...
+        jsr   IrqInit
+        ldd   #UserIRQ
+        std   Irq_user_routine
+        lda   #255
+        ldx   #Irq_one_frame
+        jsr   IrqSync
+        _gfxlock.init                   ; après IrqSync, AVANT IrqOn
+        jsr   IrqOn
+
+MainLoop
+        jsr   RunObjects
+        jsr   CheckSpritesRefresh
+        _gfxlock.on                     ; verrou + mount back-buffer
+        jsr   EraseSprites
+        jsr   UnsetDisplayPriority
+        jsr   DrawSprites
+        _gfxlock.off                    ; libère
+        _gfxlock.loop                   ; flip + update frameDrop
+        bra   MainLoop
+
+UserIRQ
+        jsr   gfxlock.bufferSwap.check  ; swap si prêt
+        jsr   PalUpdateNow
+        ; ... audio ...
+        rts
+```
+
+## `frameDrop.count` — sémantique
+
+| Valeur | Interprétation |
+|--------|----------------|
+| 1 | Frame rendue dans 1 VBL → 50 fps stable |
+| 2 | Frame rendue dans 2 VBL → 25 fps (frame skip) |
+| 3+ | Drop massif (lag) |
+| 0 | Anormal (cas init seulement) |
+
+Les routines `*Sync` utilisent cette valeur pour multiplier les vitesses/animations :
+- À 50 fps : `frameDrop.count_w = 1` → vitesse normale
+- À 25 fps : `frameDrop.count_w = 2` → vitesse doublée pour compenser
+
+C'est le mécanisme du **framerate adaptatif** : le gameplay reste « réel-temps » même si le rendu drop.
+
+## Synchronisation IRQ
+
+`IrqSync` configure l'IRQ pour se déclencher juste avant le VBL :
+
+```asm
+        lda   #255                      ; ligne 255 (juste avant ligne 0 du prochain frame)
+        ldx   #Irq_one_frame            ; une fois par frame
+        jsr   IrqSync
+```
+
+C'est essentiel pour que `gfxlock.bufferSwap.check` (appelé depuis UserIRQ) ait le temps de faire le swap **avant** que la nouvelle frame commence à être affichée — sinon on aurait du tearing.
+
+## Pitfalls
+
+- **`_gfxlock.init` après `IrqOn`** : la première IRQ peut faire un swap avant init → corruption visuelle. Toujours dans l'ordre : `IrqInit → IrqSync → _gfxlock.init → IrqOn`
+- **`_gfxlock.on` sans `_gfxlock.off`** : `gfxlock.status` reste à 1 → `bufferSwap.check` ne fait jamais de swap → écran figé
+- **`_gfxlock.off` sans `_gfxlock.loop`** : `frameDrop.count` ne se met pas à jour → routines `*Sync` cassées
+- **Écrire en zone donnée sans mount le back-buffer** : on écrit dans la visible → tearing immédiat
+- **Modifier `gfxlock.status` directement** : court-circuit la mécanique, comportement imprévisible
+- **Background process trop long dans `_gfxlock.backProcess.on`** : pas de protection — si le job dépasse le frame budget, l'écran lag
+- **Couleur de bordure changée pendant le frame** sans passer par `gfxlock.screenBorder.update` : peut être écrasée au prochain `bufferSwap.do`

--- a/skills/thomson-to8-engine-graphics-pipeline/references/sprite-packs-comparison.md
+++ b/skills/thomson-to8-engine-graphics-pipeline/references/sprite-packs-comparison.md
@@ -1,0 +1,241 @@
+# Sprite-packs — comparaison et choix
+
+L'engine fournit **trois packs de routines de rendu sprite**, à choisir selon les besoins du projet. Chaque pack est un fichier `.asm` qui regroupe (via `INCLUDE`) les sous-routines nécessaires.
+
+## Vue d'ensemble
+
+| Pack | Modes | Performances | Variants sprite | Cas d'usage |
+|------|-------|--------------|-----------------|-------------|
+| `sprite-background-erase-pack.asm` | Backup/Draw/Erase | ★★★ Optimal pour sprites mobiles | `NB0,NB1,XB0,XB1` (etc.) | **Recommandé** par défaut |
+| `sprite-background-erase-ext-pack.asm` | Backup/Draw/Erase + RLE/ZX0 | ★★★ Idem + sprites encodés | + `DMAP`, `DZX0` | Grands sprites, scrolling de fond |
+| `sprite-overlay-pack.asm` | Overlay | ★★ Plus simple, moins efficient | `ND0,ND1` (etc.) | Legacy, démos minimales |
+
+## `sprite-background-erase-pack.asm` (recommandé)
+
+```asm
+INCLUDE "./engine/graphics/sprite/sprite-background-erase-pack.asm"
+```
+
+### Contenu
+
+```asm
+        INCLUDE "./engine/graphics/sprite/background-erase-mode/DisplaySprite.asm"
+        INCLUDE "./engine/graphics/sprite/background-erase-mode/CheckSpritesRefresh.asm"
+        INCLUDE "./engine/graphics/sprite/background-erase-mode/EraseSprites.asm"
+        INCLUDE "./engine/graphics/sprite/background-erase-mode/UnsetDisplayPriority.asm"
+        INCLUDE "./engine/graphics/sprite/background-erase-mode/DrawSprites.asm"
+        INCLUDE "./engine/graphics/sprite/background-erase-mode/BgBufferAlloc.asm"
+        INCLUDE "./engine/graphics/sprite/background-erase-mode/DeleteObject.asm"
+```
+
+### Mécanique
+
+1. **Avant** de dessiner un sprite, on **sauvegarde le fond** (la zone d'écran qui sera couverte) dans une cellule de 64 octets allouée via `BgBufferAlloc`.
+2. **À l'effacement** (frame suivante, si l'objet a bougé), on restaure le fond depuis cette cellule.
+3. Le fond peut donc être **dessiné une seule fois** (au boot ou via `DrawFullscreenImage`) puis rester intact — les sprites mobiles s'en chargent eux-mêmes.
+
+### Variants sprite requis
+
+Pour qu'un sprite soit utilisable en mode backup, il faut le compiler avec le suffixe `B` :
+
+```properties
+sprite.Img_Player_001=./images/p001.png;NB0,NB1
+```
+
+- `NB0` = Normal Backup, position 0
+- `NB1` = Normal Backup, position 1 (shift 1px)
+
+Si le sprite doit pouvoir flipper :
+```properties
+sprite.Img_Player_001=./images/p001.png;NB0,NB1,XB0,XB1
+```
+
+### ⚠️ Variants `D` (Draw seul) — `render_overlay_mask` obligatoire dans `Init`
+
+Quand le sprite est compilé avec un variant `ND*` (Normal Draw), `XD*`, `YD*`, ou `XYD*` (= sans sauvegarde du fond, utilisé pour les décors statiques ou les sprites "additifs"), le **code asm de l'objet** doit poser `render_overlay_mask` dans `render_flags,u` :
+
+```asm
+Init
+        ; ... config animation, priority, position ...
+        lda   render_flags,u
+        ora   #render_overlay_mask
+        sta   render_flags,u
+        inc   routine,u
+```
+
+**Sans ça** : l'engine considère le sprite comme un sprite mode B et cherche le code d'erase compilé → qui n'existe pas pour les variants D → **rien ne s'affiche** (échec silencieux, c'est ce que ce flag est censé indiquer au moteur).
+
+Inversement, pour les variants `NB*`/`XB*`/`YB*`/`XYB*`, **ne PAS** poser `render_overlay_mask` (sinon le mécanisme de backup n'est pas appliqué).
+
+### Avantages
+- Performance optimale pour sprites mobiles (le fond n'est dessiné qu'une fois)
+- Compatible avec `DrawFullscreenImage` pour les fonds statiques
+- Pattern utilisé par r-type, bubble-bobble, sonic-2, 2026 (tous les jeux récents)
+
+### Inconvénients
+- Plus de mémoire requise (cellules de 64 octets × N sprites)
+- Variants `B` à compiler (cycles de build plus longs)
+
+## `sprite-background-erase-ext-pack.asm`
+
+```asm
+INCLUDE "./engine/graphics/sprite/sprite-background-erase-ext-pack.asm"
+```
+
+### Contenu
+
+Identique au précédent **sauf** `DrawSprites.asm` → `DrawSpritesExtEnc.asm` (encoding étendu).
+
+```asm
+        INCLUDE "./engine/graphics/sprite/background-erase-mode/DisplaySprite.asm"
+        INCLUDE "./engine/graphics/sprite/background-erase-mode/CheckSpritesRefresh.asm"
+        INCLUDE "./engine/graphics/sprite/background-erase-mode/EraseSprites.asm"
+        INCLUDE "./engine/graphics/sprite/background-erase-mode/UnsetDisplayPriority.asm"
+        INCLUDE "./engine/graphics/sprite/background-erase-mode/DrawSpritesExtEnc.asm"   ← différence
+        INCLUDE "./engine/graphics/sprite/background-erase-mode/BgBufferAlloc.asm"
+        INCLUDE "./engine/graphics/sprite/background-erase-mode/DeleteObject.asm"
+```
+
+### Quand l'utiliser
+
+Si le projet utilise des sprites avec encodage compressé :
+- `DMAP` : encodage RLE optimisé pour tiles répétitives (images de fond)
+- `DZX0` : compression ZX0 (sprites volumineux)
+
+```properties
+sprite.Img_bigBackground=./images/bg.png;NDMAP   # ou NDZX0
+```
+
+Cas typiques : pattern r-type/level01 qui utilise `sprite-background-erase-ext-pack` pour permettre les backgrounds tilés et compressés.
+
+### Compatibilité
+
+Tous les sprites des variants standards (`NB0`, `NB1`, `ND0`, etc.) restent compatibles. `DrawSpritesExtEnc` détecte le format du sprite au runtime via le rsv_ field et appelle le bon décodeur.
+
+## `sprite-overlay-pack.asm`
+
+```asm
+INCLUDE "./engine/graphics/sprite/sprite-overlay-pack.asm"
+```
+
+### Contenu
+
+```asm
+        INCLUDE "./engine/graphics/sprite/overlay-mode/DisplaySprite.asm"
+        INCLUDE "./engine/graphics/sprite/overlay-mode/BuildSprites.asm"
+        INCLUDE "./engine/graphics/sprite/overlay-mode/DeleteObject.asm"
+```
+
+### Mécanique
+
+Mode **overlay** : les sprites sont fusionnés dans un buffer overlay. Le fond est redessiné à chaque frame (en mode plein écran), puis les sprites sont ajoutés par-dessus.
+
+`BuildSprites` (équivalent de `EraseSprites + DrawSprites` en mode overlay) parcourt la DPS et redessine tout.
+
+### Activation
+
+Le mode overlay nécessite **`OverlayMode equ 1`** au début du `main.asm` :
+
+```asm
+OverlayMode equ 1
+
+        INCLUDE "./engine/constants.asm"     ; lit OverlayMode pour adapter render_flags
+        INCLUDE "./engine/macros.asm"
+        ; ...
+
+        INCLUDE "./engine/graphics/sprite/sprite-overlay-pack.asm"
+```
+
+### Variants sprite
+
+Mode overlay : les sprites sont compilés sans backup → variant `D` (Draw seul) :
+```properties
+sprite.Img_Player_001=./images/p001.png;ND0,ND1
+```
+
+### Différences de `render_flags`
+
+En mode overlay, `render_overlay_mask` (bit 2) **n'existe pas**. À la place, le bit 5 devient `render_no_range_ctrl_mask` (skip out-of-range check — **dangereux**, peut corrompre la mémoire).
+
+### Quand l'utiliser
+
+- Démos très simples (un seul background, peu de sprites mobiles)
+- Pattern legacy (cf. game-projects/test)
+- Quand le fond change à chaque frame de toute façon (pas de bénéfice à le préserver)
+
+### Inconvénients
+- Performance moindre (redessine tout chaque frame)
+- Pas adapté à scrolling complexe avec sprites multiples
+
+## Boucle MainLoop selon le pack
+
+### Avec `background-erase-pack` (ou ext)
+
+```asm
+MainLoop
+        jsr   RunObjects
+        jsr   CheckSpritesRefresh
+        _gfxlock.on
+        jsr   EraseSprites              ; étape distincte d'erase
+        jsr   UnsetDisplayPriority
+        jsr   DrawSprites               ; puis draw
+        _gfxlock.off
+        _gfxlock.loop
+        bra   MainLoop
+```
+
+### Avec `overlay-pack`
+
+```asm
+MainLoop
+        jsr   WaitVBL                   ; pas de gfxlock typiquement
+        jsr   ReadJoypads
+        jsr   RunObjects
+        jsr   BuildSprites              ; erase+draw en un coup
+        bra   MainLoop
+```
+
+## Routines partagées (présentes dans tous les packs)
+
+- `DisplaySprite` : enregistre l'objet dans la DPS (le sprite sera affiché). Variantes :
+  - `DisplaySprite` (U = OST)
+  - `DisplaySprite_x` / `DisplaySprite2` (X = OST)
+  - `DisplaySprite_priority` / `DisplaySprite3` (U = OST, A = priority)
+- `DeleteObject` : supprime un objet de la DPS et libère son slot
+
+## Choix décisionnel
+
+```
+Tu fais :                                    → Pack à utiliser
+──────────────────────────────────────────  ────────────────────────────
+Un jeu standard avec sprites mobiles         background-erase-pack
++ scrolling de fond (grands sprites)         background-erase-ext-pack
++ images compressées (RLE/ZX0)               background-erase-ext-pack
+Une démo très simple, fond redessiné         overlay-pack
+Un projet legacy déjà en overlay            overlay-pack (ou migrer)
+```
+
+## Migration overlay → background-erase
+
+Si tu veux faire évoluer un projet de overlay vers background-erase :
+
+1. **Retirer `OverlayMode equ 1`** du `main.asm`
+2. **Remplacer** l'INCLUDE `sprite-overlay-pack.asm` par `sprite-background-erase-pack.asm`
+3. **Remplacer** le `jsr BuildSprites` dans MainLoop par la séquence Erase/Unset/Draw :
+   ```asm
+   jsr CheckSpritesRefresh
+   jsr EraseSprites
+   jsr UnsetDisplayPriority
+   jsr DrawSprites
+   ```
+4. **Recompiler les sprites** avec variants `B` (typiquement passer `ND0,ND1` à `NB0,NB1`) dans les `.properties` des objets
+5. **Ajouter `InitDrawSprites`** dans le code d'init
+6. **Adapter `render_flags`** si des objets utilisent `render_no_range_ctrl_mask` (bit 5 en overlay)
+
+## Pitfalls
+
+- **Inclure deux packs simultanément** : conflits de symboles (BuildSprites vs DrawSprites), build cassé
+- **Variant `B` non compilé** mais code utilisant background-erase : sprite affiché mais sans backup, donc à l'effacement, le fond reste à 0 (couleur 0 = noir)
+- **Pas d'`InitDrawSprites`** : `glb_camera_x_offset` à 0 → sprites à la mauvaise position
+- **`OverlayMode equ 1`** mais utilisant background-erase-pack : `render_flags` mal interprétés, comportement imprévisible
+- **Mélange de `DisplaySprite` et `DisplaySprite_x`** : OK, ce sont des variantes du même mécanisme

--- a/skills/thomson-to8-engine-image-codecs/SKILL.md
+++ b/skills/thomson-to8-engine-image-codecs/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: thomson-to8-engine-image-codecs
+description: "Décrit les codecs et routines de rendu d'images du Thomson TO8/TO9 game engine (Bento8/wide-dot) : DrawFullscreenImage pour dessiner une image plein écran rapide (technique stack blasting pshs/pulu pour vitesse, lds $DF40 puis $BF40, sync IRQ critique pour 12 octets de marge), DrawFullscreenInterlacedImage pour images entrelacées (effets visuels), DrawHLine pour ligne horizontale 320x200x16 (paramètres dans dp_engine : p0/p1 x MSB/LSB, p2 y, p3/p4 nb pixels, p5/p6 couleurs), DecRLE00 / DecMapAlpha codec RLE avec transparence par Samuel Devulder (encodage 2 octets : 00 nnnnnn = ptr offset, 01 = right transparent ou repeat, 10 = left transparent ou write, 11 = ptr offset 14-bit signed), zx0_mega pour décompression ZX0 (zx0_6809_mega_wrap pour 2 parts via glb_screen_location_1/2, zx0_decompress), bm4.drawChunks pour rendu chunky bm4 (bytes par ligne, nb lignes, copy avec PULS/PSHS optimisé), variant sprites DMAP via MapRleEncoder et DZX0 via ZX0Encoder dans le builder, ClearDataMemory / ClearInterlacedDataMemory / ClearVerticalBandLR pour clear zones VRAM (stack blasting lds $DF40 + pshu pour vitesse, IRQ off requise), GetImgIdA helper. Utiliser pour afficher un splash screen, dessiner un fond de niveau, décompresser une image ZX0 ou RLE, blitter un chunk d'image, clearer une zone VRAM rapidement, optimiser le rendering avec stack tricks. Mots-clés : DrawFullscreenImage, DrawFullscreenInterlacedImage, DrawHLine, DecRLE00, DecMapAlpha, DecRLE00_alpha, zx0_mega, zx0_6809_mega_wrap, zx0_decompress, bm4.drawChunbks, bm4.drawChunks, ClearDataMem, ClearDataMemory, ClearInterlacedDataMemory, ClearVerticalBandLR, GetImgIdA, p0, p1, p2, p3, p4, p5, p6, dhl_routine, $DF40, $BF40, $C014, RLE format, stack blasting, pulu / pshs, lds, glb_screen_location_1, glb_screen_location_2, DMAP, DZX0, MapRleEncoder, ZX0Encoder, Bgi_, transparency, alpha, Samuel Devulder, sprite background, IRQ off."
+machines: [to8, to8d, to9, to9+]
+user-invocable: false
+---
+
+# Codecs et routines d'image — Thomson TO8/TO9 Game Engine
+
+L'engine fournit des routines optimisées pour le rendu d'images :
+
+| Routine | Rôle |
+|---------|------|
+| `DrawFullscreenImage` | Image plein écran rapide (stack blasting) |
+| `DrawFullscreenInterlacedImage` | Image entrelacée (effets) |
+| `DrawHLine` | Ligne horizontale (mode 320×200) |
+| `DecRLE00` | Décodeur RLE avec transparence |
+| `zx0_mega` | Décompresseur ZX0 (wrapper) |
+| `bm4.drawChunbks` | Rendu chunky bm4 |
+| `ClearDataMem*` | Clear VRAM |
+
+---
+
+## `DrawFullscreenImage` — image plein écran rapide
+
+### Technique stack blasting
+
+```asm
+        lds   #$DF40                    ; positionne S en fin de RAMA
+DFI_a
+        pulu  a,b,dp,x,y                ; lit 5 octets depuis source
+        pshs  y,x,dp,b,a                ; écrit 5 octets dans dest (via pile)
+        ; ... répété 6× ...
+        cmps  #$C014
+        bne   DFI_a
+```
+
+Astuce 6809 : `pulu` lit depuis `u` (source) en incrémentant, `pshs` écrit dans `s` (dest) en décrémentant. Avec U pointant le PNG source et S pointant la VRAM, on peut transférer 5 octets par instruction (~12 cycles vs ~30 pour 5 `lda/sta`).
+
+### Performance
+
+- 5 octets par paire `pulu`/`pshs` (~12 cycles)
+- 8000 octets de VRAM (160×200×4 bits / 8 = 16000 octets / 2 plans = 8000 octets par plan)
+- Ratio : 8000 / 5 × 12 = 19200 cycles ≈ 1 frame complète à 50 Hz
+
+C'est juste à la limite du frame budget. Pour ça, **IRQ doit être désactivée** pendant le draw (sauf si on accepte 12 octets de garbage en tête de pile).
+
+### Pré-requis
+
+```asm
+        jsr   IrqPause                  ; ou IrqOff
+        ldx   #my_image_data            ; pointeur image
+        jsr   DrawFullscreenImage
+        jsr   IrqUnpause                ; ou IrqOn
+```
+
+Sans `IrqOff`, l'IRQ peut interrompre en plein `pshs`/`pulu` et écraser des octets (les 12 derniers de la pile).
+
+### Format de l'image
+
+Le pointeur `X` doit pointer vers une structure :
+```
++0 : page mémoire des data (1 octet)
++1 : pointeur vers data (2 octets)
++3+ : data brute (8000 octets RAMA + 8000 RAMB ou similaire)
+```
+
+Le builder Java génère cette structure depuis un PNG via `palette.X` et `act.X.backgroundImage`.
+
+Constantes générées : `Bgi_<actName>` pointe vers cette structure.
+
+Voir [references/fullscreen-images.md](references/fullscreen-images.md).
+
+## `DrawFullscreenInterlacedImage` — variantes
+
+Variante pour effets entrelacés (palette qui alterne ligne par ligne, mode interlaced). Plus complexe, utilisée pour des modes graphiques avancés.
+
+## `DrawHLine` — ligne horizontale (320×200)
+
+Pour mode 320×200×16 (non standard dans Bento8). Note : marqué comme **UNFINISHED** dans le code.
+
+```asm
+p0   equ dp_engine                      ; x MSB
+p1   equ dp_engine+1                    ; x LSB
+p2   equ dp_engine+2                    ; y
+p3   equ dp_engine+3                    ; nb pixels MSB
+p4   equ dp_engine+4                    ; nb pixels LSB
+p5   equ dp_engine+5                    ; couleur 0 (s0000bvr)
+p6   equ dp_engine+6                    ; couleur 1 (0sbvr000)
+```
+
+À utiliser avec parcimonie (pas finalisée).
+
+## `DecRLE00` — codec RLE avec transparence
+
+Par Samuel Devulder. Format compact pour images avec transparence (e.g. tile alpha).
+
+### Format
+
+```
+00 000000              → end of data
+00 nnnnnn              → write ptr offset n (1-63 unsigned)
+01 000000 vvvvvvvv     → right pixel transparent, v = byte to add
+01 nnnnnn vvvvvvvv     → repeat n bytes of value v
+10 000000 vvvvvvvv     → left pixel transparent, v = byte to add
+10 nnnnnn vvvvvvvv ... → n bytes to write with values v0,v1,...
+11 nnnnnn nnnnnnnn     → write ptr offset n (-8192 to +8191, signed)
+```
+
+### Registres d'entrée
+
+```asm
+        ldy   #data_part1               ; (RAMA)
+        ldu   #data_part2               ; (RAMB)
+        ; glb_screen_location_1/2 = pointeurs VRAM (déjà set)
+        jsr   DecMapAlpha               ; (ou variante)
+```
+
+Le codec gère **2 parts** (RAMA et RAMB) en parallèle. Très utilisé pour les tiles avec couleurs transparentes.
+
+Voir [references/rle-decoders.md](references/rle-decoders.md).
+
+## `zx0_mega` — décompresseur ZX0
+
+```asm
+zx0_6809_mega_wrap
+        stu   @x
+        ldu   glb_screen_location_1
+        cmpx  #0
+        beq   >
+        jsr   zx0_decompress            ; décompresse part 1
+!
+        ldx   #0                        ; (dynamic) data part 2
+@x      equ *-2
+        beq   @rts
+        ldd   #0
+        std   @x                        ; clear exit flag
+        ldu   glb_screen_location_2
+        jmp   zx0_decompress            ; décompresse part 2
+@rts    rts
+```
+
+Wrapper qui décompresse une image ZX0 en 2 parts (RAMA et RAMB).
+
+Pré-requis : `glb_screen_location_1/2` initialisés.
+
+`zx0_decompress` est dans `engine/compression/zx0/zx0_6809_mega.asm` (variantes mega / mega_back / standard / turbo selon perf/taille).
+
+Variants sprite `DZX0` utilisent ce codec.
+
+Voir [references/zx0-decoders.md](references/zx0-decoders.md).
+
+## `bm4.drawChunbks` — rendu chunky BM4
+
+```asm
+bm4.drawChunks
+        pshs  d,x,y,u
+
+        ldd   ,u++                      ; A = nb bytes/line, B = nb lines
+        sta   @bytes
+        stb   @nbln
+        
+@drawline
+        leax  a,u                       ; end of source for this line
+        stx   @cmpu+2
+        
+        ; Optimisation par multiples de bytes
+        lsra
+        bcc   >
+        pulu  b
+        stb   ,y+                       ; 1 byte
+!       lsra
+        bcc   >
+        pulu  x
+        stx   ,y++                      ; 2 bytes
+!       lsra
+        bcc   @cmpu
+        pulu  d,x
+        std   ,y++
+        stx   ,y++                      ; 4 bytes
+@cmpu   ; reste = multiples de 8 → pshu d,x,y (6 bytes en 1 instruction)
+```
+
+Affichage rapide de chunks (8×8 ou plus) en mode BM4. Utilisé pour les fonds avec compression légère.
+
+## Clear de VRAM
+
+### `ClearDataMem`
+
+Clear toute la page courante en zone donnée ($A000-$DFFF) avec une couleur.
+
+```asm
+        ldx   #$XXXX                    ; couleur sur 4 pixels (8 bits = 2 pixels en BM16)
+        jsr   ClearDataMem
+```
+
+Utilisé par `LoadAct` quand `act.X.backgroundSolid=N` est défini.
+
+### `ClearInterlacedDataMemory`
+
+Version pour mode entrelacé.
+
+### `ClearVerticalBandLR` — clear bande verticale
+
+```asm
+ClearVerticalBandLR
+        tfr   x,y                       ; X = couleur, dupliquée dans Y
+        ldu   #$DF40                    ; haut de RAMA
+@a
+        pshu  x                         ; 1 paire pixels
+        leau  -36,U                     ; descend 36 octets (1 ligne en BM16)
+        pshu  x,y                       ; 2 paires
+        leau  -36,U
+        ; ... répété pour clearer une bande verticale
+```
+
+Stack blasting pour clear rapide. **IRQ off requis**.
+
+Utile pour clearer une zone partielle (e.g. zone HUD à droite).
+
+Voir [references/clear-routines.md](references/clear-routines.md).
+
+## `GetImgIdA` — utilitaire
+
+```asm
+GetImgIdA                                ; charge l'image ID dans A depuis...?
+```
+
+Petit helper, à vérifier dans le code.
+
+## Pipeline complet — image de fond
+
+```
+1. Property : act.default.backgroundImage=./images/bg.png
+
+2. Builder Java :
+   - Convertit PNG en format BM16 (deux plans RAMA + RAMB)
+   - Compresse via ZX0 ou stocke brut
+   - Génère structure : page + adresse + data
+   - Génère label Bgi_default
+
+3. Code asm dans LoadAct :
+   - ldb #$02; stb $E7E5 (mount page 2)
+   - ldx #Bgi_default
+   - jsr DrawFullscreenImage
+   - ldb #$03; stb $E7E5 (mount page 3 — pour double buffer)
+   - jsr DrawFullscreenImage (deuxième fois)
+   
+4. Runtime : image affichée, gfxlock alterne entre pages 2 et 3
+```
+
+Pour les sprites mobiles, le fond reste intact grâce au mode B (Background backup).
+
+## Pitfalls
+
+- **`DrawFullscreenImage` sans `IrqOff`** : 12 octets garbage en tête de stack
+- **`DrawFullscreenImage` qui ne pointe pas une page valide** : crash
+- **`ClearDataMem` sans mount préalable** : clear la mauvaise page
+- **`DecRLE00` sans `glb_screen_location_1/2`** init : écrit à des adresses random
+- **`zx0_mega` sur data non compressé ZX0** : output garbage
+- **`bm4.drawChunbks` avec format incorrect** : crash dès la 1ère iter
+- **`DrawFullscreenImage` pendant que `DrawSprites` est en cours** : conflit de stack S
+- **Format BM4 vs BM16** : différent (4 bits/pixel vs 16-couleurs). Routines pas interchangeables
+- **`pshs`/`pulu` avec mauvais alignement** : décalage des pixels
+- **IRQ `MarkObjGone`** ou similaire pendant `DrawFullscreenImage` : interruption du blast → glitch
+
+---
+
+## Références détaillées
+
+- [references/fullscreen-images.md](references/fullscreen-images.md) — DrawFullscreenImage stack-blasting technique (lds $DF40 puis $BF40, pulu/pshs), IRQ off requirement, format Bgi_X (page + adresse + data brute ou compressée), génération par builder depuis act.X.backgroundImage property, double-buffer pages 2 et 3
+- [references/rle-decoders.md](references/rle-decoders.md) — DecRLE00 / DecMapAlpha format binaire complet (00/01/10/11 + nnnnnn + vvvvvvvv), gestion transparence left/right, ptr offset signé 14-bit, registres y/u/glb_screen_location_1/2, variants pour BM4 vs BM16, performance
+- [references/zx0-decoders.md](references/zx0-decoders.md) — ZX0 décompresseur (zx0_6809_mega.asm + variants standard/turbo/mega/mega_back), zx0_decompress entry point, wrapper zx0_6809_mega_wrap pour 2-parts, variant sprite DZX0, intégration avec RAMLoader, compression ratio
+- [references/clear-routines.md](references/clear-routines.md) — ClearDataMem / ClearInterlacedDataMemory / ClearVerticalBandLR / ClearCartMemory / ClearDataMemoryRAMx, technique stack blasting (lds + pshu), IRQ off requirement, usage dans LoadAct (backgroundSolid)

--- a/skills/thomson-to8-engine-input/SKILL.md
+++ b/skills/thomson-to8-engine-input/SKILL.md
@@ -1,0 +1,324 @@
+---
+name: thomson-to8-engine-input
+description: "Décrit le système d'entrées (joypads, clavier) du Thomson TO8/TO9 game engine (Bento8/wide-dot) : routine InitJoypads pour configurer le MC6821 PIA (registres CRA/CRB $E7CE/$E7CF, DDRA/DDRB, ORA/ORB $E7CC/$E7CD), ReadJoypads (Joypads_Read / Dpad_Read / Fire_Read, mode V1 16 bits combinés ou V2 1 byte/joueur), masques c1_button_up_mask / c1_button_down_mask / c1_button_left_mask / c1_button_right_mask / c1_button_A_mask / c1_button_B_mask (et c2_*), masques communs c_button_*_mask, masques de joueur c1_dpad / c2_dpad / c1_butn / c2_butn, variables Dpad_Press / Dpad_Held / Fire_Press / Fire_Held pour player 1, Dpad2_Press / Dpad2_Held / Fire2_Press / Fire2_Held pour player 2, ReadJoypads2 pour version 2-bytes, joypad.buffer pour historique des directions (circular buffer 16 entrées, joypad.buffer.direction.write.ptr / read.ptr, joypad.buffer.addDirection / getDirection), joypad.md6 driver Mega Drive 6 boutons (cycle line select Z/Y/X/Mode + Start/A/B/C, pinout TO8 vs Mega Drive), ReadKeyboard pour clavier (Key_Press / Key_Held, appel KTST monitor et GETC), MapKeyboardToJoypads pour mapper clavier → masques joypad (touches 8/9/10/11 = directions, autres = boutons), pattern Dpad_Press (front montant) vs Dpad_Held (maintenu). Utiliser pour configurer les joypads, lire les inputs joueur 1 et 2, gérer le clavier comme alternative au joypad, ajouter le support manette Mega Drive 6 boutons, enregistrer un historique d'inputs (combos), distinguer touche pressée vs maintenue. Mots-clés : InitJoypads, ReadJoypads, ReadJoypads2, Joypads, Joypads_Read, Joypads_Held, Joypads_Press, Dpad_Read, Dpad_Press, Dpad_Held, Dpad2_Press, Dpad2_Held, Fire_Read, Fire_Press, Fire_Held, Fire2_Press, Fire2_Held, Key_Press, Key_Held, ReadKeyboard, MapKeyboardToJoypads, joypad.buffer, joypad.buffer.direction, joypad.buffer.direction.write.ptr, joypad.buffer.direction.read.ptr, joypad.buffer.addDirection, joypad.buffer.getDirection, joypad.md6, KTST, GETC, MC6821, PIA, CRA, CRB, DDRA, DDRB, ORA, ORB, $E7CC, $E7CD, $E7CE, $E7CF, c1_button_up_mask, c1_button_down_mask, c1_button_left_mask, c1_button_right_mask, c1_button_A_mask, c1_button_B_mask, c2_button_up_mask, c2_button_down_mask, c2_button_left_mask, c2_button_right_mask, c2_button_A_mask, c2_button_B_mask, c_button_up_mask, c_button_down_mask, c_button_left_mask, c_button_right_mask, c_button_A_mask, c_button_B_mask, c1_dpad, c2_dpad, c1_butn, c2_butn, megadrive 6 buttons, TH TR TL line select, pin 6 7 9, Start C A B, X Y Z Mode."
+machines: [to8, to8d, to9, to9+]
+user-invocable: false
+---
+
+# Input — Thomson TO8/TO9 Game Engine
+
+Le système d'entrées gère **joypads** (2 manettes Thomson standard) et **clavier**. Tout est accédé via le PIA MC6821 sur les ports `$E7CC-$E7CF`.
+
+L'engine fournit des routines pour :
+- **Joypads standard** (2 boutons) : `InitJoypads`, `ReadJoypads`, `ReadJoypads2`
+- **Buffer d'historique** : `joypad.buffer` (combo detection)
+- **Joypad Megadrive 6 boutons** : `joypad.md6`
+- **Clavier** : `ReadKeyboard`, `MapKeyboardToJoypads`
+
+---
+
+## Hardware — PIA MC6821
+
+Le TO8 utilise un MC6821 (PIA = Peripheral Interface Adapter) pour les manettes :
+
+```asm
+$E7CC : ORA / DDRA  (direction des joypads — selon bit 2 de CRA)
+$E7CD : ORB / DDRB  (boutons + DAC son — selon bit 2 de CRB)
+$E7CE : CRA         (Control Register A)
+$E7CF : CRB         (Control Register B)
+```
+
+CRA/CRB bit 2 :
+- `= 0` : accès au registre **DDR** (Data Direction)
+- `= 1` : accès au registre **OR** (Output Register)
+
+## `InitJoypads`
+
+Configure le PIA pour lire les joypads :
+
+```asm
+InitJoypads
+        ; CRA : passage en DDRA
+        lda   $E7CE
+        anda  #$FB                      ; clear bit 2
+        sta   $E7CE
+        andb  #0
+        stb   $E7CC                     ; DDRA = $00 → toutes les lignes en input
+        ora   #$04                      ; set bit 2
+        sta   $E7CE                     ; CRA bit 2 = 1 → accès ORA
+        
+        ; CRB : idem pour DDRB/ORB
+        lda   $E7CF
+        anda  #$FB
+        sta   $E7CF
+        andb  #0
+        stb   $E7CD                     ; DDRB = $00 → input
+        ora   #$04
+        sta   $E7CF
+        rts
+```
+
+Après cet appel, `$E7CC` lit les directions (4 bits player 1 + 4 bits player 2) et `$E7CD` lit les boutons (2 bits/joueur, plus DAC dans les autres bits).
+
+## Format des données joypads
+
+### `$E7CC` — Directions
+
+```
+Bit : 7 6 5 4   3 2 1 0
+       └ player2 ┘ └ player1 ┘
+       R L D U   R L D U
+```
+
+`0 = press, 1 = release` (inversé !).
+
+### `$E7CD` — Boutons + DAC
+
+```
+Bit : 7 6   5 4 3 2 1 0
+      A A   [6 bits DAC]   B B
+      P2 P1               P2 P1
+```
+
+Bits 6-7 : boutons A des deux joueurs.
+Bit 2-3 : boutons B (note : bit 2 pour P1, bit 3 pour P2).
+Bits 0-5 : 6 bits DAC (utilisés pour le son hardware).
+
+## `ReadJoypads` — version V1 (16 bits combinés)
+
+```asm
+ReadJoypads
+        ; Lit $E7CC et $E7CD, inverse, distribue dans :
+        ; Dpad_Read    (bas)   : directions player 1+2 sur 1 octet
+        ; Fire_Read    (haut)  : boutons player 1+2 sur 1 octet
+        ; Dpad_Held    : dpad maintenu (full byte)
+        ; Dpad_Press   : dpad pressé cette frame (front montant uniquement)
+        ; Fire_Held    : boutons maintenus
+        ; Fire_Press   : boutons pressés cette frame
+```
+
+Format combiné 16 bits :
+```
+Dpad_Held :  bits 0-3 = player1 (URDL), bits 4-7 = player2 (URDL)
+Fire_Held :  bits 0-1 = player1 (B,...) , bits 6-7 = player2 (A,...)
+```
+
+> **Format simplifié pour solo** : utiliser `c1_*_mask` qui ciblent les bits player 1 seulement.
+
+## `ReadJoypads2` — version V2 (1 byte/joueur)
+
+Variante qui sépare les deux joueurs en deux octets distincts (plus pratique pour 2 joueurs).
+
+## Masques bits
+
+### Player 1 (`c1_*_mask`)
+
+```asm
+c1_button_up_mask            equ %00000001
+c1_button_down_mask          equ %00000010
+c1_button_left_mask          equ %00000100
+c1_button_right_mask         equ %00001000
+c1_button_A_mask             equ %01000000
+c1_button_B_mask             equ %00000100      ; ATTENTION : même valeur que left_mask
+```
+
+> **Conflit `c1_button_B_mask` et `c1_button_left_mask`** : tous deux à $04. C'est parce que Dpad et Fire sont dans **deux variables différentes** (`Dpad_Read` vs `Fire_Read`). Le test `bita #c1_button_B_mask` doit être fait sur `Fire_Held`, pas `Dpad_Held`.
+
+### Player 2 (`c2_*_mask`)
+
+```asm
+c2_button_up_mask            equ %00010000      ; bits hauts
+c2_button_down_mask          equ %00100000
+c2_button_left_mask          equ %01000000
+c2_button_right_mask         equ %10000000
+c2_button_A_mask             equ %10000000
+c2_button_B_mask             equ %00001000
+```
+
+### Masques communs (les deux joueurs)
+
+```asm
+c_button_up_mask             equ %00010001      ; bits player1 + player2
+c_button_down_mask           equ %00100010
+c_button_left_mask           equ %01000100
+c_button_right_mask          equ %10001000
+c_button_A_mask              equ %11000000
+c_button_B_mask              equ %00001100
+```
+
+### Masques de joueur (filtres)
+
+```asm
+c1_dpad                      equ %00001111      ; isole les 4 bits dpad player1
+c2_dpad                      equ %11110000
+c1_butn                      equ %01000100      ; isole les 2 bits boutons player1
+c2_butn                      equ %10001000
+```
+
+## Press vs Held
+
+```asm
+Dpad_Press                   ; 1 si la direction vient d'être pressée cette frame
+Dpad_Held                    ; 1 si la direction est tenue (depuis n frames)
+Fire_Press
+Fire_Held
+```
+
+`Press` : détection de **front montant** (passe de 0 à 1) — utile pour un saut, un tir une fois.
+`Held` : état courant — utile pour un mouvement continu, une accélération.
+
+```asm
+        lda   Dpad_Press
+        bita  #c1_button_up_mask
+        beq   @no_jump
+        ; le joueur vient d'appuyer sur up
+@no_jump
+
+        lda   Dpad_Held
+        bita  #c1_button_left_mask
+        beq   @no_left
+        ; le joueur tient gauche (déplacement continu)
+@no_left
+```
+
+## Pattern d'usage typique
+
+```asm
+; Au boot
+        jsr   InitJoypads
+
+; Dans MainLoop
+MainLoop
+        jsr   ReadJoypads
+        ; Test inputs et logique gameplay
+        jsr   RunObjects
+        ; ...
+```
+
+`ReadJoypads` doit être appelée **chaque frame** avant `RunObjects` (les objets vont lire les inputs).
+
+## `joypad.buffer` — historique pour combos
+
+Circular buffer de 16 entrées pour mémoriser les directions récentes.
+
+```asm
+joypad.buffer.direction           fill 0,16
+joypad.buffer.direction.write.ptr fcb 0
+joypad.buffer.direction.read.ptr  fcb 0
+```
+
+Routines :
+- `joypad.buffer.addDirection` : ajoute la direction courante au buffer
+- `joypad.buffer.getDirection` : lit la direction suivante depuis le read pointer
+
+Pattern :
+```asm
+; Chaque frame
+        jsr   ReadJoypads
+        jsr   joypad.buffer.addDirection
+
+; Quand on veut analyser
+        ; Boucle qui lit getDirection jusqu'à $FF (fin)
+        ; Détecte une séquence type "down, down-forward, forward, punch"
+```
+
+Utile pour fighting games, combos, codes secrets (Konami code).
+
+## `joypad.md6` — Megadrive 6 boutons
+
+Driver pour la manette Megadrive 3 ou 6 boutons branchée sur le port joypad TO8.
+
+Mécanisme : multiplex via la ligne TH (pin 7). Le driver toggle TH et lit les boutons par cycles.
+
+```
+Cycle  TH   TR  TL   D3   D2   D1   D0
+1      HI   C   B    R    L    D    U
+2      LO   Start A  0    0    D    U
+3-7    ... (cycles supplémentaires pour les 6 boutons : X, Y, Z, Mode)
+```
+
+Le driver simule un état complet (Up, Down, Left, Right, A, B, C, Start, X, Y, Z, Mode) sur la base de ces 7 cycles.
+
+### Pinout
+
+| Pin | Megadrive | TO8 |
+|-----|-----------|-----|
+| 1 | Up | Up |
+| 2 | Down | Down |
+| 3 | Left | Left |
+| 4 | Right | Right |
+| 5 | +5V | +5V |
+| 6 | A/B | A |
+| 7 | TH (line select) | B |
+| 8 | GND | GND |
+| 9 | C/Start | NC |
+
+L'adaptateur Megadrive→TO8 utilise la pin 7 (B sur TO8) pour le multiplexing.
+
+Voir [references/megadrive-6-buttons.md](references/megadrive-6-buttons.md).
+
+## `ReadKeyboard` — clavier
+
+```asm
+Key_Press                   fcb $00
+Key_Held                    fcb $00
+
+ReadKeyboard
+        clrb
+        stb   Key_Press
+        jsr   KTST                      ; monitor : test si touche pressée
+        bcc   @clearHeld                ; non → exit
+        jsr   GETC                      ; oui → lit code dans B
+        cmpb  Key_Held                  ; déjà maintenue ?
+        beq   @rts                      ; oui → Press = 0, Held inchangé
+        stb   Key_Press                 ; non → enregistre press cette frame
+@clearHeld
+        stb   Key_Held
+@rts    rts
+```
+
+Utilise les routines monitor `KTST` (Key TeST) et `GETC` (GET Character).
+
+Voir [references/keyboard-input.md](references/keyboard-input.md).
+
+## `MapKeyboardToJoypads`
+
+Permet de jouer **au clavier** en mappant des touches sur les masques joypad. Le code dispatch :
+```asm
+        cmpa  #8                        ; touche flèche gauche
+        bne   >
+        orb   #c1_button_left_mask
+        ; ...
+        cmpa  #9                        ; touche flèche droite
+        ; ...
+        cmpa  #10                       ; flèche bas
+        ; ...
+        cmpa  #11                       ; flèche haut
+        ; ...
+        (autres touches = boutons)
+```
+
+Codes :
+- 8 = LEFT
+- 9 = RIGHT
+- 10 = DOWN
+- 11 = UP
+- (autres = mapping custom pour A/B)
+
+## Pitfalls
+
+- **`InitJoypads` non appelé** : `$E7CC`/`$E7CD` non configurés → lectures incohérentes
+- **Lire `$E7CC` directement sans `ReadJoypads`** : pas de débouncing, pas de Press/Held
+- **Confondre `c1_button_B_mask` ($04) et `c1_button_left_mask` ($04)** : même valeur mais sur registres différents (Fire vs Dpad)
+- **Tester `Dpad_Held` avec `c1_button_A_mask`** : masque pour Fire, pas Dpad
+- **`Dpad_Press` non clear après use** : peut déclencher plusieurs fois la même action si testé plusieurs fois
+- **`joypad.buffer` non init** : buffer plein de 0, comportement bizarre
+- **Megadrive 6 boutons sans le driver md6** : seuls 2 boutons accessibles
+- **`KTST` / `GETC` depuis IRQ** : monitor routines pas re-entrant, possible crash
+
+## Références détaillées
+
+- [references/joypad-reading.md](references/joypad-reading.md) — InitJoypads détaillé (config PIA CRA/CRB/DDRA/ORA), ReadJoypads V1 vs V2, masques c1_* / c2_* / c_* / dpad/butn, format $E7CC / $E7CD (bits inversés), distinction Press/Held (front montant), pattern d'usage par frame
+- [references/joypad-buffer.md](references/joypad-buffer.md) — Circular buffer 16 entrées, joypad.buffer.direction / write.ptr / read.ptr, addDirection / getDirection, pattern combo detection (fighter, codes secrets)
+- [references/megadrive-6-buttons.md](references/megadrive-6-buttons.md) — joypad.md6 driver, mécanique TH/TR/TL multiplex, 7 cycles de line select, pinout TO8 vs Megadrive, états Up/Down/Left/Right + A/B/C/Start + X/Y/Z/Mode, adaptateur physique
+- [references/keyboard-input.md](references/keyboard-input.md) — ReadKeyboard via KTST + GETC monitor, Key_Press / Key_Held, codes touches Thomson, MapKeyboardToJoypads (mapping 8=LEFT, 9=RIGHT, 10=DOWN, 11=UP, autres=boutons), alternative pour test sans joypad

--- a/skills/thomson-to8-engine-input/references/joypad-reading.md
+++ b/skills/thomson-to8-engine-input/references/joypad-reading.md
@@ -1,0 +1,208 @@
+# Lecture des joypads — détails
+
+## Configuration PIA — `InitJoypads`
+
+Le MC6821 (PIA) du TO8 a deux ports A et B, chacun avec 8 lignes data + 2 lignes de contrôle :
+
+| Port | Adresse OR/DDR | Adresse CR | Sémantique |
+|------|----------------|------------|------------|
+| A | `$E7CC` | `$E7CE` | Joypad directions (8 bits = 4 par joueur) |
+| B | `$E7CD` | `$E7CF` | Joypad boutons + DAC son |
+
+Selon le bit 2 du Control Register :
+- `bit 2 = 0` : `$E7CC`/`$E7CD` accède au **DDR** (Data Direction Register)
+- `bit 2 = 1` : `$E7CC`/`$E7CD` accède au **OR** (Output Register = data)
+
+### Algorithme InitJoypads
+
+```asm
+InitJoypads
+        ; 1. Passer en DDRA
+        lda   $E7CE                     ; lit CRA
+        anda  #$FB                      ; clear bit 2 → DDRA accessible
+        sta   $E7CE
+        
+        ; 2. DDRA = 0 (toutes lignes en input)
+        andb  #0
+        stb   $E7CC                     ; lignes input
+        
+        ; 3. Passer en ORA
+        ora   #$04                      ; set bit 2
+        sta   $E7CE                     ; CRA bit 2 = 1
+        
+        ; (symétrique pour CRB / DDRB / ORB)
+        lda   $E7CF
+        anda  #$FB
+        sta   $E7CF
+        andb  #0
+        stb   $E7CD
+        ora   #$04
+        sta   $E7CF
+        rts
+```
+
+Après cet appel : `$E7CC` et `$E7CD` peuvent être lus pour avoir l'état du joypad.
+
+## Format des bits sur le hardware
+
+### `$E7CC` — Directions
+
+Les bits sont **inversés** (0 = pressé, 1 = relâché) :
+
+```
+Bit : 7 6 5 4   3 2 1 0
+       └ P2 ┘   └ P1 ┘
+       R L D U  R L D U
+```
+
+Exemple : si player 1 appuie « Right + Up », `$E7CC = %11110110` (les 2 bits relachés à 1, les 2 pressés à 0).
+
+### `$E7CD` — Boutons + DAC
+
+```
+Bit : 7 6   5 4 3 2   1 0
+      A A   D D D D   B B
+      P2 P1 [6 bits DAC] P2 P1
+```
+
+Note : 6 bits centraux servent pour le DAC audio (Convertisseur Numérique-Analogique), pas pour les boutons.
+
+## `ReadJoypads` — algorithme
+
+```asm
+ReadJoypads
+        ; Lit la direction et les boutons
+        lda   $E7CC
+        coma                            ; inverse (0 = relachée → 1 = pressé)
+        sta   Dpad_Read                 ; brut
+        
+        ; Calcule Press = (nouveau & ~ancien)
+        ldb   Dpad_Held                 ; ancien
+        comb                            ; ~ancien
+        anda  Dpad_Held...              ; (simplifié)
+        sta   Dpad_Press
+        
+        ; Met à jour Held
+        lda   Dpad_Read
+        sta   Dpad_Held
+        
+        ; Idem pour Fire ($E7CD)
+        ; ...
+        rts
+```
+
+### Distinction Press / Held
+
+- `Held` : état courant après inversion (`coma`). 1 = pressé maintenant.
+- `Press` : front montant. 1 = pressé **cette frame** pour la première fois.
+
+Algorithme du front montant :
+```
+Press(t) = Held(t) AND NOT Held(t-1)
+```
+
+Utile pour distinguer :
+- **Mouvement continu** : tester `Held` (gauche tenu = déplace gauche)
+- **Action ponctuelle** : tester `Press` (saut tenu = saute une fois)
+
+## Variables exposées
+
+```asm
+; Player 1 (Dpad sur 4 bits bas, Fire sur 2 bits)
+Dpad_Read       fcb 0                   ; brut (read direct du hardware inversé)
+Dpad_Press      fcb 0                   ; front montant
+Dpad_Held       fcb 0                   ; maintenu
+
+Fire_Read       fcb 0
+Fire_Press      fcb 0
+Fire_Held       fcb 0
+```
+
+### Version 2 (V2) avec `ReadJoypads2`
+
+`ReadJoypads2` sépare clairement player 1 et player 2 dans deux variables distinctes (plus pratique pour les 2 joueurs).
+
+```asm
+; Player 1
+Joypad1_Press
+Joypad1_Held
+
+; Player 2
+Joypad2_Press
+Joypad2_Held
+```
+
+(noms exacts à vérifier dans le code engine)
+
+## Masques détaillés
+
+### Player 1
+
+```asm
+c1_button_up_mask            equ %00000001
+c1_button_down_mask          equ %00000010
+c1_button_left_mask          equ %00000100
+c1_button_right_mask         equ %00001000
+c1_button_A_mask             equ %01000000
+c1_button_B_mask             equ %00000100
+```
+
+**Important** : `c1_button_B_mask` ($04) et `c1_button_left_mask` ($04) ont la même valeur. Mais ils s'appliquent à des registres différents (`Fire_Held` pour B, `Dpad_Held` pour left). Donc pas de conflit en pratique.
+
+### Player 2
+
+```asm
+c2_button_up_mask            equ %00010000
+c2_button_down_mask          equ %00100000
+c2_button_left_mask          equ %01000000
+c2_button_right_mask         equ %10000000
+c2_button_A_mask             equ %10000000
+c2_button_B_mask             equ %00001000
+```
+
+Player 2 occupe les bits hauts (4-7) sur les mêmes octets.
+
+### Patterns d'usage
+
+```asm
+        ; Test direction P1 maintenu
+        lda   Dpad_Held
+        bita  #c1_button_left_mask
+        bne   @go_left
+        bita  #c1_button_right_mask
+        bne   @go_right
+
+        ; Test saut P1 (front montant)
+        lda   Fire_Press
+        bita  #c1_button_A_mask
+        bne   @jump
+```
+
+## Pattern d'utilisation typique
+
+```asm
+; Au boot
+        jsr   InitJoypads
+
+; MainLoop
+MainLoop
+        jsr   ReadJoypads
+        ; les variables Dpad_Press/Held/Fire_*sont à jour pour la frame
+        jsr   RunObjects                ; les objets peuvent les lire
+        ; ...
+```
+
+## Coût
+
+`ReadJoypads` : ~30-40 cycles.
+
+À 50 Hz, 50 × 40 = 2000 cycles/seconde dédiés. Négligeable.
+
+## Pitfalls
+
+- **`InitJoypads` oublié** : `$E7CC`/`$E7CD` peuvent être en output (selon état précédent) → écrasement
+- **Tester `Dpad_Held` avec masque Fire** : OK théoriquement (bits différents) mais source de confusion
+- **Modifier `Dpad_Press` / `Held`** : casse la mécanique
+- **Confondre P1 et P2 sur `Dpad_Held`** : utiliser les bons masques (`c1_*` ou `c2_*`)
+- **Lire `Press` plusieurs fois et compter sur la mise à 0** : `Press` reste à 1 toute la frame, c'est `ReadJoypads` qui le clear à la frame suivante
+- **`ReadJoypads` dans IRQ + MainLoop** : double lecture, perte d'events

--- a/skills/thomson-to8-engine-irq/SKILL.md
+++ b/skills/thomson-to8-engine-irq/SKILL.md
@@ -1,0 +1,316 @@
+---
+name: thomson-to8-engine-irq
+description: "Décrit le système d'interruption (IRQ) du Thomson TO8/TO9 game engine (Bento8/wide-dot) : IRQ manager via timer 6846 MC6846, routines IrqInit (init TIMERPT, default IrqManager), IrqSet50Hz (timer precision x8, déclenchement chaque frame, $42 dans MC6846.TCR), IrqOn / IrqOff / IrqPause / IrqUnpause, IrqSync pour synchroniser le timer avec une ligne écran spécifique (input A=line 0-255, X=timer value), variables Irq_user_routine (FDB vers la routine utilisateur), Irq_one_frame (= 312*64-1, timer pour 1 frame), Irq_one_line (= 64 cycles), IrqManager (entry IRQ avec dp=$E7, exécute Irq_user_routine), patterns UserIRQ pour PalUpdateNow / PalCycling / PalRaster_1c / MusicFrame / IrqObjSmps / IrqTimer, raster IRQ pour effets de palette à mi-écran, IrqObjSmps pour le driver SMPS (mount page Smps, jmp ,x), IrqSecond pour compter les secondes (glb_timer_frame, glb_timer compté 50 frames = 1 seconde, mn ss = 60s + s), integration avec gfxlock.bufferSwap.check pour double buffer, special mode glb_Page=0 pour éviter test RAM/ROM page switch (lecture/écriture rapide <$E6), pre/post hook user routine. Utiliser pour configurer l'IRQ utilisateur, synchroniser le rendu avec le VBL, mettre en place des effets raster (changement palette ou registre vidéo à mi-écran), intégrer un driver audio dans l'IRQ, gérer un timer en secondes, mettre/lever en pause les IRQ pendant une opération critique. Mots-clés : IrqInit, IrqOn, IrqOff, IrqPause, IrqUnpause, IrqSync, IrqSet50Hz, IrqManager, IrqObjSmps, IrqSecond, IrqTimer, Irq_user_routine, Irq_one_frame, Irq_one_line, UserIRQ, TIMERPT, MC6846.TCR, MC6846.TMSB, $6019 STATUS, $42 timer precision, 6846 timer, 312 lignes, 64 cycles per line, 50Hz, 60Hz, gfxlock.bufferSwap.check, glb_Page, glb_timer, glb_timer_frame, glb_timer_minute, glb_timer_second, raster IRQ, palette raster, scanline IRQ, Smps integration, SFXPriorityVal, TempoTimeout, CurrentTempo, StopMusic, FadeOut, FadeIn, VoiceTblPtr, SFXVoiceTblPtr, DACEnabled, andcc EF, orcc 10, sei, cli."
+machines: [to8, to8d, to9, to9+]
+user-invocable: false
+---
+
+# IRQ — Thomson TO8/TO9 Game Engine
+
+Le système d'IRQ permet d'exécuter du code **à intervalle régulier** (typiquement chaque VBL = 50 Hz) en parallèle de la `MainLoop`. C'est ce qui rend possibles : la musique synchronisée, le double-buffer vidéo, les effets raster palette, et le compteur temps réel.
+
+Ce skill couvre : la mécanique du timer 6846, les routines de gestion (`IrqInit`/`IrqSync`/`IrqOn`/`IrqOff`), les patterns de `UserIRQ`, l'intégration avec `gfxlock` et l'audio.
+
+---
+
+## Vue d'ensemble
+
+```
+Boot :  IrqInit  →  TIMERPT = IrqManager
+        IrqSet50Hz  ou  IrqSync  →  configure timer
+        configure Irq_user_routine = UserIRQ
+        IrqOn  →  active CPU IRQ
+
+Run :   À chaque tick timer (50 Hz typiquement) :
+          Hardware → IRQ → IrqManager
+          IrqManager : pre-hooks engine
+                       jsr Irq_user_routine (= UserIRQ)
+                       post-hooks engine
+                       RTI
+```
+
+## Hardware — timer 6846 (MC6846)
+
+Le 6846 est le timer hardware du TO8.
+
+```asm
+MC6846.TCR    equ  $6010-$6018          ; Timer Control Register (selon offset)
+MC6846.TMSB   equ  $6014                ; Timer MSB
+MC6846.TLSB   equ  $6015                ; Timer LSB
+```
+
+(Adresses exactes selon `engine/system/to8/map.const.asm`.)
+
+Le timer décompte du value `TMSB:TLSB` vers 0 ; à 0, il déclenche une IRQ et redémarre.
+
+### `IrqInit`
+
+```asm
+IrqInit
+        ldd   #IrqManager
+        std   TIMERPT                   ; pointer IRQ vers notre manager
+        rts
+```
+
+`TIMERPT` (`$6024`) est le vecteur IRQ. On y pose `IrqManager` (notre routine engine).
+
+### `IrqSet50Hz`
+
+```asm
+IrqSet50Hz
+        ldb   #$42
+        stb   MC6846.TCR                ; timer precision x8
+        ldd   #Irq_one_frame
+        std   MC6846.TMSB
+        jsr   IrqOn
+        rts
+```
+
+Configure le timer pour 1 IRQ par frame (50 Hz).
+
+`Irq_one_frame = 312*64-1 = 19967` :
+- 312 lignes par frame (PAL)
+- 64 cycles par ligne (à 1 MHz)
+- -1 car le timer launch à -1 (compte 0 → -1 → reload)
+
+### `IrqSync`
+
+Synchronise le timer avec une **ligne écran spécifique**. Utile pour les effets raster.
+
+```asm
+IrqSync                                 ; A=ligne, X=timer
+        ; ... attend que la ligne soit atteinte ...
+        ldd   #...
+        std   MC6846.TMSB
+        rts
+```
+
+Usage :
+```asm
+        lda   #255                      ; sync ligne 255 (hors zone visible)
+        ldx   #Irq_one_frame
+        jsr   IrqSync
+```
+
+L'IRQ se déclenche désormais à la ligne 255 (juste avant le retour de balayage, donc pendant le VBL → safe pour modifier la palette).
+
+## `IrqOn` / `IrqOff` / `IrqPause` / `IrqUnpause`
+
+```asm
+IrqOn
+        lda   $6019
+        ora   #$20
+        sta   $6019                     ; STATUS bit 5 = IRQ enable
+        andcc #$EF                      ; CPU : flag I = 0 (IRQ enabled)
+        rts
+
+IrqOff
+        lda   $6019
+        anda  #$DF
+        sta   $6019                     ; STATUS bit 5 = 0
+        orcc  #$10                      ; CPU : flag I = 1 (IRQ masked)
+        rts
+```
+
+`IrqOn` / `IrqOff` modifient **à la fois** le hardware (registre STATUS) et le CPU (flag I).
+
+`IrqPause` / `IrqUnpause` sont des versions « stack-safe » qui se souviennent de l'état précédent :
+
+```asm
+        jsr   IrqPause                  ; off + remember
+        ; ... section critique ...
+        jsr   IrqUnpause                ; restore previous state
+```
+
+Permet d'imbriquer sans risque d'oublier de réactiver les IRQ.
+
+## `IrqManager` — le dispatcher
+
+```asm
+IrqManager
+        ; pre-hooks engine (e.g. read joypads, save bank)
+        jsr   Irq_user_routine          ; appel utilisateur
+        ; post-hooks engine
+        rti
+```
+
+L'IRQ est lancée par le hardware. `IrqManager` :
+1. Sauve les registres si nécessaire (le 6809 sauvegarde automatiquement A,B,DP,X,Y,U,PC sur la pile à l'IRQ, mais pas tous selon flags)
+2. Exécute des hooks engine (pre)
+3. Appelle `Irq_user_routine`
+4. Exécute des hooks engine (post)
+5. `rti` (return from interrupt)
+
+### `glb_Page = 0` — special mode
+
+Quand `glb_Page = 0`, le manager **ne fait pas** le test RAM/ROM pour le page switch — il assume RAM toujours. Économie de cycles pour les modes intensifs (tile rendering).
+
+## `Irq_user_routine`
+
+```asm
+Irq_user_routine    fdb   0             ; pointeur 2 octets vers UserIRQ
+```
+
+Variable globale qui pointe la routine utilisateur appelée à chaque IRQ. À configurer au boot :
+
+```asm
+        jsr   IrqInit
+        ldd   #UserIRQ                  ; notre routine
+        std   Irq_user_routine
+        lda   #255
+        ldx   #Irq_one_frame
+        jsr   IrqSync
+        jsr   IrqOn
+```
+
+## Patterns de `UserIRQ`
+
+### Minimal (palette seule)
+
+```asm
+UserIRQ
+        jmp   PalUpdateNow
+```
+
+Saute directement à PalUpdateNow qui termine par `rts`.
+
+### Avec gfxlock + audio (typique)
+
+```asm
+UserIRQ
+        jsr   gfxlock.bufferSwap.check
+        jsr   PalUpdateNow
+        _MountObject ObjID_ymm
+        _ymm.processFrame
+        _MountObject ObjID_vgc
+        _MusicFrame_objvgc
+        rts
+```
+
+### Avec raster
+
+```asm
+UserIRQ
+        jsr   PalRaster_1c              ; raster palette
+        jsr   PalUpdateNow              ; (overwrite ce que raster a fait pour la zone normale)
+        rts
+```
+
+### Avec SMPS (sonic-2)
+
+```asm
+UserIRQ_Pal_Smps
+        jsr   PalUpdateNow
+        jmp   MusicFrame                ; SMPS tick
+```
+
+Plusieurs UserIRQ peuvent coexister, bascule par modification de `Irq_user_routine`.
+
+## `IrqObjSmps`
+
+Wrapper pour appeler le driver SMPS comme un objet :
+
+```asm
+IrqObjSmps
+        lda   Obj_Index_Page+ObjID_Smps
+        sta   <$E6                      ; mount Smps page
+        lda   #4                        ; MusicFrame routine id
+        ldx   Obj_Index_Address+2*ObjID_Smps
+        jmp   ,x                        ; call Smps + rti
+```
+
+Intégration de SMPS dans le système d'objet. Utilisé par sonic-2.
+
+## `IrqSecond` — compteur temps réel
+
+```asm
+IrqSecond
+        lda   glb_timer_frame
+        inca
+        cmpa  #50                       ; 50 frames = 1 seconde
+        bne   @skip
+        ldd   glb_timer
+        incb                            ; +1 seconde
+        cmpb  #60                       ; 60 secondes = 1 minute
+        bne   >
+        ldb   #0
+        inca                            ; +1 minute
+!       std   glb_timer
+        lda   #0
+@skip   sta   glb_timer_frame
+        rts
+```
+
+Variables :
+```asm
+glb_timer_frame                ; compte 0-49
+glb_timer_second               ; compte 0-59
+glb_timer_minute               ; compte 0-99 typiquement
+glb_timer  = glb_timer_minute  ; alias 2 octets pour ldd
+```
+
+À appeler dans UserIRQ pour avoir un compteur précis :
+```asm
+UserIRQ
+        jsr   IrqSecond                  ; compte le temps écoulé
+        ; ...
+        rts
+```
+
+Affichage : `glb_timer_minute:glb_timer_second` (e.g. pour un score / time bonus).
+
+## Effets raster — palette à mi-écran
+
+```asm
+        ; Setup
+        lda   #100                      ; ligne 100 (milieu écran)
+        ldx   #Irq_one_frame
+        jsr   IrqSync
+        ldd   #UserIRQ_RasterMid
+        std   Irq_user_routine
+
+UserIRQ_RasterMid
+        ; on est à la ligne 100, on peut changer une couleur
+        lda   #new_color
+        sta   $E7DA
+        ; reconfigurer pour la prochaine IRQ (fin de frame typiquement)
+        lda   #255
+        ldx   #Irq_one_frame
+        jsr   IrqSync                   ; OK depuis IRQ ? cf. doc
+        rti
+```
+
+Pattern plus avancé : multiples IRQ par frame pour cascade d'effets raster.
+
+## DP dans UserIRQ — important
+
+Le monitor système TO8 positionne `DP = $E7` **avant d'appeler le handler IRQ**, et `IrqManager` confirme ça avec `setdp $E7`. C'est ce qui permet aux routines appelées depuis UserIRQ (PalUpdateNow, PalRaster_1c, ...) d'utiliser `<$DA`/`<$DB`/`<$DC` etc. pour accéder aux registres hardware $E7xx en 1 cycle de moins.
+
+**Conséquence pratique** :
+- Dans UserIRQ et dans les routines appelées depuis UserIRQ : `<addr` OK pour $E7xx
+- Si tu modifies DP dans UserIRQ : restaurer avant le `rts` (`pshs dp` / `puls dp`)
+- Dans le code main résident : DP non garanti, **ne pas** utiliser `<addr` sans setup explicite
+
+Voir `thomson-to8-engine-memory-model/references/direct-page-usage.md` pour les patterns DP complets.
+
+## Pitfalls
+
+- **`<addr` (Direct Page) appelé depuis le code main** : DP n'est pas garanti dans le code résident, écriture au mauvais endroit. Bug silencieux. À ne JAMAIS faire dans `org $6100` / MainLoop sans setup explicite.
+- **Modifier DP dans UserIRQ sans restore** : casse les routines suivantes qui assument DP=$E7. Toujours `pshs dp` / `puls dp` autour des modifications.
+- **`Irq_user_routine` à 0** : `jsr` vers $0000 → crash
+- **`IrqOn` sans `IrqInit`** : `TIMERPT` non set, IRQ saute n'importe où
+- **`Irq_user_routine` qui ne se termine pas par `rts`** : la `rti` de IrqManager n'est pas atteinte → état CPU instable
+- **`andcc #$EF`** au lieu de `orcc #$10` (ou inverse) : inversion du flag I
+- **Modifier `Irq_user_routine` pendant une IRQ** : race condition, peut sauter à la mauvaise routine
+- **Routine UserIRQ trop longue** : déborde sur le frame suivant, l'IRQ suivante arrive avant la fin → re-entrée
+- **`rti` au lieu de `rts` dans UserIRQ** : pop le PC + flags depuis la pile (incorrect, le manager s'occupe du rti)
+- **Modifier `glb_Page`** : casse le special mode, ralentissement
+- **Effet raster avec mauvais timing IRQ** : changement de palette au mauvais moment → flicker
+
+---
+
+## Références détaillées
+
+- [references/irq-init-and-sync.md](references/irq-init-and-sync.md) — IrqInit / IrqSet50Hz / IrqSync détaillés, calcul Irq_one_frame (312*64-1), MC6846 hardware, TIMERPT vecteur, configuration timer precision x8, IrqOn / IrqOff / IrqPause / IrqUnpause stack-safe
+- [references/user-irq-patterns.md](references/user-irq-patterns.md) — Patterns UserIRQ : minimal (palette), gfxlock + audio (ymm/vgc), SMPS, raster, IrqSecond compteur, intégration multiple, IRQ routine length budget, ordre d'appel
+- [references/raster-irq.md](references/raster-irq.md) — IRQ pour effets raster : IrqSync sur ligne spécifique, multiples IRQ par frame, changement palette mi-écran, sync hardware spot via `<$E7`, calibrage tempo, intégration avec PalRaster_1c

--- a/skills/thomson-to8-engine-irq/references/irq-init-and-sync.md
+++ b/skills/thomson-to8-engine-irq/references/irq-init-and-sync.md
@@ -1,0 +1,205 @@
+# IRQ init et synchronisation
+
+## `IrqInit`
+
+```asm
+IrqInit
+        ldd   #IrqManager
+        std   TIMERPT                   ; vecteur IRQ = IrqManager
+        rts
+```
+
+`TIMERPT` est le vecteur IRQ système du Thomson TO8 (adresse mémoire fixe). En y plaçant `IrqManager`, on s'assure que toute IRQ générée par le timer 6846 sautera dans notre routine.
+
+## `IrqSet50Hz`
+
+```asm
+IrqSet50Hz
+        ldb   #$42
+        stb   MC6846.TCR                ; timer precision x8
+        ldd   #Irq_one_frame
+        std   MC6846.TMSB               ; timer reload value
+        jsr   IrqOn
+        rts
+```
+
+Configure le timer 6846 pour une IRQ par frame (50 Hz).
+
+### MC6846.TCR (Timer Control Register)
+
+```
+Bits :    0 1 2 3 4 5 6 7
+          | | | | | | | |
+          | | | | | | | └─ pre-set (1) ou pré-set hold (0)
+          | | | | | | └─── timer enable (1)
+          | | | | | └───── interrupt enable (1)
+          | | | | └─────── interrupt mode (1=internal)
+          | | | └───────── output ?
+          | | └─────────── pre-scaler ÷8 (1) ou ÷1 (0)
+          | └───────────── output ?
+          └─────────────── ?
+```
+
+`$42 = %01000010` :
+- bit 1 : timer enable
+- bit 6 : pre-scaler ÷8 (?) (à vérifier)
+
+### `Irq_one_frame`
+
+```asm
+Irq_one_frame    equ 312*64-1
+Irq_one_line     equ 64
+```
+
+- **312 lignes** par frame (mode PAL)
+- **64 cycles** par ligne (à 1 MHz)
+- `-1` car le timer compte 0 → -1 → reload
+
+= 19967 cycles (~ 20 ms)
+
+## `IrqSync`
+
+Synchronise le timer avec une **ligne écran spécifique**. Utile pour les effets raster ou pour aligner l'IRQ sur le VBL.
+
+```asm
+IrqSync                                 ; A=ligne (0-255), X=timer value
+        ; ... attend que le spot soit à la ligne A ...
+        stx   MC6846.TMSB               ; charge le nouveau timer
+        rts
+```
+
+Usage :
+```asm
+        lda   #255                      ; sync ligne 255 (~ fin de frame, VBL)
+        ldx   #Irq_one_frame
+        jsr   IrqSync
+```
+
+L'IRQ se déclenchera désormais à la ligne 255 — c'est-à-dire **pendant le VBL** (les lignes 256-311 sont hors zone visible). C'est le moment idéal pour :
+- Modifier la palette sans tearing
+- Swap les buffers vidéo (gfxlock)
+- Modifier les registres vidéo
+
+### Pattern recommandé
+
+```asm
+        jsr   IrqInit                   ; pointeur vers IrqManager
+        ldd   #UserIRQ                  ; notre routine
+        std   Irq_user_routine
+        lda   #255                      ; sync VBL
+        ldx   #Irq_one_frame
+        jsr   IrqSync
+        _gfxlock.init                   ; init double buffer (après sync)
+        jsr   IrqOn                     ; enable IRQ
+```
+
+## `IrqOn` / `IrqOff`
+
+```asm
+IrqOn
+        lda   $6019                     ; STATUS register
+        ora   #$20                      ; bit 5 = IRQ enable
+        sta   $6019
+        andcc #$EF                      ; clear flag I (CPU)
+        rts
+
+IrqOff
+        lda   $6019
+        anda  #$DF                      ; bit 5 = 0
+        sta   $6019
+        orcc  #$10                      ; set flag I (CPU mask IRQ)
+        rts
+```
+
+### `$6019` — STATUS register
+
+`$6019` est le registre de statut système (?) du TO8. Bit 5 = IRQ enable.
+
+### Flag I du CPU 6809
+
+Le 6809 a un flag I (Interrupt) dans le registre CC :
+- `I = 0` : IRQ enabled (CPU les accepte)
+- `I = 1` : IRQ masked (CPU les ignore)
+
+`andcc #$EF` clear le bit 4 ($10) → I = 0 (enable).
+`orcc #$10` set le bit 4 → I = 1 (mask).
+
+## `IrqPause` / `IrqUnpause` — stack-safe
+
+```asm
+IrqPause
+        pshs  a
+        lda   $6019
+        anda  #$20
+        bne   @irqoff                   ; était activé
+        lda   #0
+        sta   @irqst                    ; mémorise "était off"
+        bra   >
+@irqoff lda   #1
+        sta   @irqst                    ; mémorise "était on"
+        jsr   IrqOff
+!       puls  a,pc
+
+IrqUnpause
+        pshs  a
+        lda   #0
+@irqst  equ   *-1                       ; lit l'état mémorisé
+        beq   >                         ; était off → reste off
+        jsr   IrqOn                     ; était on → restore
+!       clr   @irqst
+        puls  a,pc
+```
+
+Pattern d'usage :
+```asm
+        jsr   IrqPause                  ; off + remember
+        ; section critique : accès hardware sensible
+        ; pas d'IRQ pendant ce code
+        jsr   IrqUnpause                ; restore previous state
+```
+
+L'état précédent est stocké dans `@irqst` (variable interne). Permet d'imbriquer plusieurs sections sans perdre l'état initial.
+
+## Cycle complet d'IRQ
+
+```
+1. CPU exécute une instruction
+2. Timer 6846 atteint 0
+3. Hardware déclenche IRQ
+4. CPU :
+   - Sauve PC, U, Y, X, DP, B, A, CC sur la pile S (auto)
+   - I bit = 1 (mask further IRQ)
+   - Saute à l'adresse en TIMERPT = IrqManager
+5. IrqManager :
+   - Pre-hooks engine (read joypads, etc.)
+   - jsr [Irq_user_routine] = UserIRQ
+   - Post-hooks engine
+6. rti :
+   - Restore PC, U, Y, X, DP, B, A, CC depuis la pile
+   - I bit restoré (= 0 typiquement)
+7. CPU reprend l'instruction interrompue
+```
+
+Coût total : ~50-100 cycles pour le manager + cycles UserIRQ.
+
+## Calcul de fréquence
+
+À 1 MHz et `Irq_one_frame = 19967` :
+```
+fréquence = 1000000 / 19968 ≈ 50.08 Hz
+```
+
+Suffisamment proche de 50 Hz pour synchroniser avec le VBL PAL.
+
+Pour 60 Hz : `Irq_one_frame_60Hz = 262 * 64 - 1 = 16767` (262 lignes en NTSC). Mais le TO8 est PAL, donc 50 Hz standard.
+
+## Pitfalls
+
+- **`IrqInit` non appelé** : `TIMERPT` non set → IRQ saute n'importe où
+- **`IrqOn` sans `IrqSync` ou `IrqSet50Hz`** : timer non configuré, IRQ continue à la mauvaise fréquence (ou jamais)
+- **`Irq_one_frame` modifié à la main** : casse la sync 50 Hz
+- **`IrqOn` dans une routine appelée depuis IRQ** : double activation, comportement imprévisible
+- **`IrqPause` sans `IrqUnpause`** : IRQ reste off → musique coupée, écran figé
+- **`andcc #$EF` au lieu de `orcc #$10`** (ou inverse) : inverse l'effet
+- **TIMERPT modifié par une autre routine** : redirige les IRQ ailleurs
+- **`IrqInit` re-appelé pendant le run** : potentielle race condition (IRQ pendant qu'on change TIMERPT)

--- a/skills/thomson-to8-engine-irq/references/user-irq-patterns.md
+++ b/skills/thomson-to8-engine-irq/references/user-irq-patterns.md
@@ -1,0 +1,243 @@
+# Patterns d'UserIRQ
+
+## Variable `Irq_user_routine`
+
+```asm
+Irq_user_routine    fdb   0
+```
+
+Pointeur 2 octets vers la routine utilisateur. Configurée au boot :
+
+```asm
+        ldd   #UserIRQ
+        std   Irq_user_routine
+```
+
+L'IRQ manager fait `jsr [Irq_user_routine]` à chaque tick.
+
+## ⚠️ Important : DP = $E7 dans UserIRQ
+
+Quand UserIRQ s'exécute, le registre **DP du 6809 vaut `$E7`** — c'est garanti par :
+1. Le monitor système TO8 qui pose DP=$E7 avant de sauter au handler IRQ
+2. `IrqManager` qui confirme via `setdp $E7` au début
+
+Cela permet d'utiliser **l'adressage direct page** dans UserIRQ pour accéder aux registres hardware en `$E7xx` (palette, PIA, gate array) avec 1 cycle économisé par instruction :
+
+```asm
+UserIRQ
+        ; DP = $E7 ici → <$DB ≡ $E7DB (1 cycle de moins que $E7DB)
+        lda   <$DB                ; palette index register
+        lda   <$DD                ; screen border
+        rts
+```
+
+C'est ce qui rend `PalUpdateNow`, `PalRaster_1c`, etc. très rapides — elles utilisent massivement `<$DA`/`<$DB`.
+
+**Inversement, dans le code main résident**, DP n'est PAS positionné automatiquement → ne **JAMAIS** utiliser `<addr` dans le code main d'un game-mode sauf setup explicite. Cf. `thomson-to8-engine-memory-model/references/direct-page-usage.md`.
+
+**Si tu modifies DP dans UserIRQ** (e.g. tu set DP=$9F pour accéder à ta zone DP user), pense à le restaurer à $E7 avant `rts` — sinon les hooks engine post-UserIRQ ne fonctionneront pas. Le pattern recommandé :
+
+```asm
+UserIRQ
+        pshs  dp                   ; sauve DP=$E7
+        ; ... change DP, fait du travail ...
+        puls  dp                   ; restaure DP=$E7
+        rts
+```
+
+## Patterns courants
+
+### 1. Minimal (palette seule)
+
+```asm
+UserIRQ
+        jmp   PalUpdateNow              ; (termine par rts, donc jmp OK)
+```
+
+Pour un game-mode sans gfxlock ni audio. Suffit pour appliquer les changements de palette demandés.
+
+### 2. Avec gfxlock + double-buffer
+
+```asm
+UserIRQ
+        jsr   gfxlock.bufferSwap.check  ; swap buffers si rendu prêt
+        jsr   PalUpdateNow
+        rts
+```
+
+Le `bufferSwap.check` est crucial : il fait le swap **uniquement si** `gfxlock.status = 0` (rendu fini). Sinon il attend.
+
+### 3. Avec audio ymm + vgc (pattern courant)
+
+```asm
+UserIRQ
+        jsr   gfxlock.bufferSwap.check
+        jsr   PalUpdateNow
+        _MountObject ObjID_ymm
+        _ymm.processFrame
+        _MountObject ObjID_vgc
+        _MusicFrame_objvgc
+        rts
+```
+
+L'ordre est important :
+1. Buffer swap (avant que la nouvelle frame commence à être tracée)
+2. Palette update (les changements de palette demandés dans la frame précédente)
+3. Audio tick (les chips audio sont updatés à la fin)
+
+### 4. Avec SMPS (sonic-2 style)
+
+```asm
+UserIRQ_Pal_Smps
+        jsr   PalUpdateNow
+        jmp   MusicFrame                ; SMPS tick + rts
+```
+
+Plus simple : pas de gfxlock dans sonic-2 (utilise `WaitVBL`).
+
+### 5. Avec raster (mid-screen palette change)
+
+```asm
+UserIRQ_Raster
+        jsr   PalRaster_1c              ; change palette ligne par ligne
+        jsr   PalUpdateNow              ; restore palette normale en fin
+        jmp   MusicFrame
+```
+
+L'ordre permet d'avoir l'effet raster pendant l'affichage, puis revenir à la palette normale pour la prochaine frame.
+
+### 6. Avec timer (compteur temps réel)
+
+```asm
+UserIRQ
+        jsr   gfxlock.bufferSwap.check
+        jsr   PalUpdateNow
+        jsr   IrqSecond                  ; compte le temps
+        ; audio ...
+        rts
+```
+
+## Bascule entre plusieurs UserIRQ
+
+```asm
+        ; Configuration 1 : intro avec raster
+        ldd   #UserIRQ_Raster
+        std   Irq_user_routine
+
+        ; ... attendre que l'intro soit finie ...
+
+        ; Configuration 2 : gameplay normal
+        ldd   #UserIRQ_Normal
+        std   Irq_user_routine
+```
+
+La modification de `Irq_user_routine` est immédiate (prochaine IRQ utilise la nouvelle adresse).
+
+> **Race condition possible** : si on modifie `Irq_user_routine` pendant que l'IRQ est en cours, le `jsr [Irq_user_routine]` peut sauter à mi-modification. Pour être 100% safe : `IrqPause` avant la modif, `IrqUnpause` après.
+
+## Ordre d'appel — règles
+
+### À mettre AVANT l'audio
+- `gfxlock.bufferSwap.check` : peut être bloquant si rendu non fini, doit être tôt
+- `PalUpdateNow` : applique les couleurs avant que l'IRQ déclenche d'autres effets
+
+### À mettre APRÈS l'audio
+- `IrqSecond` : compte le temps, indépendant du reste
+- Mises à jour de variables globales non-critiques
+
+### Tout au début
+- `gfxlock.bufferSwap.check` : si on lui fait le swap, on veut que ça soit aussi tôt que possible pour minimiser le tearing
+
+### Tout à la fin
+- Routines qui peuvent prendre du temps si on est sûr qu'elles ne ratent pas la fin de la frame
+
+## Budget temps
+
+L'IRQ a un budget **strict** : doit finir avant la prochaine IRQ (= 20 ms = 20000 cycles à 1 MHz).
+
+En pratique :
+- `bufferSwap.check` : ~50-100 cycles
+- `PalUpdateNow` : ~150 cycles (déroulée) ou ~225 (lean)
+- `_ymm.processFrame` : ~1500 cycles (avec compression)
+- `_MusicFrame_objvgc` : ~1000-1500 cycles
+- `IrqSecond` : ~30 cycles
+- **Total typique** : ~3000-4000 cycles (~15-20 % du budget)
+
+Reste ~16000 cycles pour la MainLoop par frame.
+
+### Dépassement du budget
+
+Si UserIRQ prend > 20000 cycles, la prochaine IRQ arrive **avant** la fin → re-entrée. Le CPU 6809 a un flag I qui masque les IRQ pendant l'exécution d'une IRQ, donc la re-entrée n'a pas lieu *immédiatement*, mais la MainLoop n'a aucun temps CPU → freeze visuel.
+
+## Pattern complexe (r-type level01)
+
+```asm
+UserIRQ
+        jsr   gfxlock.bufferSwap.check
+        jsr   PalUpdateNow
+        _MountObject ObjID_ymm01
+        _ymm.processFrame
+        ; soundFX tick (si applicable)
+        rts
+```
+
+Note : r-type a aussi un soundFX system qui tick depuis l'IRQ. Pas vu de `vgc` dans level01 (commenté dans le code).
+
+## Pattern WaitVBL (sans IRQ pour le rendu)
+
+```asm
+; Pas d'IRQ pour le rendu (cas legacy ou simple)
+MainLoop
+        jsr   WaitVBL                   ; attend le VBL manuellement
+        jsr   RunObjects
+        ; ...
+
+UserIRQ
+        jmp   PalUpdateNow              ; juste la palette via IRQ
+```
+
+`WaitVBL` est une attente bloquante synchronisée sur le VBL. Plus simple mais bloque le CPU.
+
+## Ne PAS faire dans UserIRQ
+
+- **Allouer/désallouer des objets** (`LoadObject_u`) : modifierait des structures partagées avec MainLoop sans protection
+- **Modifier `Irq_user_routine`** depuis UserIRQ : meta-modification, race condition
+- **Appels longs** (cinématique, fade complet) : déborde le budget
+- **Modifier `gfxlock.status`** : casse la mécanique du double-buffer
+- **`jsr` vers du code en page commutée sans `_MountObject`** : crash si la page n'est pas la bonne
+
+## À faire dans UserIRQ
+
+- Lectures de variables non-critiques
+- Tick audio (mécanique synchronisée timer)
+- Updates de palette (synchro VBL)
+- Compteurs temps
+- Buffer swap (gfxlock)
+
+## Restauration d'état
+
+Le 6809 sauve automatiquement à l'IRQ : `PC, U, Y, X, DP, B, A, CC` sur la pile S. À la `rti`, il restore.
+
+Si on modifie d'autres choses dans UserIRQ (bank, DP, etc.), il faut explicitement **restaurer avant `rts`** :
+
+```asm
+UserIRQ
+        pshs  dp                        ; sauve DP
+        ldd   #$E7
+        tfr   b,dp                      ; DP = $E7 pour accès direct page
+        ; ... travail ...
+        puls  dp                        ; restore DP
+        rts
+```
+
+`PalUpdateNow` le fait (`pshs dp` / `puls dp,pc`).
+
+## Pitfalls
+
+- **`Irq_user_routine` à 0** : `jsr` vers $0000 → crash
+- **UserIRQ qui se termine sans `rts`** : tombe sur du code aléatoire → crash
+- **`rti` au lieu de `rts` dans UserIRQ** : pop additionnel sur la pile, déséquilibre
+- **Modifications non protégées de variables partagées** : MainLoop voit des valeurs incohérentes
+- **Allocation d'objet dans UserIRQ** : race condition avec MainLoop
+- **`pshs` sans `puls`** : pile corrompue
+- **DP non restauré** : appelant crash

--- a/skills/thomson-to8-engine-math-rng/SKILL.md
+++ b/skills/thomson-to8-engine-math-rng/SKILL.md
@@ -1,0 +1,349 @@
+---
+name: thomson-to8-engine-math-rng
+description: "Décrit les routines mathématiques et le RNG du Thomson TO8/TO9 game engine (Bento8/wide-dot) : CalcSine pour sinus/cosinus rapide via table (input B = angle 0-255 = 0-360 degrés, output D = 255*sin, X = 255*cos, table sinewave.bin de 256 entrées + 128 offset cos), CalcAngle pour arctangente y/x via division logarithmique + table atan + ajustement octants (input D=y signed 16 bits, X=x signed 16 bits, output B = angle 0-255 avec 0 à l'est et progression horaire), Mul9x16 pour multiplication signed 9 bits × signed 16 bits (result = product/256, input D=multiplier 9-bit, X=multiplicand 16-bit, output D), RandomNumber et InitRNG pour pseudo-random (seed initialisé depuis $E7C6 timer hardware, algorithme par Samuel Devulder utilisant lsra/rorb/eorb), macro _rnda pour générer un nombre aléatoire entre min et max (range = max-min+1 multiplié par RandomNumber + min), format fixed-point 8.8 et 16.8 pour positions/vitesses, conventions d'angle 0-255 (256 degrés au lieu de 360 pour exploiter l'arithmétique 8 bits, 255=360°, 192=90°, 128=180°, 64=270°), tables pré-calculées (sinewave.bin), code par Johan Forslof (doynax) pour atan2 6502 porté en 6809. Utiliser pour calculer un déplacement angulaire, trouver l'angle vers le joueur (IA d'ennemis), générer un déplacement aléatoire, tirer au sort une variante d'objet, multiplier des coordonnées (e.g. position * vitesse), initialiser le RNG au boot. Mots-clés : CalcSine, CalcAngle, Mul9x16, RandomNumber, InitRNG, RNG_seed, _rnda, _rnd, Sine_Data, sinewave.bin, atan2, arctangent, sinus, cosinus, 256 degrees, 360 degrees, angle 0-255, signed 9 bit, signed 16 bit, fixed-point 8.8, multiplier, multiplicand, doynax, Forslof, Samuel Devulder, pseudo-random, seed, $E7C6 timer."
+machines: [to8, to8d, to9, to9+]
+user-invocable: false
+---
+
+# Math et RNG — Thomson TO8/TO9 Game Engine
+
+L'engine fournit des **routines mathématiques** optimisées 6809 pour le gameplay :
+
+| Routine | Rôle | Cycles ~ |
+|---------|------|----------|
+| `CalcSine` | sin + cos | ~30 |
+| `CalcAngle` | atan2 | ~150-200 |
+| `Mul9x16` | multiplication 9×16 | ~50 |
+| `RandomNumber` | PRNG | ~25 |
+| `InitRNG` | init PRNG | ~10 |
+| `_rnda` macro | aléatoire entre min et max | ~50 |
+
+---
+
+## Convention d'angle — 0-255 (256 degrés)
+
+```
+255 = 360°  (= 0°)
+192 = 270°
+128 = 180°
+64  = 90°
+0   = 0°
+```
+
+Note : c'est **256 degrés** au lieu de 360. Choix : exploite l'arithmétique 8 bits (overflow automatique à 255+1 = 0).
+
+Sens horaire :
+```
+       0
+       ↑
+ 192 ←   → 64
+       ↓
+      128
+```
+
+(0 = est, progression horaire)
+
+---
+
+## `CalcSine` — sinus et cosinus
+
+```asm
+        ldb   #angle                    ; angle 0-255
+        jsr   CalcSine
+        ; D = 255 * sin(angle)
+        ; X = 255 * cos(angle)
+```
+
+Implémentation :
+```asm
+CalcSine
+        ldx   #Sine_Data
+        anda  #0                        ; A = 0
+        aslb                            ; *2 (table 2 octets/entrée)
+        rola
+        leax  d,x
+        ldd   ,x                        ; sin
+        leax  $80,x                     ; cos = sin + 90° (= +128 → +256 entries × 2 = +$80)
+        ldx   ,x                        ; cos
+        rts
+
+Sine_Data
+        INCLUDEBIN "./engine/math/sinewave.bin"
+```
+
+Table : `sinewave.bin` = 256 entrées de 2 octets (512 octets total). Chaque entrée = `255 * sin(angle * 360/256)` en signed 16.
+
+Le cos est calculé en lisant l'entrée à `+$80` (= +128 angles = +90°).
+
+### Output signed 16-bit
+
+`D` et `X` sont signed 16 bits (-255 à +255 environ).
+
+Pour utiliser comme vitesse 8.8 :
+```asm
+        jsr   CalcSine
+        ; D = sin scalé sur 255
+        ; Pour vitesse : divisible par une vitesse
+        ;   D / 4 = vitesse modulée par sin
+```
+
+Voir [references/sine-cosine-table.md](references/sine-cosine-table.md).
+
+---
+
+## `CalcAngle` — arctangente y/x
+
+```asm
+        ldd   #y                        ; D = y signed 16-bit
+        ldx   #x                        ; X = x signed 16-bit
+        jsr   CalcAngle
+        ; B = angle 0-255
+```
+
+Calcule `atan2(y, x)` = angle pour aller du point (0,0) au point (x,y).
+
+Algorithme (par Johan Forslof / doynax, porté en 6809) :
+1. Down-scale les valeurs 16-bit en 9-bit (perte de précision mais OK pour angles)
+2. Division logarithmique de y/x
+3. Lookup dans table atan
+4. Ajustement d'octant (selon les signes de x et y)
+
+Coût : ~150-200 cycles selon le chemin.
+
+### Usage typique — IA qui vise
+
+```asm
+        ; Ennemi en (enemy_x, enemy_y), cible en (player_x, player_y)
+        ldd   <player_y
+        subd  <enemy_y                  ; D = delta y
+        ldx   <player_x                 ; (load player_x)
+        ; sub X from current enemy_x...
+        ; (calcul du delta x via une intermédiation)
+        ldx   <delta_x_computed
+        jsr   CalcAngle
+        stb   <enemy_angle              ; angle vers le joueur
+
+        ; Maintenant on peut faire avancer l'ennemi dans cette direction
+        ldb   <enemy_angle
+        jsr   CalcSine
+        ; D = sin(angle), X = cos(angle)
+        ; Utilise comme x_vel/y_vel scalé
+```
+
+Voir [references/atan2-logarithmic.md](references/atan2-logarithmic.md).
+
+---
+
+## `Mul9x16` — multiplication 9×16
+
+```asm
+        ldd   #multiplier               ; D = signed 9-bit
+        ldx   #multiplicand             ; X = signed 16-bit
+        jsr   Mul9x16
+        ; D = (product / 256)
+```
+
+Multiplication signed sur 9 et 16 bits, résultat scalé par 1/256.
+
+Le 6809 a un `MUL` natif (8×8 → 16) mais pas plus. Pour multiplier 9×16, il faut une routine logicielle.
+
+Variables internes (DP) :
+```asm
+@m      equ dp_engine                   ; multiplier signé
+@m_h    equ dp_engine+1                 ; multiplicand high
+@m_l    equ dp_engine+2                 ; multiplicand low
+@r_h    equ dp_engine+3                 ; result high
+@r_l    equ dp_engine+4                 ; result low
+@r      equ dp_engine+5                 ; ?
+```
+
+### Cas d'usage
+
+- Multiplier une vitesse par un facteur scalable
+- Calculer une position depuis vitesse × temps
+- Apply sin/cos pour rotation
+
+---
+
+## `RandomNumber` — PRNG
+
+```asm
+        jsr   RandomNumber
+        ; D = nombre aléatoire (16 bits)
+        ; B = octet bas (souvent suffisant)
+```
+
+Algorithme par Samuel Devulder (LFSR/XOR-shift variant) :
+
+```asm
+RandomNumber
+        ldd   #0
+RNG_seed equ *-2                        ; seed mémorisée (auto-modif)
+        lsra
+        rorb
+        eorb  RNG_seed
+        stb   @a
+        rorb
+        eorb  RNG_seed+1
+        tfr   b,a
+        eora  #0
+@a      equ *-1
+        std   RNG_seed
+        rts
+```
+
+Coût : ~25 cycles. Distribution acceptable pour le gameplay (pas crypto).
+
+### `InitRNG`
+
+```asm
+InitRNG
+        ldd   $E7C6                     ; timer 6846 MSB:LSB
+        std   RNG_seed
+        rts
+```
+
+Seed depuis le timer hardware (= valeur imprévisible au boot). À appeler une fois au démarrage.
+
+> **Pourquoi `$E7C6`** : c'est le timer 6846 (`MC6846.TMSB`). Sa valeur dépend du temps écoulé depuis le power-on / reset, donc unpredictable.
+
+### Macro `_rnda`
+
+```asm
+_rnda MACRO
+        jsr   RandomNumber
+        lda   #\2-\1+1                  ; range = max - min + 1
+        mul                             ; multiplie B (du RNG) par range
+        ; B*range / 256 dans A
+ IFEQ \1-1
+        inca
+ ELSE IFNE \1
+        adda  #\1                       ; ajoute min
+ ENDC
+ ENDM
+```
+
+Usage :
+```asm
+        _rnda 0,9                       ; A = nombre aléatoire 0-9
+        _rnda 1,6                       ; A = nombre aléatoire 1-6 (dé)
+        _rnda 0,255                     ; A = octet aléatoire complet
+```
+
+Pratique pour positionner aléatoirement, tirer un subtype, etc.
+
+Voir [references/random-number.md](references/random-number.md).
+
+---
+
+## Fixed-point 8.8
+
+Format utilisé par `x_vel`, `y_vel`, `x_acl`, `y_acl` :
+- **8 bits partie entière** (signed, -128 à +127)
+- **8 bits partie fractionnaire** (0 à 0.996)
+
+Exemples :
+- `$0100` = 1.0
+- `$0080` = 0.5
+- `$0040` = 0.25
+- `$FF80` = -0.5 (signed)
+- `$FE00` = -2.0
+
+### Multiplication 8.8 × 8.8
+
+Difficile sur 6809 sans MUL 16×16. Utilise `Mul9x16` ou décompose en plusieurs MUL 8×8.
+
+Pour multiplier `(a.b) × c` (un scaling par 8 bits) :
+- `mul a × c` → produit haut
+- `mul b × c` → produit bas
+- Combine
+
+### Format 16.8
+
+Pour `x_pos`/`y_pos` : 2 octets entier + 1 octet sub-pixel = 3 octets.
+
+Permet positions absolues sur une map jusqu'à -32768/+32767.
+
+Voir [references/fixed-point-88.md](references/fixed-point-88.md).
+
+---
+
+## Patterns d'usage
+
+### Mouvement circulaire
+
+```asm
+        ; Objet qui décrit un cercle autour d'un centre
+        lda   <my_angle                 ; angle courant
+        ldb   #1                        ; speed angle
+        adda  ,
+        sta   <my_angle                 ; avance l'angle
+        
+        ldb   <my_angle
+        jsr   CalcSine
+        ; D = sin, X = cos
+        
+        ; Position = centre + radius * (cos, sin)
+        ldd   <center_x
+        addd  ,                         ; (X scaled par radius)
+        std   x_pos,u
+        ; idem pour y
+```
+
+### Visée vers le joueur
+
+```asm
+        ldd   <player_y_pos
+        subd   <y_pos,u                 ; delta y
+        ldx   <player_x_pos
+        ldx   <x_pos,u                  ; ... delta x
+        jsr   CalcAngle
+        stb   <ennemy_aim_angle
+
+        ; Calcule vitesse dans cette direction
+        ldb   <ennemy_aim_angle
+        jsr   CalcSine
+        ; D = sin/cos, scale and store as x_vel/y_vel
+```
+
+### Random spawn
+
+```asm
+        ; Position X aléatoire 0-159
+        _rnda 0,159
+        sta   x_pixel,u
+        
+        ; Position Y aléatoire 0-199
+        _rnda 0,199
+        sta   y_pixel,u
+```
+
+### Random subtype
+
+```asm
+        ; Tirer un type d'ennemi parmi 5
+        _rnda 0,4
+        sta   subtype,u
+```
+
+---
+
+## Pitfalls
+
+- **`InitRNG` non appelé** : RNG_seed = 0 → séquence prévisible identique à chaque boot
+- **Appel `RandomNumber` depuis IRQ + MainLoop** : potentielle race condition sur RNG_seed
+- **`CalcSine` avec angle > 255** : pas un problème (B est 8 bits), wrap-around automatique
+- **`CalcAngle` avec x=y=0** : indéfini mathématiquement, comportement variable
+- **`Mul9x16` avec multiplier > 9 bits** : truncation à 9 bits, résultat incorrect
+- **Mélanger 256-deg et 360-deg** : convertir explicitement (256/360 ≈ 0.711)
+- **Format fixed-point non cohérent** : un côté `$0100`=1.0 et l'autre `$0080`=1.0, déphasage
+- **Distribution `_rnda` non uniforme** pour grand range : `B*range/256` peut être biaisé sur les extrêmes
+
+---
+
+## Références détaillées
+
+- [references/sine-cosine-table.md](references/sine-cosine-table.md) — CalcSine algorithm, table sinewave.bin (256 entrées × 2 octets), output scaled by 255, cos via offset $80, conversion 256-deg vers 360-deg, génération de la table (script Python ou pré-calculé)
+- [references/atan2-logarithmic.md](references/atan2-logarithmic.md) — CalcAngle algorithm by doynax (originally 6502, port 6809), division logarithmique pour ratio y/x, table atan, ajustement octant, scaling 16-bit → 9-bit, variables DP, performance ~150 cycles
+- [references/random-number.md](references/random-number.md) — RandomNumber algorithm by Samuel Devulder, RNG_seed auto-modif, InitRNG from timer $E7C6, _rnda macro pour range, qualité statistique du PRNG, alternative SBCL plus complexe si besoin crypto
+- [references/fixed-point-88.md](references/fixed-point-88.md) — Format 8.8 fixed-point signed, exemples ($0100, $0080, $FF80), x_vel/y_vel/x_acl/y_acl, format 16.8 pour x_pos/y_pos avec sub-pixel, multiplication 8.8 × 8.8 (via MUL 8x8 ou Mul9x16), conversion vers entier

--- a/skills/thomson-to8-engine-memory-model/SKILL.md
+++ b/skills/thomson-to8-engine-memory-model/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: thomson-to8-engine-memory-model
+description: "Décrit le modèle mémoire en runtime du Thomson TO8/TO9 game engine (Bento8/wide-dot) : carte mémoire 64 Ko adressable + jusqu'à 32 pages de 16 Ko commutables, organisation par zones (cartouche $0000-$3FFF, vidéo $4000-$5FFF, système $6000-$9FFF, données paginables $A000-$DFFF, I/O $E000-$E7FF, ROM $E800-$FFFF), point d'entrée code game-mode à $6100, zone Direct Page utilisateur $9F00-$9FFF (149 octets), DP engine dp_engine ($9F00+offset), dp_extreg pour registres étendus, pile système glb_system_stack = dp (descend depuis $9FFF), variables globales en $9DFE-$9DFF, glb_ram_end = $A000-12 (marge sprites), zone des cellules BBC $6000-$7FFF, BankSwitch routines SetCartPageA / SetCartPageB / GetCartPageA / GetCartPageB pour commutation de pages cartouche (zone $0000-$3FFF), glb_Page = 0 special mode (pas de test RAM/ROM), gestion T2 vs RAM via bit 7 (négatif = T2 ROM, positif = RAM), zone data paginable via $E7E5 (CF74021.DATA), zone cartouche via $E7E6 (CF74021.CART), zone vidéo via $E7E7 (CF74021.SYS1) et $E7DD (CF74021.SYS2 = border + buffer), bit de forme MC6846.PRC $E7C3 pour half-page swap, registres globaux glb_camera_x_pos / glb_screen_location / glb_register_s, organisation des sprites compilés et leurs débordements possibles au-delà de $A000 (jusqu'à 12 octets, d'où glb_ram_end = $A000-12), distinction Variables globales persistantes (à partir de $9DFF en remontant) vs temporaires partagées (zone dp $9F00-$9FFF), nbMaxPagesRAM 16 ou 32 selon builder.to8.memoryExtension. Utiliser pour comprendre où placer du code/data, calculer l'espace disponible pour les game-modes, débugger un dépassement mémoire, comprendre la pagination, utiliser correctement SetCartPageA/B, allouer des variables globales, comprendre la pile système et ses limites. Mots-clés : memory map, $6100, $9F00, $9E00, $9DFE, $9DFF, $A000, $DFFF, $E7C0-$E7FF, dp, dp_engine, dp_extreg, glb_system_stack, glb_ram_end, glb_camera_x_pos, glb_camera_y_pos, glb_screen_location_1, glb_screen_location_2, glb_register_s, glb_force_sprite_refresh, glb_Page, MC6846, MC6821, THMFC01, EF9369, CF74021, $E7C3 PRC, $E7C5 TCR, $E7C6 TMSB, $E7C7 TLSB, $E7C8-$E7CB PIA system, $E7CC-$E7CF PIA music/game, $E7D0-$E7D7 floppy controller, $E7DA-$E7DB palette, $E7DC LGAMOD, $E7DD border, $E7E4 COM, $E7E5 DATA, $E7E6 CART, $E7E7 SYS1, $E7F4-$E7FF audio, SetCartPageA, SetCartPageB, GetCartPageA, GetCartPageB, _SetCartPageA, _SetCartPageB, BankSwitch, page commutable, T2, cartouche, RAM, ROM, builder.to8.memoryExtension, 256K, 512K, nbMaxPagesRAM, half page, GETC, KTST, DKCO, IRQ.EXIT, TIMERPT, ROM routines, Monitor."
+machines: [to8, to8d, to9, to9+]
+user-invocable: false
+---
+
+# Modèle mémoire — Thomson TO8/TO9 Game Engine
+
+Le 6809 du TO8 adresse 64 Ko (16 bits). Le TO8 utilise un système de **pagination** pour accéder à plus (jusqu'à 512 Ko avec extension). Ce skill décrit la carte mémoire en runtime et les mécanismes de commutation de pages.
+
+---
+
+## Carte mémoire 64 Ko
+
+```
+Adresse      | Zone              | Contenu                                  | Mode
+-------------|-------------------|------------------------------------------|----------
+$0000-$3FFF  | Cartouche         | Page ROM cartouche (T2) ou RAM (16 Ko)  | Commutable
+$4000-$5FFF  | Vidéo (8 Ko)      | VRAM (page écran 0 ou 1)                | Half-page swap
+$6000-$9FFF | Système (16 Ko)   | RAM résidente                            | Fixe
+$A000-$DFFF | Données (16 Ko)   | Page RAM 2-31 (selon $E7E5)             | Commutable
+$E000-$E7FF | I/O               | Registres hardware                       | Fixe
+$E800-$FFFF | ROM système       | Monitor (KTST, GETC, DKCO, etc.)       | Fixe
+```
+
+## Détail zone système ($6000-$9FFF)
+
+C'est la zone où vit le code du game-mode :
+
+```
+$6000-$7FFF  : Background Backup Cells (BBC) — 128 cellules de 64 octets
+$6100        : Point d'entrée du code game-mode (org $6100)
+$6100-$9DFD  : Code et données du game-mode
+$9DFE-$9DFF  : Variables globales persistantes (descendant)
+$9E00-$9EFF  : Espace pile système (~256 octets)
+$9F00-$9FFF  : Zone Direct Page utilisateur (149 octets max)
+              + dp_extreg + dp_engine (haut de DP)
+```
+
+### Détails
+
+- **`org $6100`** : tout code de game-mode commence là (laisse $6000-$60FF pour le bootloader)
+- **`glb_system_stack = dp = $9F00`** : la pile descend depuis $9EFF (limite haute), donc collide avec les variables globales si trop profonde
+- **`glb_ram_end = $A000-12`** : marge de 12 octets car les sprites compilés peuvent déborder de $A000 par `glb_camera_x_offset/4` octets
+
+Voir [references/memory-map-runtime.md](references/memory-map-runtime.md).
+
+## Direct Page utilisateur ($9F00-$9FFF)
+
+```asm
+dp                            equ $9F00        ; user space (149 bytes max)
+dp_engine                     equ glb_Page-32  ; engine routines tmp var space (32 bytes)
+dp_extreg                     equ dp_engine-28 ; extra register space (28 bytes)
+glb_system_stack              equ dp           ; pile = DP zone basse
+```
+
+- **DP user** : 149 octets pour l'application (variables globales temporaires, OST joueur en DP, etc.)
+- **`dp_engine`** : 32 octets réservés au moteur (cur_priority, cur_ptr_*, etc.)
+- **`dp_extreg`** : 28 octets pour les registres étendus (glb_a0, glb_d0, ...)
+
+### ⚠️ Règle critique : DP n'est pas auto-positionné
+
+L'adressage **direct page** (`<addr` ou `addr,dp`) suppose que le registre DP du 6809 contient la bonne valeur. Or **DP n'est pas garanti** au démarrage d'un game-mode (souvent à 0 ou valeur résiduelle).
+
+| Contexte | DP positionné ? | Usage de `<addr` |
+|----------|-----------------|------------------|
+| Code résident game-mode (`org $6100`, MainLoop) | NON | ❌ ne pas utiliser (sauf si tu fais `tfr` toi-même) |
+| `UserIRQ` (appelée par IrqManager) | OUI, DP=$E7 | ✅ OK pour accéder à `<$DA`, `<$DB`, etc. (registres $E7xx) |
+| Routine engine qui set DP localement (PalUpdateNow, etc.) | OUI dans la routine | ✅ OK dans le périmètre, doit restaurer DP à la sortie |
+
+**Pour le code résident, utiliser TOUJOURS l'adressage étendu** (sans `<`) :
+
+```asm
+        lda   #50
+        sta   horizon_y      ; ✅ étendu — correct quel que soit DP
+        ; sta <horizon_y     ← ❌ écrit en (DP<<8 | offset) — pas où on pense !
+```
+
+Pour set DP localement à une routine :
+```asm
+        pshs  dp
+        ldd   #$XX
+        tfr   b,dp
+        setdp $XX            ; directive LWASM (compile-time)
+        ; ... usage de <addr ...
+        setdp dp/256         ; reset directive
+        puls  dp             ; restore DP de l'appelant
+```
+
+Voir [references/direct-page-usage.md](references/direct-page-usage.md) pour les patterns détaillés.
+
+## Variables globales
+
+```asm
+glb_ram_end                   equ $A000-12     ; marge sprites
+glb_register_s                equ glb_ram_end-2 ; sauvegarde S
+glb_screen_location_1         equ glb_register_s-2
+glb_screen_location_2         equ glb_screen_location_1-2
+glb_camera_height             equ glb_screen_location_2-2
+glb_camera_width              equ glb_camera_height-2
+; ... descend de 2 octets par variable globale ...
+glb_Page                      equ glb_timer_frame-1
+```
+
+Toutes les variables globales `glb_*` sont déclarées avec `equ <précédent>-<taille>`, formant une chaîne descendante depuis `$A000`.
+
+Voir [references/global-variables.md](references/global-variables.md).
+
+## Hardware I/O ($E7C0-$E7FF)
+
+```
+$E7C0-$E7C7 : MC6846 (timer, IRQ)
+$E7C8-$E7CF : MC6821 PIA (système + audio/joypads)
+$E7D0-$E7D7 : THMFC01 (contrôleur disquette)
+$E7DA-$E7DB : EF9369 (palette)
+$E7DC-$E7DD : CF74021 (mode page + screen border)
+$E7E4-$E7E7 : CF74021 (gates : COM, DATA, CART, SYS1)
+$E7F2-$E7F3 : EF5860 MIDI
+$E7F4-$E7FF : Audio (YM2413, SN76489, MEA8000)
+```
+
+Voir constants `engine/system/to8/memory-map.equ` et `map.const.asm`.
+
+## Pages mémoire commutables
+
+### Zone $A000-$DFFF (données)
+
+Sélection de page via `$E7E5` (`CF74021.DATA`) :
+```asm
+        ldb   #2
+        stb   $E7E5                     ; mount page 2 en $A000-$DFFF
+```
+
+Pages disponibles : 0-31 (= 32 pages × 16 Ko = 512 Ko avec extension, 0-15 sinon).
+
+### Zone $0000-$3FFF (cartouche)
+
+Sélection via `$E7E6` (`CF74021.CART`) :
+```asm
+        ; bit 5 = 1 : RAM en zone cartouche
+        ; bit 5 = 0 : ROM cartouche (T2 ou autre)
+        ; bits 0-4 : numéro de page
+```
+
+L'engine utilise cette zone pour mounter dynamiquement le code des **objets** (chaque objet est sur une page paginée, mounté avant exécution par `RunObjects`).
+
+### `BankSwitch.asm` — routines de commutation
+
+```asm
+SetCartPageA
+        sta   >glb_Page                 ; sauve la page demandée
+        bpl   @RAMPg                    ; positif → page RAM
+        ; ... négatif → page T2 ROM
+        ; séquence T2 spéciale ($0555, $02AA, $0555)
+        bra   @rts
+@RAMPg  sta   >$E7E6                    ; sélection simple RAM
+@rts    rts
+
+GetCartPageA
+        lda   >glb_Page
+        bne   @rts                      ; glb_Page != 0 → utilisé
+        lda   >$E7E6                    ; sinon, lit le hardware
+@rts    rts
+```
+
+`SetCartPageA` est utilisée via la macro `_SetCartPageA` :
+```asm
+_SetCartPageA MACRO
+ IFDEF T2
+        jsr   SetCartPageA              ; via routine (gère T2)
+ ELSE
+        sta   $E7E6                     ; directement (RAM seulement)
+ ENDC
+ ENDM
+```
+
+`IFDEF T2` permet de choisir au build entre version RAM-only (rapide) et version T2-aware (gère ROM cartouche).
+
+### `glb_Page = 0` — special mode
+
+Si `glb_Page = 0`, les routines `GetCartPageA` lisent **directement le hardware** (`lda $E7E6`). Sinon elles retournent `glb_Page` (qui mémorise la dernière page demandée).
+
+Usage : permet d'éviter le test RAM/ROM dans certains modes intensifs (tile rendering). Tu mets `glb_Page = 0` quand tu sais que tout est RAM.
+
+Voir [references/bank-switching-macros.md](references/bank-switching-macros.md).
+
+## Routines monitor ROM ($E800-$FFFF)
+
+```asm
+GETC            equ $E806               ; lit un caractère clavier
+KTST            equ $E809               ; test si touche pressée
+DKCO            equ $E82A               ; routine disque (read/write)
+IRQ.EXIT        equ $E830               ; exit IRQ propre
+```
+
+À utiliser avec parcimonie (la ROM monitor n'est pas re-entrant).
+
+## Sprite buffer overflow
+
+```asm
+glb_ram_end                   equ $A000-12     ; marge !
+```
+
+Les sprites compilés peuvent déborder de $A000 (zone système → données) jusqu'à `glb_camera_x_offset/4` octets. La marge de 12 octets en haut de la zone système empêche la collision.
+
+```asm
+; compilatedsprite peut écrire jusqu'à $9FFC sans collision
+glb_register_s                equ glb_ram_end-2   ; à $9FFE - 2 = $9FFC
+glb_screen_location_1         equ glb_register_s-2 ; à $9FFA
+```
+
+À surveiller si on a beaucoup de variables globales : le code peut s'étendre vers le bas et risquer de toucher la pile.
+
+## Variables globales du moteur
+
+Liste partielle (du haut vers le bas) :
+
+```asm
+glb_ram_end                   equ $A000-12
+glb_register_s                equ glb_ram_end-2
+glb_screen_location_1         equ glb_register_s-2
+glb_screen_location_2         equ glb_screen_location_1-2
+glb_camera_height             equ glb_screen_location_2-2
+glb_camera_width              equ glb_camera_height-2
+glb_camera_x_pos_coarse       equ glb_camera_width-2
+glb_camera_x_pos              equ glb_camera_x_pos_coarse-2
+glb_camera_x_sub              equ glb_camera_x_pos-1
+glb_camera_y_pos              equ glb_camera_x_pos-2
+glb_camera_y_sub              equ glb_camera_y_pos-1
+glb_camera_x_min_pos          equ glb_camera_y_pos-2
+glb_camera_y_min_pos          equ glb_camera_x_min_pos-2
+glb_camera_x_max_pos          equ glb_camera_y_min_pos-2
+glb_camera_y_max_pos          equ glb_camera_x_max_pos-2
+glb_camera_x_offset           equ glb_camera_y_max_pos-2
+glb_camera_y_offset           equ glb_camera_x_offset-2
+glb_force_sprite_refresh      equ glb_camera_y_offset-1
+glb_camera_move               equ glb_force_sprite_refresh-1
+glb_alphaTiles                equ glb_camera_move-1
+glb_timer_second              equ glb_alphaTiles-1
+glb_timer_minute              equ glb_timer_second-1
+glb_timer                     equ glb_timer_minute
+glb_timer_frame               equ glb_timer-1
+glb_Page                      equ glb_timer_frame-1
+```
+
+Total ~50-60 octets dans le haut de la zone système.
+
+Variables applicatives à placer **après glb_Page** (descend depuis là) — par convention `globals.X` :
+
+```asm
+GLOBAL_VARIABLES              equ $9E28           ; cf r-type/global/variables.asm
+globals.nextGameMode          equ GLOBAL_VARIABLES+0
+globals.score                 equ GLOBAL_VARIABLES+1
+globals.lives                 equ GLOBAL_VARIABLES+3
+; ... etc
+```
+
+## `builder.to8.memoryExtension`
+
+Configure le nombre max de pages RAM :
+- `Y` (recommandé) : 32 pages (= 512 Ko avec extension)
+- `N` : 16 pages (= 256 Ko, TO8 sans extension)
+
+Limite dure : pas plus de **32 pages physiques** sur le TO8.
+
+## Patterns d'usage
+
+### Calcul de la mémoire restante
+
+```asm
+; Pour un game-mode :
+;   space_available = $A000 - glb_Page - taille_pile - taille_vars_app
+;                   = $9F00 - $9F00 (DP) - 256 (pile) - X
+;                   = ($9F00 - $9F00 - 256) sous-zone DP
+;                   environ 7 Ko après le code à $6100
+```
+
+À vérifier dans les `.lst` générés par le builder Java (dans `generated-code/debug/`).
+
+### Limite supérieure du code
+
+Le code doit s'arrêter **avant `$9DFE`** (ou avant les variables globales applicatives). Si on dépasse, le moteur écrase les variables → comportement erratique.
+
+L'engine peut placer une **alerte** au build :
+```asm
+        ifgt *,$9DFD
+        error "Code dépasse $9DFD"
+        endc
+```
+
+### Direct Page partagée
+
+`dp` est partagée entre :
+- Variables globales temporaires (top de la page)
+- OST joueur en DP (`player1 equ dp`, occupe ~50 octets)
+- `glb_system_stack` (descend depuis $9EFF mais commence à $9FFF si on déclare la pile en haut)
+
+Attention aux collisions !
+
+## Pitfalls
+
+- **`<addr` (direct page) dans le code résident** : DP n'est pas garanti, écriture/lecture au mauvais endroit. Toujours utiliser l'adressage étendu (`sta var` sans `<`) dans le code main du game-mode, sauf si on a explicitement positionné DP juste avant via `tfr a,dp`. Bug silencieux, pas de crash. Cf. [references/direct-page-usage.md](references/direct-page-usage.md).
+- **Code > $9DFD** : écrase les variables globales → bugs incompréhensibles
+- **Pile trop profonde** : descend dans la zone DP utilisateur → corrompt les variables
+- **Modifier `glb_Page` directement** : casse le système BankSwitch
+- **Mounter une page sans `_SetCartPageA`** : crash si T2 (séquence spéciale requise)
+- **Reading `$E7E6` directement** : OK si `glb_Page = 0`, sinon il faut lire `glb_Page` à la place
+- **Sprite compilé qui déborde de plus de 12 octets** : touche `glb_register_s` → corruption registre S
+- **Variables `globals.X` en zone DP** : conflict avec OST si player en DP
+- **Page > 31** : pas existante sur TO8 → crash
+- **DP non set runtime** : `setdp` est statique, doit être complété par `tfr a,dp` runtime
+
+---
+
+## Références détaillées
+
+- [references/memory-map-runtime.md](references/memory-map-runtime.md) — Carte mémoire 64 Ko complète : zones cartouche/vidéo/système/données/IO/ROM, $6100 boot game-mode, $A000-12 sprite overflow margin, zone BBC $6000-$7FFF, distribution typique du code + data + vars
+- [references/direct-page-usage.md](references/direct-page-usage.md) — Zone DP $9F00-$9FFF : dp_engine (32 octets engine), dp_extreg (28 octets), DP user (149 octets), pattern setdp + tfr a,dp, accès `<addr` rapide, conflits potentiels avec pile, ObjectDp pour joueur principal en DP
+- [references/global-variables.md](references/global-variables.md) — Variables globales engine glb_* (camera, screen_location, timer, page) chaînées par equ -2, layout descendant depuis $A000, GLOBAL_VARIABLES applicatives ($9E28 r-type), conventions de nommage globals.X, persistance entre game-modes
+- [references/bank-switching-macros.md](references/bank-switching-macros.md) — SetCartPageA/B + GetCartPageA/B + macros _SetCartPageA/B (IFDEF T2), glb_Page semantics (0 = special mode, bit 7 = T2), séquence T2 commutation ($0555/$02AA), différence RAM vs ROM cartouche, intégration avec RunObjects
+- [references/system-stack-and-boundaries.md](references/system-stack-and-boundaries.md) — Pile système $9EFF descendante, glb_system_stack = dp, limites supérieures du code ($9DFD), conflits potentiels code/data/stack/DP, alertes au build, marge sprites $A000-12, builder.to8.memoryExtension 16 vs 32 pages

--- a/skills/thomson-to8-engine-memory-model/references/bank-switching-macros.md
+++ b/skills/thomson-to8-engine-memory-model/references/bank-switching-macros.md
@@ -1,0 +1,211 @@
+# Bank switching — macros et routines
+
+Le 6809 adresse 64 Ko, mais le TO8 a jusqu'à 512 Ko de RAM + ROM cartouche. La **commutation de pages** permet d'accéder à toute cette mémoire en remappant dynamiquement les zones $0000-$3FFF (cartouche) et $A000-$DFFF (données).
+
+## Hardware
+
+Trois registres pour la pagination :
+
+| Registre | Adresse | Rôle |
+|----------|---------|------|
+| `$E7E5` | `CF74021.DATA` | Sélection page RAM en zone donnée ($A000-$DFFF) |
+| `$E7E6` | `CF74021.CART` | Sélection page RAM ou ROM en zone cartouche ($0000-$3FFF) |
+| `$E7E7` | `CF74021.SYS1` | Sélection page vidéo visible |
+
+### `$E7E5` (page données)
+
+```
+Bits :  0 0 0 X X X X X     ; X = numéro de page (0-31)
+```
+
+Exemple :
+```asm
+        ldb   #2
+        stb   $E7E5                     ; page 2 en $A000-$DFFF
+```
+
+Maintenant la zone $A000-$DFFF correspond physiquement à la page 2 de RAM (16 Ko).
+
+### `$E7E6` (page cartouche)
+
+```
+Bits :  W R x x x X X X X X
+        | |       └─ numéro de page (0-31)
+        | └─────── 0 = ROM cartouche (T2), 1 = RAM
+        └───────── write enable
+```
+
+- **bit 5 = 0** : zone cartouche pointe vers ROM cartouche T2
+- **bit 5 = 1** : zone cartouche pointe vers RAM (la page indiquée)
+
+C'est plus complexe que $E7E5 car la zone cartouche peut être ROM ou RAM.
+
+## Routines BankSwitch
+
+### `SetCartPageA`
+
+```asm
+SetCartPageA
+        sta   >glb_Page                 ; sauve la page demandée
+        bpl   @RAMPg                    ; positif (bit 7=0) → RAM
+        
+        ; Page T2 ROM : séquence spéciale
+        lda   >$E7E6
+        anda  #$DF                      ; clear bit 5 → ROM cartouche
+        sta   >$E7E6
+        
+        ; Séquence de commutation T2 (Megarom)
+        lda   #$F0                      ; sortie mode commande T.2
+        sta   >$0555                    ; sécurité IRQ
+        lda   #$AA                      ; séquence
+        sta   >$0555
+        lsra                            ; = $55
+        sta   >$02AA
+        lda   #$C0
+        sta   >$0555
+        
+        lda   >glb_Page
+        anda  #$7F                      ; bit 7 = 0
+        sta   >$0555                    ; sélection page T2
+        bra   @rts
+        
+@RAMPg  sta   >$E7E6                    ; RAM en zone cartouche
+@rts    rts
+```
+
+Sémantique :
+- **Page positive** (bit 7 = 0) : page RAM, écriture directe `sta $E7E6`
+- **Page négative** (bit 7 = 1) : page T2 ROM, séquence Megarom
+
+`glb_Page` mémorise la page demandée (utile pour `GetCartPageA`).
+
+### `SetCartPageB`
+
+Identique mais via le registre B.
+
+### `GetCartPageA`
+
+```asm
+GetCartPageA
+        lda   >glb_Page
+        bne   @rts                      ; glb_Page != 0 → utiliser cette valeur
+        lda   >$E7E6                    ; sinon, lire le hardware
+@rts    rts
+```
+
+**Si `glb_Page = 0`** : lit le hardware directement (mode optimisé sans tracking applicatif).
+**Si `glb_Page != 0`** : retourne la valeur mémorisée (évite la lecture hardware).
+
+### `GetCartPageB`
+
+Idem via B.
+
+## Macros utilisateur
+
+### `_SetCartPageA`
+
+```asm
+_SetCartPageA MACRO
+ IFDEF T2
+        jsr   SetCartPageA              ; gère T2 ROM
+ ELSE
+        sta   $E7E6                     ; direct (RAM seulement)
+ ENDC
+ ENDM
+```
+
+`_SetCartPageA` est la macro recommandée. Selon `IFDEF T2` :
+- Build T2 : utilise la routine `SetCartPageA` (gère ROM cartouche)
+- Build FD/RAM : utilise `sta $E7E6` directement (plus rapide)
+
+Le builder définit `T2` automatiquement quand on build pour cartouche T2.
+
+### `_GetCartPageA`
+
+```asm
+_GetCartPageA MACRO
+ IFDEF T2
+        jsr   GetCartPageA
+ ELSE
+        lda   $E7E6
+ ENDC
+ ENDM
+```
+
+### `_SetCartPageB` / `_GetCartPageB`
+
+Versions équivalentes pour `B`.
+
+## Usage typique
+
+### Mounter une page pour exécuter du code
+
+```asm
+        ldb   #ObjID_X
+        ldx   #Obj_Index_Page
+        lda   b,x                       ; charge la page de l'objet
+        _SetCartPageA                   ; mount
+        ; ... maintenant la zone $0000-$3FFF contient le code de l'objet ...
+        ldx   #Obj_Index_Address+2*ObjID_X
+        ldx   ,x                        ; charge l'adresse
+        jsr   ,x                        ; exécute
+```
+
+### Mounter une page pour lire des données
+
+```asm
+        ldb   #data_page
+        stb   $E7E5                     ; mount en zone donnée
+        ; ... maintenant $A000-$DFFF contient les data ...
+        ldx   #data_addr
+        ldd   ,x                        ; lit
+```
+
+## `glb_Page = 0` — special mode
+
+Si `glb_Page = 0`, l'engine **assume RAM toujours**. Économie :
+- `GetCartPageA` lit directement `$E7E6` au lieu de `glb_Page`
+- Pas de test bit 7 (T2 vs RAM)
+
+Utilisé pour les modes intensifs comme le tile rendering où les pages sont contrôlées de bout en bout.
+
+À mettre :
+```asm
+        clr   glb_Page                  ; ou ldb #0; stb glb_Page
+        ; ... mode rapide ...
+```
+
+À remettre à une valeur non-zéro avant de réutiliser BankSwitch.
+
+## Pagination de la zone vidéo
+
+Différente : `$E7DD` (`CF74021.SYS2`) et `$E7E7` (`CF74021.SYS1`).
+
+```asm
+$E7DD :  bits 0-3 = couleur bordure, bits 6-7 = page vidéo visible
+$E7E7 :  bits 0-1 = mode RAM/ROM/écran, ...
+```
+
+C'est `gfxlock.bufferSwap.do` qui gère ça (cf. skill graphics-pipeline).
+
+## Calcul des pages générées par le builder
+
+Le builder Java affecte automatiquement les objets à des pages RAM via un **knapsack packing** (algorithme d'optimisation pour minimiser le nombre de pages utilisées).
+
+Convention :
+- **Page 1** : résidente (boot, code engine commun, tables d'index)
+- **Page 2-3** : double-buffer vidéo (gfxlock)
+- **Page 4+** : code des objets (compilés sprites + routines)
+
+Voir skill `build-pipeline` pour le détail du packing.
+
+## Pitfalls
+
+- **Mounter une page sans `_SetCartPageA`** : `sta $E7E6` direct ignore la logique T2 → si on est en build T2, crash
+- **Oublier de restaurer la page** après usage : la routine suivante exécute la mauvaise page
+- **`glb_Page` désynchronisé du hardware** : si on écrit `$E7E6` direct sans MAJ `glb_Page`, GetCartPageA retourne la mauvaise valeur
+- **Page > 31** : pages physiques inexistantes → comportement imprévisible
+- **Bit 7 mal géré** : on peut accidentellement passer en T2 ROM au lieu de RAM
+- **`_GetCartPageA` après modification directe** : retourne `glb_Page` mémorisé, pas la vraie valeur hardware
+- **Mounter pendant une IRQ** : si la IRQ termine, la page mountée par IRQ écrase la page utilisée par le main → race condition. Sauver/restaurer DP+page si nécessaire
+- **`glb_Page = 0`** activé puis appel à une routine qui suppose tracking : la page sera lue directement, peut être incohérente

--- a/skills/thomson-to8-engine-memory-model/references/direct-page-usage.md
+++ b/skills/thomson-to8-engine-memory-model/references/direct-page-usage.md
@@ -1,0 +1,181 @@
+# Usage du Direct Page (DP)
+
+Le 6809 a un registre **DP** (Direct Page) de 8 bits qui définit la page haute pour le mode d'adressage **direct** (notation asm `<addr` ou `addr,dp`). Une instruction en mode direct économise **1 octet et 1 cycle** par accès — c'est tentant pour optimiser, mais le DP doit être **positionné explicitement** sinon les accès tombent au mauvais endroit.
+
+---
+
+## ⚠️ Règle critique : DP n'est PAS auto-positionné
+
+| Contexte | Valeur de DP au runtime | Conséquence |
+|----------|-------------------------|-------------|
+| Code résident (`org $6100` du game-mode, MainLoop, routines applicatives) | **Inconnue** (souvent 0, ou valeur résiduelle) | `<addr` lit/écrit à `(DP_actuel)*256 + offset` — généralement en `$00xx` au lieu de la zone attendue → **bug silencieux** |
+| `UserIRQ` (appelée par `IrqManager`) | **$E7** (positionné par le monitor + confirmé par `setdp $E7` dans IrqManager) | `<addr` accède aux registres `$E7xx` (palette, hardware) sans surcoût — **OK** |
+| Routine engine avec `setdp` + `tfr a,dp` explicite (ex: `PalUpdateNow`) | Valeur définie par la routine, restaurée à la sortie via `pshs dp`/`puls dp` | OK dans le périmètre de la routine |
+
+**Erreur classique** : écrire dans le code main d'un game-mode :
+```asm
+        lda   #50
+        sta   <horizon_y     ; ← FAUX si DP n'est pas set
+```
+
+Si DP vaut 0 au moment de cet appel, `sta <horizon_y` écrit en `$0000 + (horizon_y & $FF)`, c'est-à-dire **en zone cartouche** (page 0). Pas du tout là où la variable réside.
+
+**Correction** :
+```asm
+        lda   #50
+        sta   horizon_y      ; mode étendu — toujours correct
+```
+
+L'adressage étendu fait référence à l'adresse absolue (16 bits), indépendamment du DP.
+
+---
+
+## Quand utiliser le DP, quand l'éviter
+
+### ❌ Ne PAS utiliser `<addr` dans le code résident
+
+Sauf si tu **maîtrises** la valeur du DP à ce moment précis (e.g. tu viens de faire `lda #$XX; tfr a,dp` toi-même), n'utilise pas l'adressage direct.
+
+**Coût** : ~1 cycle/accès — négligeable dans 95% des cas. La sécurité prime.
+
+### ✅ Utiliser `<addr` dans `UserIRQ`
+
+Le monitor positionne **DP = $E7** avant d'appeler l'IRQ handler. `IrqManager` confirme ça avec `setdp $E7` au début. Donc dans UserIRQ :
+
+```asm
+UserIRQ
+        jsr   gfxlock.bufferSwap.check
+        jsr   PalUpdateNow       ; cette routine gère son propre DP
+        ; ICI : DP = $E7
+        ; lda <$DB                ← OK, équivalent à lda $E7DB
+        ; ...
+        rts
+```
+
+C'est ce qui permet à `PalUpdateNow` et `PalRaster_1c` d'utiliser massivement `<$DA`, `<$DB`, etc. pour les registres palette — c'est ~30% plus rapide que `$E7DA`/`$E7DB` en mode étendu.
+
+### ✅ Utiliser `<addr` dans une routine spécialisée qui set DP localement
+
+Pattern classique pour les routines engine optimisées :
+
+```asm
+MyOptimizedRoutine
+        pshs  dp                  ; sauve DP de l'appelant
+        ldd   #$9F
+        tfr   b,dp                ; positionne DP = $9F
+        setdp $9F                 ; (directive LWASM, statique)
+        
+        ; ... maintenant on peut utiliser <addr pour accéder à $9F00-$9FFF rapidement ...
+        ldd   <ma_var             ; = ldd $9F00 + offset(ma_var)
+        
+        setdp dp/256              ; (reset directive pour la suite)
+        puls  dp,pc               ; restaure DP de l'appelant
+```
+
+Note les **deux** opérations :
+1. `tfr b,dp` : positionne DP **au runtime**
+2. `setdp $9F` : indique au **compilateur LWASM** la valeur de DP, pour qu'il génère des `<addr` correctement
+
+L'oubli de `setdp` provoque des erreurs de compilation (`addr` hors range direct page) OU des `<addr` mal calculés. L'oubli de `tfr` provoque des bugs runtime.
+
+À la sortie, **toujours restaurer DP** via `puls dp` (ou via `setdp dp/256` qui n'est qu'une directive de compilation et ne change pas DP runtime — il faut bien faire les deux).
+
+### ✅ Objet joueur en Direct Page (ObjectDp)
+
+L'engine propose `ObjectDp` qui place tout un OST en Direct Page ($9F00) pour économiser des cycles sur les accès `<x_pos`, `<x_vel`, etc. Cf. skill `object-management`, référence `direct-page-object.md`. Dans ce cas, DP est mis à $9F par le code d'init et le code du joueur peut utiliser `<` librement.
+
+---
+
+## Hiérarchie de la zone DP utilisateur (`$9F00-$9FFF`)
+
+```
+$9F00  ┌───────────────────────────────────────────────────────────┐
+       │ Zone utilisateur (149 octets max)                         │
+       │  → variables globales temporaires partagées (cur_priority, │
+       │    cur_ptr_*, etc. — utilisées par les routines engine    │
+       │    qui set DP=$9F)                                         │
+       │  → OU OST du joueur principal si pattern ObjectDp         │
+       │  → OU variables applicatives au choix                     │
+       │                                                            │
+$9F95  ├───────────────────────────────────────────────────────────┤
+       │ dp_extreg (28 octets) — registres étendus (glb_a0/d0,     │
+       │ partagés entre routines engine type moveByScript)         │
+$9FB1  ├───────────────────────────────────────────────────────────┤
+       │ dp_engine (32 octets) — variables temporaires de l'engine │
+       │ (cur_priority, cur_ptr_sub_obj_erase/draw, p0..p6 pour    │
+       │ DrawHLine, etc.)                                          │
+       │                                                            │
+$9FE0  ├───────────────────────────────────────────────────────────┤
+       │ glb_Page (1 octet) + autres flags globaux                 │
+       │                                                            │
+       │ ↑ pile système descend depuis $9EFF, voire $9FFF si       │
+       │   l'application le permet                                  │
+$9FFF  └───────────────────────────────────────────────────────────┘
+```
+
+**Important** : les zones `dp_engine` et `dp_extreg` sont utilisées par des routines engine qui font `setdp $9F` localement. Ne PAS modifier ces emplacements depuis le code applicatif sauf si on sait exactement ce qu'on fait — sinon corruption silencieuse.
+
+---
+
+## Patterns concrets
+
+### Code main (résident) — accès variables globales
+
+```asm
+        org $6100
+        ; ... init ...
+        lda   #50
+        sta   horizon_y        ; ✅ mode étendu — toujours correct
+        ; sta <horizon_y       ← ❌ NE PAS faire : DP non défini ici
+
+MainLoop
+        lda   horizon_y        ; ✅ lecture étendue OK
+        ; ...
+```
+
+### UserIRQ — peut utiliser `<` pour les registres $E7xx
+
+```asm
+UserIRQ
+        ; DP = $E7 garanti par le monitor + IrqManager
+        jsr   gfxlock.bufferSwap.check    ; gère son DP en interne
+        jsr   PalUpdateNow                ; idem
+        
+        ; Si on veut écrire directement à un registre hardware $E7xx :
+        ; lda <$DC             ← OK ≡ lda $E7DC
+        ; sta <$DD             ← OK ≡ sta $E7DD
+        rts
+```
+
+### Routine engine optimisée (e.g. PalUpdateNow)
+
+```asm
+PalUpdateNow
+        tst   PalRefresh
+        bne   @rts
+        pshs  dp               ; sauve DP (peut être $E7 si appelée depuis IRQ, autre sinon)
+        ldd   #$E7
+        tfr   b,dp             ; positionne DP = $E7
+        ; (à ce point, setdp $E7 est en vigueur côté compilation)
+        ldx   Pal_current
+        sta   <$DB             ; = sta $E7DB (1 cycle économisé)
+        ; ... boucle qui écrit dans <$DA, <$DB ...
+        com   PalRefresh
+        puls  dp,pc            ; restaure DP de l'appelant
+        setdp dp/256           ; reset directive pour le code suivant
+@rts    rts
+```
+
+L'idée : **set DP dans le périmètre de la routine, restore à la sortie**. C'est le seul moyen sûr de bénéficier du DP optimisé dans un environnement où le DP global n'est pas garanti.
+
+---
+
+## Pitfalls
+
+- **`sta <var` dans le code résident** : DP non défini → écriture au mauvais endroit. Le bug est silencieux (pas de crash, juste une valeur perdue).
+- **`setdp $XX` sans `tfr a,dp`** : la directive compile bien (en supposant DP=$XX) mais le runtime utilise un autre DP → mauvais accès.
+- **`tfr a,dp` sans `setdp $XX`** : le runtime est correct mais LWASM peut refuser de compiler `<addr` s'il ne pense pas que addr est dans la page DP.
+- **Oublier `pshs dp / puls dp`** dans une routine qui change DP : casse l'appelant.
+- **Modifier `dp_engine` / `dp_extreg`** depuis le code applicatif : corrompt les routines engine (cur_priority, glb_a0/d0, etc.) → bugs erratiques.
+- **Compter sur DP=$00 par défaut** : c'est probablement le cas au boot mais pas garanti après que le code engine en ait modifié.
+- **`<addr` dans une fonction appelée depuis plusieurs contextes** (résident + IRQ) : DP variable selon le contexte → comportement erratique. Préférer adressage étendu OU set DP localement.

--- a/skills/thomson-to8-engine-new-game/SKILL.md
+++ b/skills/thomson-to8-engine-new-game/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: thomson-to8-engine-new-game
+description: "Décrit la création d'un nouveau jeu dans game-projects/ avec le Thomson TO8/TO9 game engine (Bento8 / wide-dot) : organisation des dossiers, fichiers de configuration .properties (projet, game-mode, objet), squelette du main.asm (point d'entrée $6100, double buffering gfxlock, IRQ utilisateur, allocation dynamique d'objets), squelette d'un objet (table de routines, jump table indirect, AnimateSprite, DisplaySprite), conventions de palette et d'act, déclaration RAM (Dynamic_Object_RAM, nb_dynamic_objects, ext_variables_size), pipeline de compilation par le java-generator BuildDisk. Utiliser lors de la création d'un nouveau game-project, de l'ajout d'un nouveau game-mode (titre, niveau, écran de chargement), de l'ajout d'un nouvel objet (joueur, ennemi, projectile, décor, HUD), de la configuration des cibles fd/t2/t2flash (disquette, cartouche megarom T2, cartouche flash SDDRIVE), du choix d'un sprite-pack (background-erase, overlay, ext-pack), de la définition d'animations (v00 simple ou v02 advanced avec durée et flags par frame), ou du paramétrage du builder LWASM (pragma, includeDirs, define, debug, useCache, maxTries). Mots-clés : game-projects, config-windows.properties, config-macos.properties, config-linux.properties, main.properties, gameModeBoot, gameMode.X, engine.asm.boot.fd, engine.asm.boot.t2, engine.asm.boot.t2flash, engine.asm.RAMLoader.fd, engine.asm.RAMLoaderManager, builder.lwasm, builder.diskName, builder.t2Name, builder.generatedCode, builder.constAnim, builder.to8.memoryExtension, builder.compilatedSprite, engine.asm.mainEngine, object.X, palette.X, actBoot, act.X.palette, act.X.screenBorder, act.X.backgroundImage, act.X.backgroundSolid, act.X.objectPlacement, gameModeCommon, code=, common-code=, sprite.X, animation.X, animation-data, sound.X, data.X, tileset.X, spriteIndex, animationIndex, RAM, NB0, NB1, ND0, ND1, XB0, XB1, YB0, YB1, XYB0, XYB1, DMAP, DZX0, _full, _autopal, _resetAnim, _goBackNFrames, _goToAnimation, _nextRoutine, _resetAnimAndSubRoutine, _nextSubRoutine, InitGlobals, InitStack, InitDrawSprites, LoadAct, IrqInit, IrqSync, IrqOn, Irq_user_routine, Irq_one_frame, UserIRQ, gfxlock, _gfxlock.init, _gfxlock.on, _gfxlock.off, _gfxlock.loop, gfxlock.bufferSwap, EraseSprites, DrawSprites, CheckSpritesRefresh, UnsetDisplayPriority, AnimateSprite, AnimateSpriteSync, DisplaySprite, RunObjects, LoadObject_u, LoadObject_x, UnloadObject_u, ObjID_, GmID_, Pal_, Ani_, Img_, Bgi_, _MountObject, _RunObjectSwap, routine,u, id,u, subtype,u, anim,u, priority,u, render_flags,u, status_flags,u, x_pos, y_pos, x_pixel, y_pixel, xy_pixel, x_vel, y_vel, Dynamic_Object_RAM, nb_dynamic_objects, nb_graphical_objects, ext_variables_size, object_size, AABB_lists, AABB_list, $6100, $9F00, sprite-background-erase-pack, sprite-background-erase-ext-pack, sprite-overlay-pack, ZX0, Exomizer, knapsack, LWASM, fd, t2, T2 flash, SDDRIVE."
+machines: [to8, to8d, to9, to9+]
+user-invocable: false
+---
+
+# Créer un nouveau game dans le framework Bento8 / wide-dot (Thomson TO8/TO9)
+
+Ce skill explique comment créer un **nouveau jeu** dans le repo `thomson-to8-game-engine` selon les conventions actuelles du framework. Il décrit la structure de dossiers, les fichiers `.properties` à fournir, et le squelette ASM 6809 à écrire.
+
+Pour des informations exhaustives sur chaque fichier ou syntaxe, voir les références listées en fin de page.
+
+---
+
+## Vue d'ensemble — anatomie d'un game-project
+
+Tout jeu vit dans `game-projects/<nom-du-jeu>/`. La structure canonique est :
+
+```
+game-projects/<nom-du-jeu>/
+├── config-windows.properties        ← configuration du build (obligatoire)
+├── config-macos.properties          ← variante optionnelle
+├── config-linux.properties          ← variante optionnelle
+├── config-windows.t2.properties     ← variante optionnelle pour cartouche T2
+├── game-mode/
+│   └── <mode>/
+│       ├── main.properties          ← déclaration du game-mode
+│       ├── main.asm                 ← code 6809 du game-mode (ORG $6100)
+│       └── ram-data.asm             ← variables RAM, déclaration Dynamic_Object_RAM
+└── objects/
+    └── <objet>/
+        ├── <objet>.properties       ← code, sprites, animations
+        ├── <objet>.asm              ← code 6809 de l'objet (table de routines)
+        └── image/                   ← PNG sources
+```
+
+Le **java-generator** (`java-generator/`, classe `BuildDisk`) lit le `config-<os>.properties`, parcourt récursivement les `main.properties` de chaque `gameMode.X`, puis chaque `object.X`, génère les constantes `ObjID_<nom>`, `GmID_<nom>`, `Ani_<nom>`, `Img_<nom>`, `Pal_<nom>`, `Bgi_<nom>`, compile les sprites en code 6809 dépaqueté, et empaquète tout dans une image disquette `.fd` ou cartouche `.t2`/`.t2flash`.
+
+Pour la structure de dossiers et conventions de nommage en détail, voir [references/project-organization.md](references/project-organization.md).
+
+---
+
+## Les trois niveaux de fichiers `.properties`
+
+### 1. Niveau projet : `config-<os>.properties`
+
+À la racine du game-project. Définit :
+
+- les chemins vers le loader engine (`engine.asm.boot.fd/t2/t2flash`, `engine.asm.RAMLoader*`)
+- le game-mode de démarrage (`gameModeBoot=...`) et la liste des game-modes (`gameMode.X=./game-mode/X/main.properties`)
+- les paramètres du builder (`builder.lwasm`, `builder.diskName`, `builder.debug`, `builder.compilatedSprite.useCache`, etc.)
+
+Voir [references/config-properties.md](references/config-properties.md) pour la liste exhaustive des ~25 clés acceptées.
+
+### 2. Niveau game-mode : `game-mode/<mode>/main.properties`
+
+Déclare un mode de jeu (titre, niveau, écran de chargement). Contient :
+
+- le chemin du `main.asm` (`engine.asm.mainEngine=...`)
+- la liste des objets actifs dans ce mode (`object.<Nom>=...`)
+- la liste des palettes (`palette.Pal_<Nom>=...`)
+- la définition des actes (sous-états sans rechargement disquette : `actBoot`, `act.<nom>.palette/screenBorder/backgroundImage/...`)
+
+Voir [references/gamemode-properties.md](references/gamemode-properties.md).
+
+### 3. Niveau objet : `objects/<objet>/<objet>.properties`
+
+Déclare un objet (joueur, ennemi, décor, HUD). Contient :
+
+- le chemin du code asm (`code=...`)
+- les sprites (`sprite.Img_X=image.png;variants`)
+- les animations (`animation.Ani_X=fps;Img_A;Img_B;_resetAnim`)
+- optionnellement sons, données binaires, tilesets
+
+Voir [references/object-properties.md](references/object-properties.md).
+
+---
+
+## Le code ASM 6809
+
+### Squelette d'un game-mode (`main.asm`)
+
+Le pattern de référence (école « code inliné classique » utilisée par `r-type`, `bubble-bobble`, `sonic-2`, `2026`) est :
+
+```asm
+        opt   c,ct
+
+SOUND_CARD_PROTOTYPE equ 1
+
+        INCLUDE "./engine/system/to8/memory-map.equ"
+        INCLUDE "./engine/system/to8/map.const.asm"
+        INCLUDE "./engine/constants.asm"
+        INCLUDE "./engine/macros.asm"
+        INCLUDE "./engine/graphics/buffer/gfxlock.macro.asm"
+
+        org   $6100
+
+        jsr   InitGlobals
+        jsr   InitDrawSprites
+        jsr   InitStack
+        jsr   LoadAct               ; généré par le builder à partir de actBoot
+
+        ; allouer l'objet de départ
+        jsr   LoadObject_u
+        lda   #ObjID_<Player>
+        sta   id,u
+
+        ; configurer l'IRQ utilisateur
+        jsr   IrqInit
+        ldd   #UserIRQ
+        std   Irq_user_routine
+        lda   #255
+        ldx   #Irq_one_frame
+        jsr   IrqSync
+        _gfxlock.init
+        jsr   IrqOn
+
+MainLoop
+        jsr   RunObjects
+        jsr   CheckSpritesRefresh
+        _gfxlock.on
+        jsr   EraseSprites
+        jsr   UnsetDisplayPriority
+        jsr   DrawSprites
+        _gfxlock.off
+        _gfxlock.loop
+        bra   MainLoop
+
+UserIRQ
+        jsr   gfxlock.bufferSwap.check
+        jsr   PalUpdateNow
+        rts
+
+        INCLUDE "./game-mode/<mode>/ram-data.asm"
+
+        ; routines moteur à inclure en queue (cf. référence)
+        INCLUDE "./engine/InitGlobals.asm"
+        ; ... etc
+```
+
+Voir [references/mainasm-skeleton.md](references/mainasm-skeleton.md) pour le squelette complet (toutes les includes engine, UserIRQ avec son, déclaration de `ram-data.asm`, variantes overlay/background-erase, etc.).
+
+### Squelette d'un objet (`<objet>.asm`)
+
+Tout objet suit cette structure :
+
+```asm
+        INCLUDE "./engine/macros.asm"
+
+<Nom>                                  ; point d'entrée = nom exact de l'objet (camelcase ou PascalCase)
+        lda   routine,u
+        asla                           ; multiplie par 2 (table de fdb)
+        ldx   #<Nom>_Routines
+        jmp   [a,x]                    ; saut indirect
+
+<Nom>_Routines
+        fdb   Init                     ; routine 0
+        fdb   Main                     ; routine 1
+        ; ... autant de routines que nécessaire
+
+Init
+        ldd   #Ani_<defaultAnim>
+        std   anim,u
+        ldb   #4                       ; priorité d'affichage (1=front, 8=back)
+        stb   priority,u
+        ; Position centre du sprite — règle : center = ceil(taille/2)-1
+        ; (cf. references/object-skeleton.md, point critique !)
+        ldd   #$80AF                   ; position écran (x_pixel=$80, y_pixel=$AF)
+        std   xy_pixel,u
+        ; OBLIGATOIRE si le sprite est compilé en variant ND* (sans backup) :
+        ; sinon l'engine cherche un erase qui n'existe pas → sprite invisible
+        lda   render_flags,u
+        ora   #render_overlay_mask
+        sta   render_flags,u
+        inc   routine,u                ; passe en routine 1 au prochain RunObjects
+        rts
+
+Main
+        ; logique frame par frame
+        jsr   AnimateSprite
+        jmp   DisplaySprite
+```
+
+Voir [references/object-skeleton.md](references/object-skeleton.md) pour les offsets OST (`x_pos`, `y_pos`, `x_vel`, `render_flags`, `status_flags`, `routine_secondary`, `anim_frame`, etc.), les variantes de boucle, les conventions d'`Init`/`Main`, la manipulation de l'AABB de collision, et les patterns Sync vs non-Sync.
+
+---
+
+## Workflow recommandé pour créer un nouveau jeu
+
+1. **Copier un projet existant proche du besoin** (par exemple `game-projects/2026/` ou `game-projects/test/` pour un projet minimaliste) plutôt que partir d'une feuille blanche
+2. **Renommer** les références : `builder.diskName`, `builder.t2Name`, les noms des game-modes (`gameModeBoot`, `gameMode.X`)
+3. **Adapter `config-windows.properties`** : pointer les loader engine, fixer les paramètres builder, déclarer le ou les game-modes
+4. **Créer le game-mode initial** : `main.properties` + `main.asm` + `ram-data.asm`
+5. **Créer un premier objet minimal** (joueur ou décor) : `<obj>.properties` + `<obj>.asm` + un sprite PNG
+6. **Lancer le build** Java :
+   ```bash
+   cd java-generator
+   mvn clean compile assembly:single
+   java -jar target/build-disk-*.jar ../game-projects/<nom>/config-windows.properties
+   ```
+7. **Tester** dans DCMOTO ou un émulateur (le `.fd` est dans `./dist/<diskName>.fd` du game-project)
+
+---
+
+## Conventions de nommage des constantes générées
+
+Le builder crée automatiquement ces constantes à partir des entrées `.properties` :
+
+| Préfixe | Source | Exemple |
+|---------|--------|---------|
+| `ObjID_<Nom>` | `object.<Nom>=...` dans `main.properties` | `ObjID_Player`, `ObjID_Bubble` |
+| `GmID_<Nom>` | `gameMode.<Nom>=...` dans `config-<os>.properties` | `GmID_TitleScreen`, `GmID_level01` |
+| `Pal_<Nom>` | `palette.<Nom>=...` dans `main.properties` | `Pal_background`, `Pal_black` |
+| `Img_<Nom>` | `sprite.Img_<Nom>=...` dans l'`.properties` de l'objet | `Img_Player_Idle_001` |
+| `Ani_<Nom>` | `animation.Ani_<Nom>=...` dans l'`.properties` de l'objet | `Ani_Player_Walk` |
+| `Bgi_<actName>` | `act.<actName>.backgroundImage=...` | `Bgi_default`, `Bgi_titleScreen` |
+
+Le nom dans le `.properties` est conservé tel quel — pas de transformation. La convention de fait dans le repo est **PascalCase** pour `ObjID_/GmID_`, **Pal_/Img_/Ani_** comme préfixe explicite.
+
+---
+
+## Pitfalls fréquents
+
+- **`<addr` (Direct Page) dans le code main d'un game-mode** : DP n'est PAS positionné automatiquement dans le code résident. Toujours utiliser l'adressage étendu (`sta horizon_y` et pas `sta <horizon_y`) sauf si on a explicitement fait `tfr a,dp` juste avant. Le bug est silencieux : la donnée écrit en `(DP)*256+offset`, pas à l'adresse attendue. Cf. [references/mainasm-skeleton.md](references/mainasm-skeleton.md) section « Règle critique Direct Page ». Exception : dans `UserIRQ`, DP=$E7 garanti par le monitor → `<$DA`/`<$DB` etc. OK.
+- **Sprite ND* sans `render_overlay_mask`** : le plus piégeux — sprite compilé en variant `ND0`/`ND1`/`XD*`/etc. (Normal Draw sans backup) ET `render_overlay_mask` non posé dans `render_flags,u` à l'init → le sprite est **invisible**, sans erreur. L'engine attend un code d'erase qui n'existe pas. Cf. [references/object-skeleton.md](references/object-skeleton.md) section « Règles critiques ».
+- **Position d'un sprite calculée comme `taille/2`** : la convention CENTER utilise `ceil(taille/2)-1`, pas `taille/2`. Sprite 160 px centré X = `x_pixel = 79`, pas 80. Si erreur d'un pixel, peut faire déborder hors écran et l'engine **ne dessine pas du tout** (clipping out). Cf. [references/object-skeleton.md](references/object-skeleton.md).
+- **`InitDrawSprites` manquant** : si on utilise `sprite-background-erase-pack` ou `-ext-pack`, l'appel à `InitDrawSprites` est obligatoire avant `LoadObject_u` (sinon les buffers d'effacement ne sont pas alloués).
+- **`palette` manquante dans le `main.properties`** : le builder lève une exception « palette not found ». Au moins une `palette.Pal_X=...` est obligatoire.
+- **Le `act` référencé par `actBoot` n'existe pas** : aucune erreur au build, mais `LoadAct` ne fera rien et l'écran restera noir.
+- **Oubli d'`inc routine,u` dans `Init`** : l'objet reste bloqué en routine 0 et `Init` est rappelée à chaque frame.
+- **`Dynamic_Object_RAM` sous-dimensionné** : si `nb_dynamic_objects` est trop petit, `LoadObject_u` retourne avec le flag Z mis (échec) ; toujours tester ce flag après l'appel.
+- **`builder.to8.memoryExtension=N`** limite à 16 pages RAM (256 Ko). Mettre `Y` (32 pages / 512 Ko) pour tout jeu non-trivial, sauf si on cible une machine sans extension.
+
+---
+
+## Références détaillées
+
+- [references/project-organization.md](references/project-organization.md) — Arborescence canonique, dossiers obligatoires/optionnels, conventions de nommage, `cfg/`, `global/`, `resources/`, `tmp/`, `generated-code/`, `dist/`
+- [references/config-properties.md](references/config-properties.md) — Toutes les clés du `config-<os>.properties` : `engine.asm.boot.fd/t2/t2flash`, `engine.asm.RAMLoader*`, `gameModeBoot`, `gameMode.X`, `builder.lwasm/pragma/includeDirs/define`, `builder.debug/logToConsole/parallel`, `builder.diskName/t2Name/generatedCode/constAnim`, `builder.to8.memoryExtension`, `builder.compilatedSprite.useCache/maxTries`, `builder.exobin`, `builder.hxcfe`, variantes fd / t2 / t2flash
+- [references/gamemode-properties.md](references/gamemode-properties.md) — `engine.asm.mainEngine`, `gameModeCommon.<n>`, `object.<Nom>`, `palette.<Nom>`, `actBoot`, `act.<nom>.palette/screenBorder/backgroundImage/backgroundSolid/objectPlacement`, sémantique de l'Act, ordre d'attribution des `ObjID_`
+- [references/object-properties.md](references/object-properties.md) — `code`, `common-code`, `sprite.X=file;variants;RAM` avec syntaxe complète (`NB0,NB1,ND0,ND1,XB0,XB1,YB0,YB1,XYB0,XYB1,DMAP,DZX0`, ref image, `:` autopal, `_full`/_autopal), `animation.X` v00 et v02, `animation-data`, `sound.X`, `data.X`, `tileset.X=file;nb,cols,rows,centerMode,mapFile,mapBitDepth`, `spriteIndex=RAM`, `animationIndex=RAM`
+- [references/mainasm-skeleton.md](references/mainasm-skeleton.md) — Squelette `main.asm` complet école 2 (`gfxlock`+IRQ+LoadObject_u), variantes avec/sans musique YM2413+SN76489, choix du sprite-pack (`sprite-background-erase-pack` vs `-ext-pack` vs `sprite-overlay-pack`), section UserIRQ canonique, déclaration `ram-data.asm`, includes engine recommandées et leur ordre
+- [references/object-skeleton.md](references/object-skeleton.md) — Squelette d'objet (entry point + jump table), offsets OST `id`/`subtype`/`render_flags`/`status_flags`/`priority`/`anim`/`anim_frame`/`anim_frame_duration`/`anim_flags`/`x_pos`/`y_pos`/`xy_pixel`/`x_pixel`/`y_pixel`/`x_vel`/`y_vel`/`routine`/`routine_secondary`/`routine_tertiary`/`routine_quaternary`, conventions Init/Main, `AnimateSprite` vs `AnimateSpriteSync`, `DisplaySprite`, dépôts d'AABB pour la collision (`_Collision_AddAABB`), création d'objets fils (`LoadObject_x` + `sta id,x`)

--- a/skills/thomson-to8-engine-new-game/references/config-properties.md
+++ b/skills/thomson-to8-engine-new-game/references/config-properties.md
@@ -1,0 +1,250 @@
+# `config-<os>.properties` — référence exhaustive
+
+Le fichier `config-<os>.properties` à la racine du game-project est le **point d'entrée du builder Java** (classe `Game` chargée par `BuildDisk.main`). Il déclare le loader engine, les game-modes et tous les paramètres de build.
+
+Format : `clé=valeur` (java.util.Properties, supporté par `OrderedProperties` qui préserve l'ordre d'insertion). Les commentaires commencent par `#` ou `!`.
+
+---
+
+## Convention de variantes par OS
+
+Le builder ne distingue pas les OS par le suffixe ; c'est juste une convention humaine. On choisit le fichier à passer en argument :
+
+```bash
+java -jar build-disk.jar ./config-windows.properties
+java -jar build-disk.jar ./config-macos.properties
+java -jar build-disk.jar ./config-linux.properties
+```
+
+La seule différence entre les variantes est typiquement le chemin de `builder.lwasm` (binaire spécifique à la plateforme) et `builder.exobin` / `builder.hxcfe`.
+
+---
+
+## Section 1 — Engine ASM source code (loader)
+
+Les chemins vers le code asm du **loader** que le builder copie en mémoire ROM/RAM/cartouche.
+
+| Clé | Obligatoire ? | Rôle |
+|-----|---------------|------|
+| `engine.asm.boot.fd` | OUI | Bootloader disquette (lit le secteur 0 et lance `RAMLoaderManager`) |
+| `engine.asm.RAMLoaderManager.fd` | OUI | Manager qui décompresse les pages RAM depuis la disquette |
+| `engine.asm.RAMLoader.fd` | OUI | Routine de décompression (zx0 ou exomizer) |
+| `engine.asm.boot.t2` | OUI | Bootloader cartouche T2 (ROM Mega) |
+| `engine.asm.RAMLoaderManager.t2` | OUI | Manager de pages pour T2 |
+| `engine.asm.RAMLoader.t2` | OUI | Routine de décompression pour T2 |
+| `engine.asm.boot.t2flash` | OUI | Bootloader cartouche T2 flash (SDDRIVE) |
+| `engine.asm.t2flash` | OUI | Module spécifique à la cartouche flash |
+
+> Toutes ces clés sont **obligatoires** même si on ne build que pour disquette. Le builder lève une exception sinon (cf. `Game.java` lignes 105-145).
+
+**Pattern standard** (chemins relatifs depuis le game-project) :
+
+```properties
+engine.asm.boot.fd=../../engine/boot/boot-fd.asm
+engine.asm.RAMLoaderManager.fd=../../engine/ram/RAMLoaderManagerFd.asm
+engine.asm.RAMLoader.fd=../../engine/ram/zx0/RAMLoaderFd.asm
+
+engine.asm.boot.t2=../../engine/boot/boot-t2.asm
+engine.asm.RAMLoaderManager.t2=../../engine/ram/RAMLoaderManagerT2.asm
+engine.asm.RAMLoader.t2=../../engine/ram/zx0/RAMLoaderT2.asm
+
+engine.asm.boot.t2flash=../../engine/boot/boot-t2-flash.asm
+engine.asm.t2flash=../../engine/megarom-t2/t2-flash.asm
+```
+
+**Variantes de compression** :
+
+```properties
+# Compression ZX0 (recommandée — meilleur ratio)
+engine.asm.RAMLoader.fd=../../engine/ram/zx0/RAMLoaderFd.asm
+
+# Compression Exomizer (plus rapide à décoder)
+# engine.asm.RAMLoader.fd=../../engine/ram/exo/RAMLoaderFd.asm
+```
+
+Le choix se fait aussi en posant ou non `builder.exobin=...` (voir section 3).
+
+---
+
+## Section 2 — Game definition
+
+| Clé | Obligatoire ? | Rôle |
+|-----|---------------|------|
+| `gameModeBoot` | OUI | Nom du game-mode chargé au démarrage (doit matcher une clé `gameMode.X`) |
+| `gameMode.<X>=path` | OUI (≥ 1) | Déclare un game-mode et son `main.properties` |
+
+```properties
+gameModeBoot=TitleScreen
+gameMode.TitleScreen=./game-mode/00/main.properties
+gameMode.level01=./game-mode/01/main.properties
+gameMode.level02=./game-mode/02/main.properties
+```
+
+Le builder génère une constante `GmID_<X>` pour chaque entrée, indexée selon l'ordre d'apparition (préservé grâce à `OrderedProperties`).
+
+**Désactiver temporairement un game-mode** : commenter la ligne (`#gameMode.level02=...`). Le builder ignore les `gameMode` commentés mais conserve les autres.
+
+---
+
+## Section 3 — Build parameters (LWASM)
+
+Paramètres passés à l'assembleur LWASM.
+
+| Clé | Obligatoire ? | Valeur | Rôle |
+|-----|---------------|--------|------|
+| `builder.lwasm` | OUI | chemin | Exécutable LWASM (Linux/macOS/Windows) |
+| `builder.lwasm.pragma` | OUI (vide accepté) | `undefextern`, `autobranchlength,noforwardrefmax`, ... | Pragmas LWASM, transmis en `--pragma=...` |
+| `builder.lwasm.includeDirs` | OUI | `./,../..` | Liste séparée par virgules, transmise en `--includedir=...` à LWASM |
+| `builder.lwasm.define` | OUI (vide accepté) | `DEBUG,boot_color_gr=$00,invincible` | Liste de `--define=...` |
+
+```properties
+builder.lwasm=../../tools/win/lwasm.exe
+builder.lwasm.pragma=undefextern
+builder.lwasm.includeDirs=../..,.
+builder.lwasm.define=boot_color_gr=$00,boot_color_b=$00
+```
+
+**`builder.lwasm.includeDirs`** doit pointer la racine d'où partent les chemins `./engine/...` utilisés dans le code asm. Typiquement `../..` (la racine du repo engine) plus `.` (le game-project lui-même).
+
+**`builder.lwasm.define`** se transmet aux directives `IFDEF` du code. Exemples observés dans le repo :
+
+- `DEBUG=1` — active des logs/traces
+- `TRACK_INTERLACED` — mode disque entrelacé
+- `TRACK_HALFLINES` — mode demi-lignes
+- `T2` — auto-défini quand on build pour T2
+- `boot_color_gr=$00`, `boot_color_b=$00` — couleurs du splash boot
+- `invincible` — flag projet-spécifique
+
+> Pragma utile pour rechercher des optimisations manquantes : `builder.lwasm.pragma=autobranchlength,noforwardrefmax`. Très lent à compiler, à utiliser seulement pour un diff/audit.
+
+---
+
+## Section 4 — Build parameters (générique)
+
+| Clé | Obligatoire ? | Valeur | Rôle |
+|-----|---------------|--------|------|
+| `builder.debug` | OUI | `Y`/`N` | Si `Y`, génère listings + symboles dans `generated-code/debug/` |
+| `builder.logToConsole` | OUI | `Y`/`N` | Si `Y`, logs Log4j en console pendant le build |
+| `builder.parallel` | OUI | `Y`/`N` | Si `Y`, build parallèle (multi-thread, plus rapide) |
+| `builder.diskName` | OUI | chemin sans extension | Nom de la disquette produite ; `./dist/<nom>` → produit `dist/<nom>.fd` |
+| `builder.t2Name` | OUI | nom court | Nom de la cartouche T2 ; **max 22 caractères** (tronqué automatiquement) |
+| `builder.generatedCode` | OUI | dossier | Sortie des fichiers asm intermédiaires (créé automatiquement) |
+| `builder.constAnim` | OUI | fichier `.equ` | Inclut les constantes d'animation (`_resetAnim`, `_goBackNFrames`, ...) |
+| `builder.to8.memoryExtension` | OUI | `Y`/`N` | `Y` = 32 pages RAM (512 Ko, recommandé) ; `N` = 16 pages (256 Ko) |
+| `builder.compilatedSprite.useCache` | OUI | `Y`/`N` | `Y` = réutilise les `.asm`/`.bin`/`.lst` déjà générés (build incrémental) |
+| `builder.compilatedSprite.maxTries` | OUI | entier | Nb d'essais aléatoires pour optimiser les permutations de + de 10 éléments. Rapide: `500000`. Lent: `5000000` |
+| `builder.exobin` | optionnel | chemin | Si défini, compresse les données RAM avec Exomizer ; sinon ZX0 |
+| `builder.hxcfe` | optionnel | chemin | Outil HxC-FloppyEmulator pour produire des images en formats supplémentaires |
+
+```properties
+builder.debug=Y
+builder.logToConsole=Y
+builder.parallel=Y
+builder.diskName=./dist/<nom>
+builder.t2Name=<nom>
+builder.generatedCode=./generated-code
+builder.constAnim=./engine/graphics/animation/constants-animation.equ
+builder.to8.memoryExtension=Y
+builder.compilatedSprite.useCache=Y
+builder.compilatedSprite.maxTries=500000
+
+# builder.exobin=../../tools/win/exomizer.exe       # décommenter pour Exomizer
+# builder.hxcfe=../../tools/win/hxcfe.exe           # décommenter pour HxC
+```
+
+### Notes sur `builder.to8.memoryExtension`
+
+- `Y` : `nbMaxPagesRAM = 32` (TO8 + extension 512 Ko), recommandé pour tout jeu non-trivial
+- `N` : `nbMaxPagesRAM = 16` (TO8 seul, 256 Ko)
+- Détermine combien de pages RAM le builder peut allouer pour placer les objets, sprites compilés, sons, etc.
+
+### Notes sur `builder.compilatedSprite.useCache`
+
+- `Y` : réutilise les `.asm`/`.bin`/`.lst` générés précédemment dans `generated-code/`. Build incrémental rapide quand seuls le code asm a changé.
+- `N` : recompile intégralement tous les sprites. À utiliser quand on a changé les PNG sources ou les options de compilation des sprites.
+
+---
+
+## Configurations spéciales — variantes par target
+
+### Variante T2 (cartouche megarom)
+
+Convention : fichier `config-windows.t2.properties` séparé.
+
+Différences typiques par rapport à la variante FD :
+- `gameMode.<X>=./game-mode/X/main.t2.properties` (au lieu de `.properties`)
+- `builder.lwasm.define=T2,...` (pour activer les `IFDEF T2` dans le code asm)
+- `builder.diskName` parfois omis (on n'utilise que `.t2Name`)
+
+### Variante T2 flash (SDDRIVE)
+
+Utilise les clés `engine.asm.boot.t2flash` et `engine.asm.t2flash`. La build produit en plus un `<t2Name>.t2flash` dans `dist/`.
+
+---
+
+## Exemple complet commenté
+
+```properties
+# ============================================================================
+# BuildDisk - Configuration file
+# ============================================================================
+
+# Section 1 — Engine ASM source code (loader)
+# ----------------------------------------------------------------------------
+engine.asm.boot.fd=../../engine/boot/boot-fd.asm
+engine.asm.RAMLoaderManager.fd=../../engine/ram/RAMLoaderManagerFd.asm
+engine.asm.RAMLoader.fd=../../engine/ram/zx0/RAMLoaderFd.asm
+
+engine.asm.boot.t2=../../engine/boot/boot-t2.asm
+engine.asm.RAMLoaderManager.t2=../../engine/ram/RAMLoaderManagerT2.asm
+engine.asm.RAMLoader.t2=../../engine/ram/zx0/RAMLoaderT2.asm
+
+engine.asm.boot.t2flash=../../engine/boot/boot-t2-flash.asm
+engine.asm.t2flash=../../engine/megarom-t2/t2-flash.asm
+
+# Section 2 — Game definition
+# ----------------------------------------------------------------------------
+gameModeBoot=TitleScreen
+gameMode.TitleScreen=./game-mode/title/main.properties
+gameMode.level01=./game-mode/01/main.properties
+
+# Section 3 — Build parameters (LWASM)
+# ----------------------------------------------------------------------------
+builder.lwasm=../../tools/win/lwasm.exe
+builder.lwasm.pragma=undefextern
+builder.lwasm.includeDirs=../..,.
+builder.lwasm.define=boot_color_gr=$00,boot_color_b=$00
+
+# Section 4 — Build parameters (générique)
+# ----------------------------------------------------------------------------
+builder.debug=Y
+builder.logToConsole=Y
+builder.parallel=Y
+builder.diskName=./dist/mygame
+builder.t2Name=mygame
+builder.generatedCode=./generated-code
+builder.constAnim=./engine/graphics/animation/constants-animation.equ
+builder.to8.memoryExtension=Y
+builder.compilatedSprite.useCache=Y
+builder.compilatedSprite.maxTries=500000
+
+# Section 5 — Optionnels
+# ----------------------------------------------------------------------------
+#builder.exobin=../../tools/win/exomizer.exe
+#builder.hxcfe=../../tools/win/hxcfe.exe
+```
+
+---
+
+## Erreurs de build courantes
+
+| Message du builder | Cause | Solution |
+|--------------------|-------|----------|
+| `engine.asm.boot.fd not found in <file>` | Une clé `engine.asm.*` manque | Ajouter toutes les 8 clés section 1 |
+| `gameModeBoot not found in <file>` | Clé `gameModeBoot` absente | Ajouter `gameModeBoot=<nom-d-un-gameMode>` |
+| `gameMode not found in <file>` | Aucune clé `gameMode.X` déclarée | Ajouter au moins un `gameMode.<X>=...` |
+| `builder.to8.memoryExtension not found in <file>` | Clé absente | Ajouter `builder.to8.memoryExtension=Y` |
+| `builder.compilatedSprite.useCache not found in <file>` | Clé absente | Ajouter `builder.compilatedSprite.useCache=Y` |
+| `Impossible de charger le fichier de configuration: <path>` | Chemin référencé par `gameMode.X` introuvable | Corriger le chemin du `main.properties` |
+
+> Toutes les vérifications « not found » sont dans `Game.java` constructeur. Le builder est strict et bloquant : il faut TOUTES les clés obligatoires.

--- a/skills/thomson-to8-engine-new-game/references/gamemode-properties.md
+++ b/skills/thomson-to8-engine-new-game/references/gamemode-properties.md
@@ -1,0 +1,391 @@
+# `game-mode/<X>/main.properties` — référence exhaustive
+
+Le fichier `main.properties` d'un game-mode déclare :
+- le code asm principal du mode
+- les **objets** actifs dans ce mode (génère les `ObjID_<X>`)
+- les **palettes** utilisées (génère les `Pal_<X>`)
+- éventuellement des **game-modes communs** (`gameModeCommon.<n>=...`)
+- les **actes** (sous-états qui ne déclenchent pas de rechargement disquette)
+
+Format : `clé=valeur` (java.util.Properties via `OrderedProperties`). Chargé par `GameMode.java`.
+
+---
+
+## Clés au niveau game-mode
+
+| Clé | Obligatoire ? | Multiple ? | Rôle |
+|-----|---------------|------------|------|
+| `engine.asm.mainEngine` | OUI | non | Chemin vers le `main.asm` du game-mode (généralement `./game-mode/<X>/main.asm`) |
+| `object.<Nom>` | OUI (≥ 1) | oui | Déclare un objet et son `.properties`. Génère `ObjID_<Nom>` |
+| `palette.<Nom>` | OUI (≥ 1) | oui | Déclare une palette (depuis un PNG). Génère `Pal_<Nom>` |
+| `gameModeCommon.<n>` | optionnel | oui (n numérique) | Référence un game-mode commun (code/objets partagés entre game-modes) |
+| `actBoot` | recommandé | non | Nom de l'acte chargé au démarrage du game-mode |
+| `act.<acte>.palette` | optionnel | un par acte | Palette à activer pour cet acte |
+| `act.<acte>.screenBorder` | optionnel | un par acte | Couleur de bordure (0-15) |
+| `act.<acte>.backgroundImage` | optionnel | un par acte | Chemin PNG pour fond d'écran |
+| `act.<acte>.backgroundSolid` | optionnel | un par acte | Index couleur unie (0-15) pour fond uni |
+| `act.<acte>.objectPlacement` | optionnel | un par acte | Fichier de placement d'objets pré-définis |
+
+---
+
+## 1. `engine.asm.mainEngine`
+
+```properties
+engine.asm.mainEngine=./game-mode/TitleScreen/main.asm
+```
+
+C'est le fichier ASM 6809 qui sera assemblé pour produire le binaire du game-mode. Le builder y inclut automatiquement des prepends (org $6100, etc. — cf. `BuildDisk.compileObjectWithImageRef`).
+
+Le chemin est relatif à la **racine du game-project**, pas au `main.properties`.
+
+---
+
+## 2. `object.<Nom>=path`
+
+```properties
+object.Player=./objects/player/player.properties
+object.Bubble=./objects/bubble/bubble.properties
+object.Background=./objects/background/background.properties
+```
+
+Chaque entrée :
+- charge le fichier `.properties` de l'objet
+- enregistre l'objet dans `gameMode.objects` (liste ordonnée)
+- génère la constante `ObjID_<Nom>` avec un index séquentiel **selon l'ordre d'apparition**
+
+> L'ordre des `object.X=...` est conservé par `OrderedProperties`. Le premier objet déclaré aura `ObjID_<Nom> = 1`, le second `2`, etc. (l'index `0` est réservé pour « slot libre »).
+
+### Réutilisation d'objets entre game-modes
+
+Si le **même nom d'objet** est référencé par plusieurs game-modes, l'objet n'est créé qu'une fois et est partagé : c'est `GameMode.java` ligne 109-117 qui détecte via `Game.allObjects.containsKey(...)`. Cela permet de définir un `Player` une seule fois et de l'utiliser dans `TitleScreen`, `level01`, `level02`, etc.
+
+Mais attention : **chaque game-mode peut référencer un `.properties` différent** pour le même nom logique. Exemple chez r-type :
+```properties
+# Dans game-mode/01/main.d7.properties
+object.Player1=./objects/player1/player1.d7.properties
+# Dans game-mode/01/main.t2.properties
+object.Player1=./objects/player1/player1.t2.properties
+```
+
+Le builder ne se base que sur le **nom** pour la dédup ; deux fichiers différents avec le même nom donnent le même `ObjID_` mais peuvent embarquer des sprites / code différents par target.
+
+---
+
+## 3. `palette.<Nom>=path/to/image.png`
+
+```properties
+palette.Pal_Background=./objects/background/frameintro/000.png
+palette.Pal_TitleScreen=./game-mode/00/images/logo_pal.png
+palette.Pal_black=../../engine/palette/color/Pal_black.png
+```
+
+La palette est **extraite du PNG** par le builder (`Palette.java`). Le PNG doit être en mode palette indexée (4-bit ou 8-bit, max 16 couleurs).
+
+> **Au moins une palette est obligatoire**. Le builder lève `"palette not found in <file>"` sinon.
+
+Conventions observées :
+- `palette.Pal_<nom-de-l-image>` quand la palette vient d'une image de fond
+- `palette.Pal_black=../../engine/palette/color/Pal_black.png` pour la palette noire engine (utilisée pour les fades)
+
+La constante générée `Pal_<Nom>` est l'adresse de la data palette (16 entrées de 2 octets) en mémoire ; elle s'utilise typiquement avec :
+```asm
+        ldd   #Pal_Background
+        std   Pal_current
+        clr   PalRefresh
+        jsr   PalUpdateNow
+```
+
+---
+
+## 4. `gameModeCommon.<n>=path` — objets partagés entre game-modes
+
+> **Feature importante mais sous-utilisée**. Permet de partager le **code et les données d'objets** entre plusieurs game-modes, avec deux bénéfices majeurs :
+> 1. **Économie de ROM cartouche T2** : un objet partagé n'est écrit **qu'une seule fois** dans le ROM si plusieurs game-modes y font référence, au lieu d'une copie par game-mode.
+> 2. **Économie de temps de chargement disquette** : les pages RAM contenant les objets communs peuvent être réutilisées entre game-modes (pas de rechargement complet à chaque transition).
+
+### Syntaxe
+
+```properties
+gameModeCommon.0=./global/common/audio.properties
+gameModeCommon.1=./global/common/hud.properties
+gameModeCommon.2=./global/common/projectiles.properties
+```
+
+- La clé doit être **un entier** (`gameModeCommon.0`, `gameModeCommon.1`, ...). Le builder lève une exception sinon (cf. `GameMode.java` lignes 88-92 : `Integer.parseInt(curGameModeCommon.getKey())`).
+- L'index numérique fixe l'**ordre de chargement** des communs : `.0` avant `.1` avant `.2`. Cet ordre est exploité par certains modules engine.
+
+### Format du fichier `.properties` référencé
+
+Le fichier référencé est un `.properties` allégé qui **ne contient que des objets** :
+
+```properties
+# common-audio.properties (partagé entre tous les game-modes)
+object.ymm=./engine/objects/sound/ymm/ymm.properties
+object.vgc=./engine/objects/sound/vgc/vgc.properties
+object.soundFX=./objects/soundFX/soundFX.properties
+object.fade=./engine/objects/palette/fade/fade.properties
+```
+
+Clés acceptées dans un `gameModeCommon` :
+
+| Clé | Acceptée ? | Note |
+|-----|------------|------|
+| `object.<Nom>` | OUI, ≥ 1 obligatoire | Au moins un objet, sinon « object not found » |
+| `engine.asm.mainEngine` | NON | Pas de code main dans un common |
+| `palette.<Nom>` | NON | Les palettes restent dans le main.properties du game-mode |
+| `act.<X>.*` | NON | Les actes restent par game-mode |
+| `gameModeCommon.<n>` | NON | Un common ne peut pas référencer d'autres communs |
+
+> Voir `GameModeCommon.java` : seul `PropertyList.get(prop, "object")` est appelé, les autres clés sont ignorées.
+
+### Mécanisme côté builder
+
+Lorsque le builder traite un game-mode :
+
+1. **Phase de parsing** : chaque `gameModeCommon.<n>` est résolu en instance `GameModeCommon`. Si un même fichier est référencé par plusieurs game-modes, **la même instance est partagée** (déduplication par chemin de fichier, cf. `GameMode.java` lignes 95-102 : `Game.allGameModeCommons.containsKey(...)`).
+2. **Phase de fusion d'objets** : les objets déclarés dans le common sont fusionnés dans la liste d'objets du game-mode parent — ils reçoivent un `ObjID_<Nom>` comme s'ils étaient déclarés directement dans le `main.properties`.
+3. **Phase d'allocation RAM (knapsack packing)** : le code des objets communs est ajouté aux items à placer en RAM, **par game-mode**. Chaque game-mode aura ses objets communs en RAM lorsqu'il sera chargé.
+4. **Phase d'écriture ROM T2** : c'est là que la mutualisation opère pleinement. Le builder compare les blobs (page+adresse+contenu) des objets communs entre game-modes. **Si deux game-modes ont un objet commun stocké à la même page/adresse avec le même contenu, le builder n'écrit qu'une copie dans le ROM** (cf. `BuildDisk.java` lignes 1990-2010, dédup via `HashMap<GameModeCommon, List<RAMLoaderIndex>>`).
+5. **Phase d'écriture du .glb partagé** : un fichier `SHARED_ASSETS/<commonName>.glb` est généré, contenant les constantes `ObjID_<Nom>` partagées, pour que tous les game-modes utilisateurs voient les mêmes IDs.
+
+### Pourquoi c'est important
+
+Sans `gameModeCommon`, si tu déclares dans 10 game-modes :
+```properties
+object.ymm=./engine/objects/sound/ymm/ymm.properties
+object.vgc=./engine/objects/sound/vgc/vgc.properties
+object.fade=./engine/objects/palette/fade/fade.properties
+```
+
+Le code de chaque objet est **dupliqué 10 fois dans le ROM T2** (1 fois par game-mode). Sur 128 pages disponibles en cartouche, ça consomme inutilement de l'espace.
+
+Avec `gameModeCommon`, ces objets sont écrits **1 seule fois** dans le ROM, et tous les game-modes le pointent.
+
+### Cas d'usage typiques
+
+- **Audio engine partagé** : `ymm`, `vgc`, `soundFX` réutilisés dans tous les game-modes
+- **HUD/score commun** : objets `scores`, `lives`, `messages` réutilisés entre niveaux
+- **Palette fade** : `fade` (engine/objects/palette/fade/) utilisé partout pour les transitions
+- **Joueur + projectiles** dans un shoot'em up : `Player1`, `Weapon`, `Bullet` partagés entre `level01`, `level02`, ...
+- **Ennemis récurrents** : un mini-boss qui apparaît dans plusieurs niveaux
+
+### Exemple complet — audio commun à tous les game-modes
+
+```
+game-projects/<jeu>/
+├── config-windows.properties
+├── global/
+│   └── common-audio.properties     ← le common
+├── game-mode/
+│   ├── TitleScreen/main.properties ← référence le common
+│   ├── level01/main.properties     ← référence le common
+│   └── level02/main.properties     ← référence le common
+└── objects/
+    ├── soundFX/soundFX.properties
+    └── ...
+```
+
+`global/common-audio.properties` :
+```properties
+object.ymm=./engine/objects/sound/ymm/ymm.properties
+object.vgc=./engine/objects/sound/vgc/vgc.properties
+object.soundFX=./objects/soundFX/soundFX.properties
+object.fade=./engine/objects/palette/fade/fade.properties
+```
+
+`game-mode/TitleScreen/main.properties` :
+```properties
+engine.asm.mainEngine=./game-mode/TitleScreen/main.asm
+
+# référence du common
+gameModeCommon.0=./global/common-audio.properties
+
+# objets spécifiques au game-mode
+object.titleLogo=./objects/title/logo.properties
+object.pressStart=./objects/title/pressStart.properties
+
+palette.Pal_title=./game-mode/TitleScreen/images/title.png
+actBoot=default
+act.default.palette=Pal_title
+act.default.backgroundImage=./game-mode/TitleScreen/images/title.png
+```
+
+`game-mode/level01/main.properties` :
+```properties
+engine.asm.mainEngine=./game-mode/level01/main.asm
+
+gameModeCommon.0=./global/common-audio.properties
+
+object.Player=./objects/player/player.properties
+object.Enemy=./objects/enemy/enemy.properties
+
+palette.Pal_level=./game-mode/level01/images/level.png
+actBoot=default
+act.default.palette=Pal_level
+```
+
+Les constantes `ObjID_ymm`, `ObjID_vgc`, `ObjID_soundFX`, `ObjID_fade` sont disponibles dans les deux game-modes avec **la même valeur d'index**, et le code de ces objets n'occupe qu'une page ROM partagée.
+
+### Bonnes pratiques
+
+- **Placer le `.properties` du common dans `global/`** (par convention) — c'est de la responsabilité projet, pas game-mode
+- **Inclure les objets vraiment réutilisés** dans le common — pas tout — sinon on charge inutilement du code en RAM pour des game-modes qui ne l'utilisent pas
+- **Ordre des `gameModeCommon.<n>`** : si plusieurs communs, mettre le plus stable (audio) en `.0`, les optionnels après
+- **Ne pas mettre les sprites/animations dans le common** : les `sprite.X` et `animation.X` sont déclarés dans l'`.properties` de chaque objet, pas dans le common. Le common ne déclare que `object.X=path`.
+- **Tester sur cartouche T2** la dédup : sur disquette, le bénéfice est essentiellement en temps de chargement ; en cartouche T2 c'est en espace ROM.
+
+### Limites
+
+- Un `gameModeCommon` ne peut **pas** lui-même référencer d'autres `gameModeCommon` (pas de hiérarchie)
+- Les **palettes ne sont pas partageables** via common (toujours déclarées par game-mode)
+- La dédup en T2 est faite **par contenu de blob** : si deux game-modes utilisent le même objet mais avec des sprites différents (variantes `.t2.properties`), la dédup ne s'applique pas
+- L'ordre `.0`, `.1`, `.2` est **strictement numérique** — les noms type `gameModeCommon.audio` lèvent une exception au build
+
+---
+
+## 5. Actes — sous-états sans rechargement
+
+Un **acte** est un sous-état d'un game-mode qui n'entraîne **aucun rechargement disquette/cartouche**. Tous les actes partagent le code et les objets du game-mode, mais peuvent avoir des palettes/fonds différents et des placements d'objets différents.
+
+### `actBoot=<nom>`
+
+```properties
+actBoot=default
+```
+
+Désigne quel acte est chargé au démarrage. **Si absent**, `LoadAct` est généré vide et l'écran n'est pas initialisé.
+
+> `actBoot` peut être nul (`null` en Java). Dans ce cas le builder ne génère pas de code dans `LoadAct` (cf. `BuildDisk.writeLoadActIndex` ligne 814).
+
+### Propriétés d'un acte
+
+| Clé | Valeur | Effet généré dans `LoadAct` |
+|-----|--------|----------------------------|
+| `act.<X>.palette` | nom d'une `palette.Pal_<X>` déclarée | `ldd #<paletteName>; std Pal_current; clr PalRefresh` |
+| `act.<X>.screenBorder` | entier 0-15 | écrit la couleur de bordure dans `$E7DD` et `gfxlock.screenBorder.color` (si présent) |
+| `act.<X>.backgroundImage` | chemin PNG | génère un `Bgi_<X>` et appelle `DrawFullscreenImage` sur les pages 2 et 3 (double buffering) |
+| `act.<X>.backgroundSolid` | index 0-15 | remplit les pages 2 et 3 avec la couleur (`ldx #$XXXX; jsr ClearDataMem`) |
+| `act.<X>.objectPlacement` | chemin fichier | placement d'objets pré-définis (rare, lecture du champ uniquement — pas vu de traitement actif récent) |
+
+### Exemple complet
+
+```properties
+actBoot=default
+
+act.default.palette=Pal_TitleScreen
+act.default.screenBorder=8
+act.default.backgroundImage=./game-mode/00/images/title.png
+
+# Acte alternatif (basculement par changement de variable + LoadAct)
+act.menu.palette=Pal_TitleScreen
+act.menu.screenBorder=0
+act.menu.backgroundSolid=0
+```
+
+### Notes sur le code généré par `LoadAct`
+
+Le builder Java écrit dans `LoadAct` (cf. `BuildDisk.writeLoadActIndex`) **uniquement** pour l'acte référencé par `actBoot`. Les autres `act.<X>.*` ne sont pas exploités directement.
+
+Si `backgroundImage` ou `backgroundSolid` est défini, le code généré charge l'image sur **deux pages physiques** (2 et 3, via `$E7E5`) pour assurer que le double-buffering soit cohérent (gfxlock alterne entre les deux pages) :
+
+```asm
+LoadAct
+        ldb   #$02                     * load page 2
+        stb   $E7E5                    * in data space ($A000-$DFFF)
+        ldx   #Bgi_default
+        jsr   DrawFullscreenImage
+        ; ...
+        IFDEF gfxlock.bufferSwap.do
+        jsr   gfxlock.bufferSwap.do
+        ENDC
+        ; ...
+        ldb   #$03                     * load page 3
+        stb   $E7E5
+        ldx   #Bgi_default
+        jsr   DrawFullscreenImage
+        ; ...
+```
+
+Si on n'utilise pas gfxlock, le bloc est protégé par `IFDEF`. Si on n'utilise pas `WaitVBL`, idem.
+
+---
+
+## Exemples de `main.properties`
+
+### Game-mode minimal (un objet, un fond uni)
+
+```properties
+engine.asm.mainEngine=./game-mode/test/test.asm
+
+object.Player=./objects/player/player.properties
+
+palette.Pal_default=./objects/player/image/idle-000.png
+
+actBoot=default
+act.default.palette=Pal_default
+act.default.screenBorder=0
+act.default.backgroundSolid=0
+```
+
+### Game-mode TitleScreen avec musique (pattern 2026)
+
+```properties
+engine.asm.mainEngine=./game-mode/TitleScreen/main.asm
+
+object.background=./objects/background/background.properties
+object.ymm=./objects/music/ymm.properties
+object.vgc=./objects/music/vgc.properties
+
+palette.Pal_Background=./objects/background/frameintro/000.png
+
+actBoot=titleScreen
+act.titleScreen.palette=Pal_Background
+act.titleScreen.screenBorder=8
+act.titleScreen.backgroundImage=./objects/background/frameintro/000.png
+```
+
+### Game-mode complexe (pattern r-type level01, extrait)
+
+```properties
+engine.asm.mainEngine=./game-mode/01/main.asm
+
+# Palettes
+palette.Pal_game=./game-mode/01/images/pal.png
+palette.Pal_tunnel=./game-mode/01/images/pal-inside.png
+palette.Pal_black=../../engine/palette/color/Pal_black.png
+palette.Pal_messages=./objects/messages/images/messages.png
+
+# Objets globaux
+object.fade=../../engine/objects/palette/fade/fade.properties
+object.animation=./objects/animation/obj.d7.properties
+
+# Objets jeu
+object.LevelInit=./objects/levels/01/obj.d7.properties
+object.LevelWave=./objects/levels/01/object-wave/obj.d7.properties
+object.Player1=./objects/player1/player1.d7.properties
+object.Weapon=./objects/player1/weapon/obj.d7.properties
+# ... (50+ objets pour un niveau)
+
+# Audio
+object.ymm01=./objects/levels/01/music/ymm.d7.properties
+object.soundFX=./objects/soundFX/soundFX.d7.properties
+
+# Acte
+actBoot=default
+act.default.palette=Pal_black
+act.default.screenBorder=0
+act.default.backgroundSolid=0
+```
+
+---
+
+## Erreurs courantes au niveau game-mode
+
+| Message | Cause | Solution |
+|---------|-------|----------|
+| `engine.asm.mainEngine not found in <file>` | Clé absente | Ajouter la ligne |
+| `object not found in <file>` | Aucun `object.X=...` | Déclarer au moins un objet |
+| `palette not found in <file>` | Aucun `palette.X=...` | Déclarer au moins une palette |
+| `gameModeCommon.<X> should be of type gameModeCommon.<n>` | Clé non-numérique | `gameModeCommon.audio` → `gameModeCommon.0` |
+| L'écran est noir au boot | `actBoot` absent ou ne matche aucun `act.X.*` | Ajouter `actBoot=<nom>` + au moins une propriété `act.<nom>.*` |
+| `Bgi_<actName>` non défini lors de l'assemblage | `act.<X>.backgroundImage` manquant mais code asm utilise `Bgi_<X>` | Soit ajouter la prop, soit retirer la ref dans le code |

--- a/skills/thomson-to8-engine-new-game/references/mainasm-skeleton.md
+++ b/skills/thomson-to8-engine-new-game/references/mainasm-skeleton.md
@@ -1,0 +1,515 @@
+# Squelette `main.asm` d'un game-mode
+
+Ce document décrit le **squelette canonique** d'un `main.asm` selon le pattern utilisé par les game-projects récents (`r-type`, `bubble-bobble`, `sonic-2`, `2026`). Le code utilise `gfxlock` pour le double buffering, l'IRQ utilisateur synchronisé sur le VBL, et l'allocation **dynamique** d'objets via `LoadObject_u`.
+
+---
+
+## Architecture en couches
+
+Un `main.asm` est structuré en **5 sections** :
+
+1. **Préambule** — defines, INCLUDEs des macros/constantes
+2. **Code d'initialisation** — au démarrage, à partir de `$6100`
+3. **Boucle principale** — `MainLoop` qui tourne en boucle
+4. **UserIRQ** — interruption appelée à chaque VBL (palette, son, swap buffer)
+5. **RAM data + routines moteur** — fin du fichier (INCLUDE du `ram-data.asm` + des routines engine)
+
+---
+
+## Squelette commenté complet
+
+```asm
+        opt   c,ct                          ; LWASM options : c=case sensitive, ct=cycle timings
+
+* ==============================================================================
+* Defines
+* ==============================================================================
+SOUND_CARD_PROTOTYPE equ 1                  ; ancien port carte son SN76489 (si applicable)
+;SN76489_JUMPER_LOW   equ 1                 ; jumper bas (optionnel selon hardware)
+;DEBUG                equ 1                 ; flag debug (active des traces)
+
+* ==============================================================================
+* Includes — constantes, macros, équivalences
+* ==============================================================================
+        INCLUDE "./engine/system/to8/memory-map.equ"
+        INCLUDE "./engine/system/to8/map.const.asm"
+        INCLUDE "./engine/constants.asm"
+        INCLUDE "./engine/macros.asm"
+        INCLUDE "./engine/graphics/buffer/gfxlock.macro.asm"
+        ; INCLUDE "./engine/collision/macros.asm"            ; si collisions AABB
+        ; INCLUDE "./engine/graphics/tilemap/vscroll/vscroll.macro.asm"  ; si scroll vertical
+        ; INCLUDE "./engine/objects/sound/ymm/ymm.macro.asm"  ; si musique YM2413
+
+; ------- Macros musicales (à reprendre dans chaque game-mode si pas centralisé) -------
+MUSIC_NO_LOOP   EQU 0
+MUSIC_LOOP      EQU 1
+
+_MusicInit_objvgc MACRO
+        lda   \1
+        ldy   \3
+        ldb   \2
+        jsr   ,x
+        ENDM
+
+_MusicInit_objymm MACRO
+        lda   \1
+        ldy   \3
+        ldb   \2
+        jsr   ,x
+        ENDM
+
+_MusicFrame_objvgc MACRO
+        ldb   #$80
+        jsr   ,x
+        ENDM
+
+_MusicFrame_objymm MACRO
+        ldb   #$80
+        jsr   ,x
+        ENDM
+
+* ==============================================================================
+* Point d'entrée — chargé en $6100 par le RAMLoader engine
+* ==============================================================================
+        org   $6100
+
+        jsr   InitGlobals                   ; clear direct page + init globals engine
+        jsr   InitDrawSprites               ; init buffers d'effacement (sprite-bg-erase)
+        jsr   InitStack                     ; init pile d'allocation objets
+        jsr   LoadAct                       ; code généré par le builder selon actBoot
+        jsr   InitJoypads                   ; init lecture manettes (si jeu joué au joypad)
+        ; jsr   InitRNG                     ; init générateur aléatoire (si utilisé)
+
+        ; --- Optionnel : ouverture/fermeture de l'écran/palette en début de mode ---
+        ldd   #Pal_current_palette
+        std   Pal_current
+        clr   PalRefresh
+        ; jsr   PalUpdateNow                ; force update immédiate
+
+        ; --- Allocation des objets dynamiques de départ ---
+        jsr   LoadObject_u                  ; alloue un slot, retourne u (Z=1 si plein)
+        beq   @noslot                       ; tester Z pour gérer le cas plein
+        lda   #ObjID_Player                 ; identifiant de l'objet (généré par builder)
+        sta   id,u                          ; lie le slot à l'objet logique
+        ; sta   subtype,u                   ; optionnel : variante de l'objet
+@noslot
+
+        ; --- Initialisation musique (si applicable) ---
+        _MountObject ObjID_ymm              ; charge la page de l'objet musique YMM
+        _MusicInit_objymm #0,#MUSIC_LOOP,#0 ; track 0, en boucle, fade 0
+
+        _MountObject ObjID_vgc              ; charge la page de l'objet musique VGC (SN76489)
+        _MusicInit_objvgc #0,#MUSIC_LOOP,#0
+
+        ; --- Configuration de l'IRQ utilisateur ---
+        jsr   IrqInit                       ; init système IRQ
+        ldd   #UserIRQ                      ; pointeur vers notre routine d'IRQ
+        std   Irq_user_routine
+        lda   #255                          ; sync : ligne 255 = hors zone visible (VBL)
+        ldx   #Irq_one_frame                ; déclenche une fois par frame
+        jsr   IrqSync
+        _gfxlock.init                       ; init du double-buffering gfxlock
+        jsr   IrqOn                         ; active les interruptions
+
+* ==============================================================================
+* Boucle principale
+* ==============================================================================
+MainLoop
+        jsr   RunObjects                    ; exécute toutes les routines des objets vivants
+        ; --- Tests de collision (si applicable) ---
+        ; _Collision_Do AABB_list_player,AABB_list_enemy
+        jsr   CheckSpritesRefresh           ; détermine quels sprites doivent être redessinés
+        _gfxlock.on                         ; verrouille la phase de rendu (swap buffer side)
+        jsr   EraseSprites                  ; efface les sprites de la frame précédente
+        jsr   UnsetDisplayPriority          ; reset prio pour le tri à venir
+        jsr   DrawSprites                   ; dessine les sprites (avec leur priorité)
+        _gfxlock.off                        ; libère la phase de rendu
+        _gfxlock.loop                       ; gestion du compteur de frames + flip ID
+        bra   MainLoop
+
+* ==============================================================================
+* IRQ utilisateur (appelée 50 fois par seconde sur le VBL)
+* ==============================================================================
+UserIRQ
+        jsr   gfxlock.bufferSwap.check      ; échange les buffers vidéo si rendu prêt
+        jsr   PalUpdateNow                  ; applique les changements de palette
+        ; --- Sound frame tick (si applicable) ---
+        _MountObject ObjID_ymm
+        _ymm.processFrame
+        _MountObject ObjID_vgc
+        _MusicFrame_objvgc
+        rts
+
+* ==============================================================================
+* RAM Data — déclaration de l'OST (Object Status Table)
+* ==============================================================================
+        INCLUDE "./game-mode/<mode>/ram-data.asm"
+
+; Variables RAM spécifiques au game-mode (optionnel)
+; main.object.count  fcb   0
+; main.playerOne     fdb   0
+
+* ==============================================================================
+* Routines moteur — inclues à la fin du fichier
+* ==============================================================================
+
+        ; --- Utilitaires ---
+        INCLUDE "./engine/ram/BankSwitch.asm"
+        INCLUDE "./engine/graphics/buffer/gfxlock.asm"
+        INCLUDE "./engine/palette/PalUpdateNow.asm"
+        INCLUDE "./engine/ram/ClearDataMemory.asm"
+        INCLUDE "./engine/irq/Irq.asm"
+        INCLUDE "./engine/level-management/LoadGameMode.asm"
+
+        ; --- Joypad ---
+        INCLUDE "./engine/joypad/InitJoypads.asm"
+        INCLUDE "./engine/joypad/ReadJoypads.asm"
+
+        ; --- Object management ---
+        INCLUDE "./engine/object-management/RunObjects.asm"
+        INCLUDE "./engine/object-management/RunPgSubRoutine.asm"
+        ; INCLUDE "./engine/object-management/ObjectMoveSync.asm"   ; si déplacements
+
+        ; --- Animation ---
+        INCLUDE "./engine/graphics/animation/AnimateSprite.asm"
+        ; INCLUDE "./engine/graphics/animation/AnimateSpriteSync.asm"  ; version sync
+
+        ; --- Sprite pack (CHOISIR UN SEUL) ---
+        INCLUDE "./engine/graphics/sprite/sprite-background-erase-pack.asm"
+        ; INCLUDE "./engine/graphics/sprite/sprite-background-erase-ext-pack.asm"  ; encoding étendu
+        ; INCLUDE "./engine/graphics/sprite/sprite-overlay-pack.asm"               ; mode overlay (legacy)
+
+        ; --- Sound (si musique) ---
+        INCLUDE "./engine/objects/sound/ymm/ymm.const.asm"
+        INCLUDE "./engine/objects/sound/ymm/ymm.data.asm"
+        ; INCLUDE "./engine/sound/sn76489.asm"
+        ; INCLUDE "./engine/sound/ym2413.asm"
+
+        ; --- Math (si nécessaire) ---
+        ; INCLUDE "./engine/math/CalcSine.asm"
+        ; INCLUDE "./engine/math/RandomNumber.asm"
+
+        ; --- Collision (si nécessaire) ---
+        ; INCLUDE "./engine/collision/collision.asm"
+
+        ; --- DOIT être en DERNIER (dépendances ifdef sur ce qui précède) ---
+        INCLUDE "./engine/InitGlobals.asm"
+```
+
+---
+
+## Choix du sprite-pack
+
+Trois packs sont disponibles dans `engine/graphics/sprite/` :
+
+### `sprite-background-erase-pack.asm` (par défaut, recommandé)
+
+Inclut : `DisplaySprite`, `CheckSpritesRefresh`, `EraseSprites`, `UnsetDisplayPriority`, `DrawSprites`, `BgBufferAlloc`, `DeleteObject`.
+
+- Mode **backup/draw/erase** : chaque sprite mobile sauvegarde le fond avant de se dessiner, et le restaure quand il disparaît.
+- Exige des sprites compilés avec variante `B` (`NB0,NB1,XB0,XB1`...).
+- Appel `InitDrawSprites` obligatoire au boot.
+- Pattern : `EraseSprites` → `UnsetDisplayPriority` → `DrawSprites`.
+
+### `sprite-background-erase-ext-pack.asm` (encoding étendu)
+
+Identique au précédent **sauf** `DrawSprites.asm` → `DrawSpritesExtEnc.asm`.
+
+- Permet des sprites avec **encodage RLE/ZX0** pour les images de fond ou grands sprites (variante `DMAP`, `DZX0`).
+- Choisir ce pack si on utilise des objets avec sprites encodés.
+
+### `sprite-overlay-pack.asm` (mode overlay, legacy)
+
+Inclut : `DisplaySprite`, `BuildSprites`, `DeleteObject`.
+
+- Mode **overlay** : les sprites sont fusionnés dans un buffer overlay (ancienne approche, utilisée par `test/`).
+- Plus simple, moins performant en cas de nombreux sprites mobiles.
+- Nécessite `OverlayMode equ 1` en préambule.
+- Pattern (boucle main) : `BuildSprites` au lieu de `EraseSprites + DrawSprites`.
+
+**Recommandation** : choisir `background-erase-pack` (ou `-ext-pack` si tu as des sprites encodés) pour tout nouveau projet.
+
+---
+
+## Variantes de boucle principale
+
+### Avec gfxlock (pattern moderne, école 2)
+
+```asm
+MainLoop
+        jsr   RunObjects
+        jsr   CheckSpritesRefresh
+        _gfxlock.on
+        jsr   EraseSprites
+        jsr   UnsetDisplayPriority
+        jsr   DrawSprites
+        _gfxlock.off
+        _gfxlock.loop
+        bra   MainLoop
+```
+
+### Avec WaitVBL (pattern simple, école 1)
+
+```asm
+MainLoop
+        jsr   WaitVBL                  ; attend le retour vertical
+        jsr   ReadJoypads
+        jsr   RunObjects
+        jsr   CheckSpritesRefresh
+        jsr   EraseSprites
+        jsr   UnsetDisplayPriority
+        jsr   DrawSprites
+        bra   MainLoop
+```
+
+Plus simple mais sans double-buffering : risque de **tearing** visible en bas d'écran si la frame déborde.
+
+### Avec collision avant rendu
+
+```asm
+MainLoop
+        jsr   RunObjects
+        _Collision_Do AABB_list_player,AABB_list_enemy
+        _Collision_Do AABB_list_player,AABB_list_bonus
+        jsr   CheckSpritesRefresh
+        _gfxlock.on
+        jsr   EraseSprites
+        jsr   UnsetDisplayPriority
+        jsr   DrawSprites
+        _gfxlock.off
+        _gfxlock.loop
+        bra   MainLoop
+```
+
+Les `AABB_list_X` sont déclarées dans `ram-data.asm` (cf. ci-dessous).
+
+---
+
+## `ram-data.asm` — squelette canonique
+
+Le fichier `ram-data.asm` (inclus depuis `main.asm`) déclare l'**OST** (Object Status Table) et ses dimensions.
+
+### Version minimale (sans collision)
+
+```asm
+; RAM variables
+
+* ===========================================================================
+* Object Constants
+* ===========================================================================
+
+ext_variables_size                equ 0    ; octets supplémentaires par objet dynamique
+nb_dynamic_objects                equ 8    ; nb max d'objets vivants simultanément
+nb_graphical_objects              equ 8    ; max 64 (sprites visibles à l'écran)
+
+Dynamic_Object_RAM
+                                  fill  0,nb_dynamic_objects*object_size
+Dynamic_Object_RAM_End
+```
+
+### Version avec préchargement statique (école legacy, pattern `test`)
+
+Permet d'avoir des objets **toujours présents** dès le démarrage, sans appel à `LoadObject_u`.
+
+```asm
+ext_variables_size                equ 0
+nb_dynamic_objects                equ 3
+nb_graphical_objects              equ 3
+
+Object_RAM
+SS_Object_RAM
+Dynamic_Object_RAM                fcb   ObjID_Back
+                                  fill  0,object_size-1
+                                  fcb   ObjID_Back2
+                                  fill  0,object_size-1
+                                  fcb   ObjID_Player
+                                  fill  0,object_size-1
+Dynamic_Object_RAM_End
+SS_Object_RAM_End
+Object_RAM_End
+```
+
+### Version avec collisions AABB (pattern bubble-bobble, r-type)
+
+```asm
+ext_variables_size                equ 9    ; espace pour structs AABB (9 octets par AABB)
+nb_dynamic_objects                equ 22
+nb_graphical_objects              equ 12
+
+Dynamic_Object_RAM                
+                                  fill  0,nb_dynamic_objects*object_size
+Dynamic_Object_RAM_End
+
+* ===========================================================================
+* Collision lists
+* ===========================================================================
+AABB_lists.nb                     equ   (AABB_endLists-AABB_lists)/2
+AABB_lists
+AABB_list_player                  fdb   0,0
+AABB_list_enemy                   fdb   0,0
+AABB_list_bonus                   fdb   0,0
+AABB_endLists
+```
+
+### Avec objet en Direct Page (pattern r-type — accès rapide au joueur)
+
+```asm
+ext_variables_size                equ 20
+nb_dynamic_objects                equ 57
+nb_graphical_objects              equ 57
+
+* OST en Direct Page (accès 1 cycle plus rapide)
+player1                           equ   dp                  ; alias DP pour le joueur
+palettefade                       fcb   ObjID_fade          ; objet fade pré-chargé
+                                  fill  0,object_size-1
+
+Dynamic_Object_RAM                fill  0,(nb_dynamic_objects)*object_size
+Dynamic_Object_RAM_End
+```
+
+---
+
+## Dimensions de l'OST — comment choisir
+
+| Paramètre | Effet | Recommandation |
+|-----------|-------|----------------|
+| `nb_dynamic_objects` | Nb max d'objets vivants. Chaque objet prend `object_size` octets. | Commencer petit (8-16), augmenter si `LoadObject_u` échoue (Z=1) |
+| `nb_graphical_objects` | Max 64 (limite engine). Combien de sprites à l'écran simultanément. | Tenir compte des sprites du HUD + des explosions transitoires |
+| `ext_variables_size` | Octets supplémentaires alloués à chaque objet. | `0` minimum, `9` pour 1 AABB, `20` pour structs complexes (player avec ring-buffer, etc.) |
+
+`object_size` est défini dans `engine/constants.asm` : `object_base_size + ext_variables_size + object_rsvd_size`. La taille de base est ~34 octets.
+
+---
+
+## UserIRQ — patterns selon les besoins
+
+### Minimal (palette seule)
+
+```asm
+UserIRQ
+        jmp   PalUpdateNow
+```
+
+### Avec gfxlock buffer swap
+
+```asm
+UserIRQ
+        jsr   gfxlock.bufferSwap.check
+        jsr   PalUpdateNow
+        rts
+```
+
+### Avec musique YMM + VGC
+
+```asm
+UserIRQ
+        jsr   gfxlock.bufferSwap.check
+        jsr   PalUpdateNow
+        _MountObject ObjID_ymm
+        _ymm.processFrame
+        _MountObject ObjID_vgc
+        _MusicFrame_objvgc
+        rts
+```
+
+### Avec effet raster palette (SMPS, sonic-2)
+
+```asm
+UserIRQ_Raster_Smps
+        jsr   PalRaster_1c              ; change la palette à mi-écran
+        jmp   MusicFrame
+```
+
+---
+
+## Définition du game-mode courant et suivant
+
+Pour permettre les transitions de game-mode (ex : titre → niveau 1) :
+
+```asm
+        lda   #GmID_level01
+        sta   glb_Cur_Game_Mode
+
+        ; Plus tard, pour basculer vers un autre mode :
+        lda   #GmID_level02
+        sta   glb_Next_Game_Mode
+        ; puis dans la boucle main, après détection :
+        ; jsr   LoadGameMode
+```
+
+`LoadGameMode` (dans `engine/level-management/LoadGameMode.asm`) déclenche le rechargement disquette/cartouche du game-mode suivant.
+
+---
+
+## Pattern avec includes factorisés (école goldorak)
+
+Si tu factorises tes INCLUDEs dans `global/global-preambule-includes.asm` et `global/global-trailer-includes.asm` (pattern goldorak), ton `main.asm` devient :
+
+```asm
+        INCLUDE "./global/global-preambule-includes.asm"
+        org   $6100
+
+        _gameMode.init #GmID_splash             ; macro qui fait Init + Stack + LoadAct + Joypads
+        _objectManager.new.u #ObjID_Splash       ; macro qui fait LoadObject_u + sta id
+        _music.init.SN76489 #Vgc_intro,#MUSIC_LOOP,#0
+        _music.init.YM2413 #Ym_intro,#MUSIC_LOOP,#0
+        _music.init.IRQ #UserIRQ,#OUT_OF_SYNC_VBL,#Irq_one_frame
+
+MainLoop
+        jsr   ReadJoypads
+        jsr   RunObjects
+        jsr   CheckSpritesRefresh
+        jsr   EraseSprites
+        jsr   UnsetDisplayPriority
+        jsr   DrawSprites
+        jsr   WaitVBL
+        bra   MainLoop
+
+UserIRQ
+        jsr   PalUpdateNow
+        rts
+
+        INCLUDE "./game-mode/splash/ram-data.asm"
+        INCLUDE "./global/global-trailer-includes.asm"
+```
+
+Ce pattern est très lisible mais nécessite de packager les macros (`_gameMode.init`, `_objectManager.new.u`, `_music.init.*`) — actuellement dans `goldorak/global/global-macros.asm`, **pas encore dans `engine/`**.
+
+---
+
+## ⚠️ Règle critique : Direct Page (DP) dans le code main
+
+Dans le code résident (entre `org $6100` et la fin du MainLoop), **le registre DP du 6809 n'est PAS positionné automatiquement**. Sa valeur est inconnue (souvent 0, parfois résiduelle d'un setup précédent).
+
+Conséquence : **ne jamais utiliser `<addr` (adressage direct page) dans le code main**. Toujours l'adressage étendu :
+
+```asm
+; Init / MainLoop / UserIRQ du game-mode :
+        lda   #50
+        sta   horizon_y       ; ✅ étendu : adresse 16 bits, indépendant du DP
+        ; sta <horizon_y      ← ❌ écrit en (DP_actuel)*256 + offset — pas où prévu
+
+        lda   horizon_y       ; ✅ lecture étendue OK
+```
+
+**Seules exceptions** où `<addr` est OK :
+1. **Dans UserIRQ** : le monitor a positionné `DP = $E7` avant d'appeler le handler (puis `IrqManager` fait `setdp $E7`). Donc `<$DA`, `<$DB` (registres palette) etc. fonctionnent. C'est ce qui permet aux routines `PalUpdateNow`/`PalRaster_1c` d'être rapides.
+2. **Dans une routine qui set DP localement** via `pshs dp; ldd #$XX; tfr b,dp; setdp $XX` (et restore avec `puls dp` à la sortie). Pattern utilisé par les routines engine.
+3. **Code joueur en DP** (pattern `ObjectDp` : OST du joueur en $9F00-$9FFF, le DP est explicitement positionné à $9F avant `_RunObject ObjID_Player,#player1`).
+
+Pour la grande majorité du code applicatif, l'**adressage étendu** est la règle. La perte d'1 cycle/accès est négligeable et évite des bugs silencieux indétectables (la valeur va dans la mauvaise zone mémoire sans erreur).
+
+Voir le skill `thomson-to8-engine-memory-model/references/direct-page-usage.md` pour les détails complets.
+
+---
+
+## Pitfalls
+
+- **`<addr` dans le code main sans setup DP** : écriture/lecture à la mauvaise adresse, bug silencieux. Cf. section dédiée ci-dessus.
+- **Oublier `org $6100`** : le code se place à l'adresse 0 par défaut et plante au boot.
+- **`InitDrawSprites` manqué** quand on utilise `sprite-background-erase-pack` ou `-ext-pack` : pas de crash mais les buffers d'erase sont à 0 et le rendu est cassé.
+- **`InitStack` manqué** : `LoadObject_u` retourne toujours Z=1 (pile vide) car la pile d'allocation n'est pas initialisée.
+- **`IrqOn` avant `_gfxlock.init`** : `gfxlock.status` n'est pas initialisé, le rendu est cassé.
+- **`InitGlobals.asm` mis en haut des INCLUDEs** : il dépend de symboles définis par d'autres modules (ifdef chain), il **doit être à la fin**.
+- **Sprite-pack mélangé avec overlay** : `BuildSprites` et `DrawSprites` ne sont **pas compatibles** ensemble — choisir un seul pack.
+- **`org $6100` placé après l'INCLUDE des macros** : les `MACRO` doivent être définies avant `org` car LWASM compile en deux passes.

--- a/skills/thomson-to8-engine-new-game/references/object-properties.md
+++ b/skills/thomson-to8-engine-new-game/references/object-properties.md
@@ -1,0 +1,378 @@
+# `objects/<objet>/<objet>.properties` — référence exhaustive
+
+Le `.properties` d'un objet déclare son **code asm**, ses **sprites** (frames d'images), ses **animations**, et optionnellement des **sons**, **données binaires**, **tilesets** et **données d'animation**.
+
+Format : `clé=valeur` (java.util.Properties via `OrderedProperties`). Chargé par `Object.java`.
+
+---
+
+## Clés au niveau objet
+
+| Clé | Obligatoire ? | Multiple ? | Rôle |
+|-----|---------------|------------|------|
+| `code` | OUI (sauf si `common-code`) | non | Chemin vers le `.asm` de l'objet, suivi optionnellement de `;RAM` |
+| `common-code` | OUI (sauf si `code`) | non | Marque le code comme commun (réservé pour usage futur) |
+| `sprite.Img_<Nom>` | OUI si l'objet est graphique | oui | Déclare un sprite avec son image et ses variantes |
+| `animation.Ani_<Nom>` | optionnel | oui | Déclare une séquence d'animation |
+| `animation-data` | optionnel | **1 seule** | Données binaires d'animation pré-générées (ex: scripts moveByScript) |
+| `sound.<Nom>` | optionnel | oui | Déclare un son ou une donnée binaire |
+| `data.<Nom>` | optionnel | oui | Alias de `sound.X` (mêmes propriétés, nom plus parlant pour des binaires non-audio) |
+| `tileset.<Nom>` | optionnel | oui | Déclare un tileset (pour scrolling, maps) |
+| `spriteIndex` | optionnel | non | Si vaut `RAM`, l'index des sprites est placé en RAM (sinon ROM) |
+| `animationIndex` | optionnel | non | Si vaut `RAM`, l'index des animations est placé en RAM (sinon ROM) |
+
+> Le builder lève une exception si **les deux** `code` et `common-code` sont définis, ou si **aucun des deux** ne l'est (cf. `Object.java` lignes 62-69).
+
+---
+
+## 1. `code` — chemin du code asm de l'objet
+
+```properties
+code=./objects/player/player.asm
+code=./objects/enemy/enemy.asm;RAM
+```
+
+- Le chemin est relatif à la racine du game-project.
+- Le suffixe optionnel `;RAM` (`codeInRAM=true`) force le placement du code en RAM. Par défaut, le code va en ROM cartouche T2 (s'il y a une cible T2) et en page chargée sur disquette pour FD.
+
+### `common-code` (réservé)
+
+```properties
+common-code=./global/common/audio-shared.asm
+```
+
+Marque ce code comme partagé. **Pas encore implémenté** : commentaire `// TODO common-code is not yet implemented` dans `Object.java`. Évite de l'utiliser pour l'instant.
+
+---
+
+## 2. `sprite.Img_<Nom>=<image>;<variants>;<RAM?>`
+
+Déclare un sprite (= une frame d'image avec ses transformations possibles).
+
+### Syntaxe complète
+
+```
+sprite.Img_<Nom>=<file>[:<assoc>][,<refFile>[,<assoc>][,<interlaceFlag>]];<variants>[;RAM]
+```
+
+| Position | Champ | Description |
+|----------|-------|-------------|
+| 1 | `file` | Chemin du PNG source (obligatoire) |
+| 1 (après `:`) | `assoc` | Index palette associé, ex: `_autopal(2-5)` |
+| 1 (après `,`) | `refFile` | PNG de référence pour diff (compression delta) |
+| 1 (après `,,`) | `assoc` (alternative) | Même que `:` mais en 3e champ csv |
+| 1 (après `,,,`) | `interlace` | `_full` = pas d'entrelacement (par défaut entrelacé) |
+| 2 | `variants` | Liste séparée par virgules des variantes à compiler |
+| 3 | `RAM` | Si présent, place le sprite en RAM |
+
+### Exemples
+
+```properties
+# Sprite simple : draw seul, position 0
+sprite.Img_logo=./objects/logo/logo.png;ND0
+
+# Sprite avec backup/draw/erase, positions 0 et 1 (pour shifts de 1px)
+sprite.Img_Player_Idle_001=./objects/player/image/idle-001.png;NB0,NB1
+
+# Sprite + flip horizontal (X) avec backup, positions 0/1 normales + flip
+sprite.Img_Player_Run_001=./objects/player/image/run0001.png;NB0,NB1,XB0,XB1
+
+# Sprite plein écran (background)
+sprite.Img_titleScreen=./objects/background/title.png,./objects/background/title.png,,_full;ND0
+
+# Sprite delta (image diff par rapport à ref)
+sprite.Img_anim_001=./objects/anim/001.png,./objects/anim/000.png;ND0
+
+# Sprite forcé en RAM
+sprite.Img_critical=./objects/critical/img.png;NB0;RAM
+```
+
+### ⚠️ Règle critique côté code asm pour les variants `D` (Draw seul)
+
+Si tu déclares un variant `ND0`, `ND1`, `XD0`, `XD1`, `YD*`, `XYD*` (mode Draw **sans backup**), le code asm de l'objet doit **obligatoirement** poser `render_overlay_mask` dans `render_flags,u` dans la routine `Init` :
+
+```asm
+        lda   render_flags,u
+        ora   #render_overlay_mask
+        sta   render_flags,u
+```
+
+**Sans ce flag**, l'engine traite le sprite comme un mode backup (B) et cherche un code d'erase qui n'a pas été compilé → **le sprite est invisible**, sans message d'erreur. Bug très piégeux : on cherche pendant des heures.
+
+Pour les variants `NB*`/`XB*`/`YB*`/`XYB*` (mode Backup), `render_overlay_mask` doit **rester à 0**.
+
+### Syntaxe des **variantes**
+
+Une variante est une chaîne du type `<orientation><mode><shift>`. Plusieurs variantes par sprite sont séparées par virgules dans le 2e champ.
+
+| Code | Élément | Description |
+|------|---------|-------------|
+| `N` | orientation | **N**ormal (orientation source) |
+| `X` | orientation | flip horizontal (mi**X**) |
+| `Y` | orientation | flip vertical |
+| `XY` | orientation | flip horizontal + vertical |
+| `B` | mode | **B**ackup background + draw + erase (sprite mobile sur fond) |
+| `D` | mode | **D**raw seul, pas de sauvegarde de fond (sprite statique ou fond) |
+| `0` | shift | position pair (pixel 0) |
+| `1` | shift | position impair (décalage 1 pixel) |
+| `DMAP` | mode spécial | Draw avec encodage RLE map |
+| `DZX0` | mode spécial | Draw avec compression ZX0 |
+
+Composition typique : `<orientation><mode><shift>`
+
+| Variante | Signification |
+|----------|---------------|
+| `NB0` | Normal, Backup mode, position 0 |
+| `NB1` | Normal, Backup mode, position 1 (shift 1px) |
+| `ND0` | Normal, Draw seul, position 0 |
+| `ND1` | Normal, Draw seul, position 1 |
+| `XB0` / `XB1` | Flip horizontal, Backup |
+| `YB0` / `YB1` | Flip vertical, Backup |
+| `XYB0` / `XYB1` | Flip H+V, Backup |
+| `XD0` / `XD1` | Flip horizontal, Draw seul |
+| `DMAP` | Draw avec encodage MAP RLE (compression d'images de fond) |
+| `DZX0` | Draw avec compression ZX0 |
+
+### Quelle variante utiliser ?
+
+- **Sprite mobile** (joueur, ennemi qui bouge à 1px près) : `NB0,NB1` au minimum, **plus** `XB0,XB1` si le sprite doit être miroir → `NB0,NB1,XB0,XB1`
+- **Sprite fixe** (icône, HUD, logo) : `NB0` suffit
+- **Image de fond** : `ND0` ou `ND0;_full` (cas `Img_intro_000=path,path,,_full;ND0`)
+- **Sprite tilemap** : `DMAP` (compression RLE optimisée pour tiles)
+- **Données de scroll** : `DZX0` (compression ZX0)
+
+### `_autopal(min-max)` — palette automatique
+
+Permet au builder de tester différentes permutations de palette pour optimiser la compression :
+
+```properties
+sprite.Img_anim_001=./image.png:_autopal(2-5),./image_ref.png;ND0
+```
+
+Le builder essaiera différentes permutations des index palette 2 à 5 (4 couleurs) pour minimiser la taille compressée.
+
+> ⚠️ **Index PNG vs index runtime Thomson** : les valeurs `2-5` dans `_autopal(2-5)` sont des **index PNG** (indexation côté éditeur image, avec 0 = transparent). À l'exécution, ils correspondent aux slots Thomson `1-4` (shift de -1, cf. `PaletteTO8.java` qui lit le PNG sur les index 1..16 et écrit dans les slots Thomson 0..15). Si on adresse manuellement la palette via `$E7DB` ou des tables raster, utiliser l'index **runtime** = idx PNG − 1. Voir [thomson-to8-engine-palette/references/palette-system.md](../../thomson-to8-engine-palette/references/palette-system.md) section "Index couleur : PNG vs runtime Thomson".
+
+### `_full` — désactiver l'entrelacement
+
+```properties
+sprite.Img_intro_000=./000.png,./000.png,,_full;ND0
+```
+
+Force le mode plein écran non-entrelacé. Utile pour les images de splash / titre statiques.
+
+---
+
+## 3. `animation.Ani_<Nom>=...` — séquence d'animation
+
+Le builder supporte **deux formats** d'animation. La distinction se fait sur la **présence d'une virgule** dans le premier champ après le `=`.
+
+### Format v00 — simple (legacy)
+
+Le 1er champ est un entier : **duration globale** (durée commune en frames pour toutes les images).
+
+```
+animation.Ani_<Nom>=<duration>;<Img_1>;<Img_2>;...;<endTag>[;<param>]
+```
+
+```properties
+animation.Ani_Idle=2;Img_Idle_000;Img_Idle_001;Img_Idle_002;Img_Idle_003;_resetAnim
+animation.Ani_Run=4;Img_Run_001;Img_Run_002;Img_Run_003;Img_Run_004;_goBackNFrames;3
+animation.Ani_Die=0;Img_Die_001;_nextRoutine
+```
+
+- `duration` est stockée **moins 1** en mémoire (`0` = 1 frame par image, `1` = 2 frames, etc.)
+- Chaque `Img_<X>` est résolu en pointeur vers le sprite (2 octets `fdb`)
+- Les `_endTags` (cf. ci-dessous) terminent la séquence
+
+### Format v02 — avancé (durée + flags par frame)
+
+Le 1er champ contient des virgules : chaque frame est `<Img>,<duration>,<flags>` :
+
+```
+animation.Ani_<Nom>=<Img_1>,<duration>,<flags>;<Img_2>,<duration>,<flags>;...;<endTag>[;<param>]
+```
+
+```properties
+animation.Ani_PlayerWalk=Img_Walk_001,4,$00;Img_Walk_002,4,$00;Img_Walk_003,4,$00;_resetAnim
+animation.Ani_AttackCombo=Img_Atk_001,3,$00;Img_Atk_002,2,$01;Img_Atk_003,5,$02;_nextRoutine
+```
+
+- `duration` (per frame, décrémentée de 1 par le builder) — nombre de frames d'affichage de cette image
+- `flags` (1 octet) — offset dans une `anim_flags` LUT, sert à déclencher des callbacks (hitbox, son) au moment précis de cette frame
+- Format stocké en mémoire : 5 octets par frame (`fdb image; fcb duration; fcb flags`)
+
+> **Important** : Le builder déclenche `Animation v02 need three comma separated parameters` si le champ contient une virgule mais pas exactement deux virgules.
+
+### Tags de fin d'animation
+
+| Tag | Taille (octets) | Effet |
+|-----|-----------------|-------|
+| `_resetAnim` | 1 | Recommence l'animation depuis le début (boucle infinie) |
+| `_goBackNFrames` | 2 | `_goBackNFrames;<N>` — Recule de N frames dans la séquence |
+| `_goToAnimation` | 3 | `_goToAnimation;<Ani_X>` — Bascule sur une autre animation (pointeur 2 octets) |
+| `_nextRoutine` | 1 | `inc routine,u` — passe à la routine suivante de l'objet |
+| `_resetAnimAndSubRoutine` | 1 | Reset anim ET routine secondaire (`routine_secondary=0`) |
+| `_nextSubRoutine` | 1 | `inc routine_secondary,u` |
+
+Exemples :
+```properties
+animation.Ani_LoopForever=2;Img_a;Img_b;Img_c;_resetAnim
+
+animation.Ani_PingPong=2;Img_a;Img_b;Img_c;Img_d;_goBackNFrames;3
+; Lecture : a,b,c,d puis recule de 3 = revient à b, donc lit b,c,d,b,c,d,... 
+
+animation.Ani_ChainToOther=2;Img_intro_a;Img_intro_b;_goToAnimation;Ani_loop
+; Joue Ani_intro_a puis Ani_intro_b puis bascule sur Ani_loop
+
+animation.Ani_AnimateThenStateChange=2;Img_die_a;Img_die_b;_nextRoutine
+; Joue l'anim puis incrémente routine,u — l'objet passe à sa logique suivante
+```
+
+---
+
+## 4. `animation-data` — données binaires associées à l'animation
+
+```properties
+animation-data=./global/preset/loadFirePreset.bin
+```
+
+Place un blob binaire **au début** des données d'animation de l'objet (référencé par `AnimationBin`). Cas d'usage : scripts précompilés `moveByScript`, tables de constantes spécifiques.
+
+> Limité à **1 seule** entrée par objet (`if (animationDataProperties.size()>1) throw new Exception`).
+
+---
+
+## 5. `sound.<Nom>` et `data.<Nom>` — données binaires
+
+Mêmes propriétés (le builder fusionne les deux maps : `soundsProperties.putAll(dataProperties)`).
+
+```
+sound.<Nom>=<file>[;RAM]
+data.<Nom>=<file>[;RAM]
+```
+
+```properties
+# Audio
+sound.Snd_jump=./objects/player/sounds/jump.bin
+sound.Snd_die=./objects/player/sounds/die.bin;RAM
+
+# Données binaires non-audio (préférer data.)
+data.Lvl_map=./objects/levels/01/map.bin
+data.Lvl_tiles=./objects/levels/01/tiles.bin;RAM
+```
+
+Le suffixe `;RAM` force le placement en RAM (sinon ROM).
+
+> Note du code source : `// TODO sound is to be renamed by data — we are using an alias here`. Préférer `data.X` pour les binaires non-audio.
+
+---
+
+## 6. `tileset.<Nom>` — tilesets pour scrolling
+
+Syntaxe :
+```
+tileset.<Nom>=<file>;<nbTiles>,<nbColumns>,<nbRows>[,<centerMode>[,<mapFile>[,<mapBitDepth>]]]
+```
+
+| Champ | Valeur | Description |
+|-------|--------|-------------|
+| `file` | chemin PNG | Image du tileset (une grille de tiles) |
+| `nbTiles` | entier | Nb total de tiles dans l'image |
+| `nbColumns` | entier | Nb de colonnes de la grille |
+| `nbRows` | entier | Nb de lignes de la grille |
+| `centerMode` | `CENTER`/`TOP_LEFT`/`TILE8x16`/`TILE16x16` | Mode de centrage (défaut `TOP_LEFT`) |
+| `mapFile` | chemin | Fichier de map de tiles (optionnel) |
+| `mapBitDepth` | `8` ou autre | Profondeur de bit pour les ID de tiles dans la map (défaut 8) |
+
+```properties
+tileset.TileSet_levelA=./objects/scroll/levelTilesetA.png;61,8,8,TILE16x16
+tileset.TileSet_with_map=./objects/scroll/tiles.png;100,10,10,TILE16x16,./objects/scroll/map.bin,16
+```
+
+> Les tilesets sont **toujours placés en RAM** (`tileset.inRAM = true;` codé en dur, commentaire : « tileset should always be in RAM for rendering speed »).
+
+---
+
+## 7. `spriteIndex=RAM` / `animationIndex=RAM`
+
+Place respectivement l'**index des sprites** et l'**index des animations** en RAM au lieu de ROM. Utile quand on a beaucoup de sprites/animations et qu'on veut éviter le bank switching.
+
+```properties
+spriteIndex=RAM
+animationIndex=RAM
+```
+
+Aucun effet si la valeur n'est pas `RAM` (équivalent à absent).
+
+---
+
+## Exemples complets
+
+### Objet minimal — un fond non-animé
+
+```properties
+code=./objects/background/background.asm
+
+sprite.Img_background=./objects/background/image/bg.png;ND0
+```
+
+### Player avec idle + run + flip horizontal (pattern bubble-bobble)
+
+```properties
+code=./objects/player/player.asm
+
+# Sprites en mode Backup, positions 0/1, et leurs miroirs horizontaux
+sprite.Img_Player_Run_001=./objects/player/image/run0001.png;NB0,NB1,XB0,XB1
+sprite.Img_Player_Run_002=./objects/player/image/run0002.png;NB0,NB1,XB0,XB1
+sprite.Img_Player_Run_003=./objects/player/image/run0003.png;NB0,NB1,XB0,XB1
+sprite.Img_Player_Jump_001=./objects/player/image/jump0001.png;NB0,NB1,XB0,XB1
+sprite.Img_Player_Fall_001=./objects/player/image/fall0001.png;NB0,NB1,XB0,XB1
+
+# Animations
+animation.Ani_Player_Wait=20;Img_Player_Run_001;Img_Player_Run_003;_resetAnim
+animation.Ani_Player_Run=4;Img_Player_Run_001;Img_Player_Run_002;Img_Player_Run_003;_resetAnim
+animation.Ani_Player_Jump=4;Img_Player_Jump_001;_resetAnim
+animation.Ani_Player_Fall=4;Img_Player_Fall_001;_resetAnim
+```
+
+### Background animé (image plein écran, pattern 2026)
+
+```properties
+code=./objects/background/background.asm
+
+# Sprite chaque frame est un delta de la frame précédente
+sprite.Img_intro_000=./objects/background/frameintro/000.png,./objects/background/frameintro/000.png,,_full;ND0
+sprite.Img_intro_006=./objects/background/frameintro/006.png,./objects/background/frameintro/000.png,,_full;ND0
+sprite.Img_intro_010=./objects/background/frameintro/010.png,./objects/background/frameintro/006.png,,_full;ND0
+# ... (chaque frame = delta avec une frame précédente, le builder compresse)
+
+# Animation
+animation.Ani_Background=7;Img_intro_000;Img_intro_006;Img_intro_010;_goToAnimation;Ani_Background_loop
+```
+
+### Objet avec tileset + maps (pattern bubble-bobble scroll)
+
+```properties
+code=./objects/scroll/scroll.asm
+
+tileset.TileSet=./objects/scroll/map.tiles.png;61,8,8,TILE16x16
+data.Map_level1=./objects/scroll/map_level1.bin;RAM
+
+spriteIndex=RAM
+animationIndex=RAM
+```
+
+---
+
+## Erreurs courantes au niveau objet
+
+| Message | Cause | Solution |
+|---------|-------|----------|
+| `Only one code or common-code property allowed` | Les deux sont définis | Garder uniquement `code=` |
+| `One code or common-code property mandatory` | Aucun des deux | Ajouter `code=./path/to/<obj>.asm` |
+| `Only one animation-data allowed` | Plusieurs `animation-data` | N'en garder qu'un |
+| `Animation v02 need three comma separated parameters` | Format animation v02 incorrect | Vérifier `Img,duration,flags` avec exactement 2 virgules |
+| Sprite ne s'affiche pas après un flip | Variante miroir manquante | Ajouter `XB0,XB1` ou `XD0,XD1` aux variants |
+| `Undefined symbol: Img_<X>` lors de l'assembly | Sprite référencé dans le code mais pas déclaré | Ajouter le `sprite.Img_<X>=...` |
+| `Undefined symbol: Ani_<X>` | Animation référencée mais pas déclarée | Ajouter le `animation.Ani_<X>=...` |

--- a/skills/thomson-to8-engine-new-game/references/object-skeleton.md
+++ b/skills/thomson-to8-engine-new-game/references/object-skeleton.md
@@ -1,0 +1,549 @@
+# Squelette d'un objet — `objects/<name>/<name>.asm`
+
+Tout objet du framework suit la même architecture : un **point d'entrée** qui saute via une **table de routines indexée par `routine,u`**, et un ensemble de **routines** (Init, Main, et autres états) qui modifient les champs de l'OST (Object Status Table) pointée par `u`.
+
+---
+
+## Architecture en 4 sections
+
+```
+┌─ HEADER : INCLUDE macros + constantes locales
+│
+├─ ENTRY POINT : <Name>  (= nom exact de l'objet déclaré dans main.properties)
+│      lda routine,u
+│      asla
+│      ldx #<Name>_Routines
+│      jmp [a,x]
+│
+├─ ROUTINES TABLE : <Name>_Routines  (fdb vers chaque routine)
+│      fdb Init       ← routine 0
+│      fdb Main       ← routine 1
+│      fdb ...
+│
+└─ ROUTINES : Init, Main, ... (logique métier)
+```
+
+---
+
+## Squelette canonique
+
+```asm
+; ---------------------------------------------------------------------------
+; Object - <Name>
+;
+; input REG : [u] pointer to Object Status Table (OST)
+; ---------------------------------------------------------------------------
+
+        INCLUDE "./engine/macros.asm"
+        ; INCLUDE "./engine/collision/macros.asm"      ; si l'objet utilise des AABB
+        ; INCLUDE "./engine/collision/struct_AABB.equ" ; idem
+
+; -------- Constantes locales à l'objet --------
+Init_routine    equ 0
+Main_routine    equ 1
+Die_routine     equ 2
+
+; -------- Variables locales (offsets dans ext_variables) --------
+; Si ext_variables_size >= N dans ram-data.asm, on peut réserver des slots :
+my_counter      equ ext_variables       ; 1 octet à l'offset ext_variables (souvent +38)
+my_target_addr  equ ext_variables+1     ; 2 octets
+
+; -------- Entry point (= nom exact de l'objet) --------
+<Name>
+        lda   routine,u
+        asla                            ; *2 (table de fdb donc 2 octets par entrée)
+        ldx   #<Name>_Routines
+        jmp   [a,x]                     ; saut indirect
+
+; -------- Table de routines --------
+<Name>_Routines
+        fdb   Init                      ; routine 0 — exécutée une fois
+        fdb   Main                      ; routine 1 — exécutée à chaque frame
+        fdb   Die                       ; routine 2 — état "mort" éventuel
+
+; ============================================================================
+; ROUTINE 0 — Init
+; Exécutée la première frame après allocation. Doit terminer par inc routine,u
+; (sinon Init est rappelée à l'infini)
+; ============================================================================
+Init
+        ; --- Sélectionner l'animation par défaut ---
+        ldd   #Ani_<defaultAnim>
+        std   anim,u
+
+        ; --- Priorité d'affichage (1=front, 8=back) ---
+        ldb   #4
+        stb   priority,u
+
+        ; --- Position initiale (en coord ÉCRAN, sur 1 octet) ---
+        ; ATTENTION — règle de positionnement du centre :
+        ;   center_pos = ceil(sprite_size/2) - 1
+        ; Pour un sprite 16x16 centré sur (X=80, Y=100) à l'écran :
+        ;   x_pixel = 80 - 7 = 73  (= 80 - (ceil(16/2)-1))
+        ;   y_pixel = 100 - 7 = 93
+        ; Si le sprite déborde de l'écran ET que render_xloop_mask n'est
+        ; PAS activé, l'engine peut décider de ne rien afficher du tout
+        ; (clipping out total) — le sprite disparaît silencieusement !
+        ldd   #$80AF                    ; x=$80=128, y=$AF=175
+        std   xy_pixel,u
+
+        ; --- CRITIQUE pour sprites ND* (Normal Draw sans backup) ---
+        ; Si le sprite est compilé en variant ND0/ND1/XD0/etc. (donc sans
+        ; sauvegarde du fond), il FAUT poser render_overlay_mask. Sinon
+        ; l'engine traite le sprite comme un background-erase et cherche
+        ; un backup qui n'existe pas → rien ne s'affiche (silencieux).
+        ; Cette ligne est INUTILE pour les variants NB*/XB* (mode backup).
+        lda   render_flags,u
+        ora   #render_overlay_mask
+        sta   render_flags,u
+
+        ; Variante : position en coord PLAYFIELD (sur 2 octets pour scrolling)
+        ; ldd   #200
+        ; std   x_pos,u
+        ; ldd   #100
+        ; std   y_pos,u
+        ; lda   render_flags,u
+        ; ora   #render_playfieldcoord_mask
+        ; sta   render_flags,u
+
+        ; --- Render flags additionnels (optionnel) ---
+        ; lda   render_flags,u
+        ; ora   #render_overlay_mask    ; sprite sans backup de fond
+        ; sta   render_flags,u
+
+        ; --- Orientation initiale (optionnel) ---
+        ; lda   status_flags,u
+        ; ora   #status_xflip_mask
+        ; sta   status_flags,u
+
+        ; --- Variables locales ---
+        clr   my_counter,u
+
+        ; --- Si l'objet a une AABB de collision ---
+        ; lda   #-1                     ; potentiel infini (toujours actif)
+        ; sta   AABB_0+AABB.p,u
+        ; _ldd  4,8                     ; rayon hitbox (rx=4, ry=8)
+        ; std   AABB_0+AABB.rx,u
+        ; _Collision_AddAABB AABB_0,AABB_list_player
+
+        ; --- Passer en routine 1 (NE PAS OUBLIER !) ---
+        inc   routine,u
+
+; ============================================================================
+; ROUTINE 1 — Main (exécutée à chaque frame)
+; ============================================================================
+Main
+        ; --- Lecture inputs (joypad) ---
+        lda   Dpad_Held
+        bita  #c1_button_left_mask
+        beq   @notLeft
+        dec   x_pixel,u
+@notLeft
+        bita  #c1_button_right_mask
+        beq   @notRight
+        inc   x_pixel,u
+@notRight
+
+        ; --- Animation + rendu (TOUJOURS en queue de Main) ---
+        jsr   AnimateSprite
+        jmp   DisplaySprite
+
+; ============================================================================
+; ROUTINE 2 — Die
+; ============================================================================
+Die
+        ; Marquer pour suppression au prochain frame
+        lda   render_flags,u
+        ora   #render_todelete_mask
+        sta   render_flags,u
+        rts
+```
+
+---
+
+## Offsets OST complets
+
+Tous ces offsets sont définis dans `engine/constants.asm`. Ils s'utilisent avec le suffixe `,u` (ou `,x` selon le registre passé).
+
+### Identité
+
+| Offset | Symbole | Taille | Rôle |
+|--------|---------|--------|------|
+| 0 | `id` | 1 octet | `ObjID_<nom>` (0 = slot libre) |
+| 1 | `subtype` | 1 octet | `Sub_<nom>` — variante de l'objet (ex: ennemi de tel niveau) |
+| 1 | `subtype_w` | 2 octets | Variante 2 octets (chevauche `render_flags`) |
+| 2 | `render_flags` | 1 octet | Flags de rendu (cf. tableau ci-dessous) |
+| 3 | `run_object_prev` | 2 octets | Chaînage liste — précédent (géré par engine) |
+| 5 | `run_object_next` | 2 octets | Chaînage liste — suivant (géré par engine) |
+
+### Affichage
+
+| Offset | Symbole | Taille | Rôle |
+|--------|---------|--------|------|
+| 7 | `priority` | 1 octet | Priorité 0-8. **0 = invisible**, 1 = devant (1er plan), 8 = arrière |
+| 8 | `anim` | 2 octets | Pointeur vers `Ani_<X>` |
+| 10 | `prev_anim` | 2 octets | Animation précédente (pour transitions) |
+| 10 | `sub_anim` | 2 octets | Animation secondaire (overlap avec `prev_anim`) |
+| 12 | `anim_frame` | 1 octet | Index de la frame courante dans l'animation |
+| 13 | `anim_frame_duration` | 1 octet | Compteur restant de frames pour l'image courante (0-127) |
+| 13 | `wave_frame_drop` | 1 octet | (overlap) Frame drop pour object wave |
+| 14 | `anim_flags` | 1 octet | Offset dans LUT `anim_flags` (v02 advanced) ou flag de link |
+| 14 | `status_flags` | 1 octet | (overlap) Orientation : xflip/yflip |
+| 16 | `image_set` | 2 octets | Pointeur vers `Img_<X>` actuel (0000 = pas d'image) |
+
+### Position et vitesse
+
+| Offset | Symbole | Taille | Rôle |
+|--------|---------|--------|------|
+| 18 | `x_pos` | 2 octets | Position X en coord playfield (signed) |
+| 20 | `x_sub` | 1 octet | Sub-pixel X (1/256 de pixel) — doit suivre `x_pos` |
+| 21 | `y_pos` | 2 octets | Position Y en coord playfield (signed) |
+| 23 | `y_sub` | 1 octet | Sub-pixel Y — doit suivre `y_pos` |
+| 24 | `xy_pixel` | 2 octets | Position écran (x_pixel + y_pixel groupés) |
+| 24 | `x_pixel` | 1 octet | Position X écran (0-159 selon mode) |
+| 25 | `y_pixel` | 1 octet | Position Y écran (0-199) — doit suivre `x_pixel` |
+| 26 | `x_vel` | 2 octets | Vitesse horizontale signed 8.8 (fixed point) |
+| 28 | `y_vel` | 2 octets | Vitesse verticale signed 8.8 |
+| 30 | `x_acl` | 2 octets | Accélération horizontale 8.8 (gravité) |
+| 32 | `y_acl` | 2 octets | Accélération verticale 8.8 |
+
+### Routines
+
+| Offset | Symbole | Rôle |
+|--------|---------|------|
+| 34 | `routine` | Index de la routine principale (table primaire) |
+| 35 | `routine_secondary` | Index de la routine secondaire |
+| 36 | `routine_tertiary` | Index de la routine tertiaire |
+| 37 | `routine_quaternary` | Index de la routine quaternaire |
+
+### Extensions
+
+| Symbole | Rôle |
+|---------|------|
+| `ext_variables` | = `object_base_size` (souvent 38). Start de l'espace utilisateur si `ext_variables_size > 0` |
+
+---
+
+## `render_flags` — table des bits
+
+### Mode background-erase (par défaut)
+
+| Bit | Mask | Symbole | Effet |
+|-----|------|---------|-------|
+| 0 | $01 | `render_xmirror_mask` | Mirroir horizontal du sprite |
+| 1 | $02 | `render_ymirror_mask` | Mirroir vertical du sprite |
+| 2 | $04 | `render_overlay_mask` | Mode overlay : pas de backup du fond (sprite "additif") |
+| 3 | $08 | `render_playfieldcoord_mask` | Coord playfield (1) vs écran (0) |
+| 4 | $10 | `render_xloop_mask` | Loop sprite hors écran X |
+| 5 | $20 | `render_todelete_mask` | Marquer pour suppression par engine |
+| 6 | $40 | `render_subobjects_mask` | Render sous-objets |
+| 7 | $80 | `render_hide_mask` | Cacher sprite sans libérer la prio/mapping |
+
+### Mode overlay (`OverlayMode equ 1`)
+
+| Bit | Mask | Symbole | Effet |
+|-----|------|---------|-------|
+| 0 | $01 | `render_xmirror_mask` | Mirroir horizontal |
+| 1 | $02 | `render_ymirror_mask` | Mirroir vertical |
+| 3 | $08 | `render_playfieldcoord_mask` | Coord playfield |
+| 4 | $10 | `render_xloop_mask` | Loop X |
+| 5 | $20 | `render_no_range_ctrl_mask` | **DANGER** : skip out-of-range (peut corrompre la mémoire) |
+| 6 | $40 | `render_subobjects_mask` | Sous-objets |
+| 7 | $80 | `render_hide_mask` | Cacher |
+
+> Le mode est sélectionné par la présence de `OverlayMode equ 1` au début du `main.asm`. `render_overlay_mask` n'existe **pas** en mode overlay.
+
+---
+
+## `status_flags` — bits d'orientation
+
+| Bit | Mask | Symbole | Effet |
+|-----|------|---------|-------|
+| 0 | $01 | `status_xflip_mask` | Flip horizontal (s'applique pendant AnimateSprite) |
+| 1 | $02 | `status_yflip_mask` | Flip vertical |
+
+---
+
+## `priority` — sémantique
+
+| Valeur | Signification |
+|--------|---------------|
+| 0 | **Rien à afficher** (sprite invisible mais routine continue à tourner) |
+| 1 | Front (1er plan) — dessiné en dernier, masque les autres |
+| 2-7 | Intermédiaires (plus la valeur est faible, plus l'objet est devant) |
+| 8 | Back (arrière-plan) — dessiné en premier |
+
+---
+
+## Routines auxiliaires (secondary, tertiary, quaternary)
+
+On peut implémenter des **state machines en parallèle** dans un même objet :
+
+```asm
+Main
+        ; sous-machine principale
+        lda   routine_secondary,u
+        asla
+        ldx   #Main_Secondary_Table
+        jmp   [a,x]
+
+Main_Secondary_Table
+        fdb   Walking
+        fdb   Jumping
+        fdb   Crouching
+```
+
+Pratique pour découpler la logique (animation/déplacement/IA) sans avoir à multiplier les routines de niveau 1.
+
+---
+
+## Patterns de routines
+
+### Init + Main (le plus simple)
+
+```asm
+<Name>_Routines
+        fdb   Init
+        fdb   Main
+
+Init
+        ldd   #Ani_Idle
+        std   anim,u
+        ldb   #4
+        stb   priority,u
+        inc   routine,u
+
+Main
+        jsr   AnimateSprite
+        jmp   DisplaySprite
+```
+
+### Init + Main avec destruction conditionnelle
+
+```asm
+<Name>_Routines
+        fdb   Init
+        fdb   Main
+        fdb   Die
+
+Init
+        ldd   #Ani_alive
+        std   anim,u
+        ldb   #2
+        stb   priority,u
+        inc   routine,u
+
+Main
+        ; ... logique ...
+        tst   <my_health
+        bne   @alive
+        ldb   #Die_routine
+        stb   routine,u
+        rts
+@alive
+        jsr   AnimateSprite
+        jmp   DisplaySprite
+
+Die
+        ; lance une animation "explosion" puis se supprime
+        ldd   #Ani_explosion
+        std   anim,u
+        lda   render_flags,u
+        ora   #render_todelete_mask     ; sera supprimé après l'animation
+        sta   render_flags,u
+        jsr   AnimateSprite
+        jmp   DisplaySprite
+```
+
+### Avec switch sur subtype (un même objet, plusieurs ennemis)
+
+```asm
+Init
+        lda   subtype,u
+        asla
+        ldx   #Init_BySubtype
+        jmp   [a,x]
+
+Init_BySubtype
+        fdb   Init_Subtype0
+        fdb   Init_Subtype1
+        fdb   Init_Subtype2
+
+Init_Subtype0
+        ldd   #Ani_TypeA
+        std   anim,u
+        ; ...
+        inc   routine,u
+        rts
+
+Init_Subtype1
+        ldd   #Ani_TypeB
+        std   anim,u
+        ; ...
+        inc   routine,u
+        rts
+```
+
+---
+
+## Création d'un objet fils
+
+Pendant `Init` ou `Main`, on peut allouer un sous-objet :
+
+```asm
+        pshs  u                         ; sauve l'OST du parent
+        jsr   LoadObject_u              ; alloue, retourne u (Z=1 si plein)
+        beq   @noslot
+        lda   #ObjID_Bullet
+        sta   id,u                      ; l'objet créé est mis dans la queue
+        ldd   x_pos,s                   ; recopier position parent
+        std   x_pos,u
+        ; ... init complémentaire du fils ...
+@noslot
+        puls  u                         ; restaure l'OST du parent
+```
+
+Variante avec `LoadObject_x` (préserve `u`) :
+
+```asm
+        jsr   LoadObject_x              ; alloue, retourne x (Z=1 si plein)
+        beq   @noslot
+        lda   #ObjID_Bullet
+        sta   id,x
+        ldd   x_pos,u                   ; u parent reste accessible
+        std   x_pos,x
+@noslot
+```
+
+---
+
+## Différences entre routines moteur
+
+| Routine | Quand l'utiliser |
+|---------|------------------|
+| `AnimateSprite` | Animation simple, indépendant du framerate |
+| `AnimateSpriteSync` | Animation synchronisée au framerate effectif (`gfxlock.frameDrop.count`). Préférable pour gameplay homogène |
+| `DisplaySprite` | Termine la routine ET marque l'objet pour affichage |
+| `ObjectMove` | Applique x_vel/y_vel à x_pos/y_pos |
+| `ObjectMoveSync` | Version sync (multiplie le vel par le frame drop) |
+| `ObjectFall` / `ObjectFallSync` | Applique y_acl à y_vel puis y_vel à y_pos (gravité) |
+
+> **Règle** : terminer `Main` par `jmp DisplaySprite` (pas `jsr`) — `DisplaySprite` se finit par `rts`, donc le saut direct est équivalent à un `jsr` suivi de `rts`, mais 4 cycles plus rapide.
+
+---
+
+## Suppression / déchargement d'un objet
+
+Deux approches :
+
+### Suppression auto via `render_todelete_mask`
+
+```asm
+        lda   render_flags,u
+        ora   #render_todelete_mask
+        sta   render_flags,u
+        ; l'engine supprimera l'objet au prochain EraseSprites
+```
+
+### Suppression manuelle
+
+```asm
+        jsr   UnloadObject_u            ; libère le slot et délink de la run-list
+        ; après cet appel, u n'est plus valide
+        rts                             ; sortir immédiatement
+```
+
+---
+
+## Patterns spéciaux
+
+### Objet en Direct Page (joueur principal, accès rapide)
+
+Si dans `ram-data.asm` on a `player1 equ dp`, alors le code du joueur peut utiliser :
+
+```asm
+        ; au lieu de ldd x_pos,u (3 cycles + offset)
+        ldd   <x_pos                    ; (2 cycles, mode direct page)
+```
+
+L'objet n'est pas alloué via `LoadObject_u` — il occupe directement la zone DP. Sa routine doit être appelée manuellement (par exemple avec `_RunObjectSwap` ou `_MountObject` + `jsr ,x`).
+
+### Objet sans rendu (audio, logique pure)
+
+```asm
+        ldb   #0
+        stb   priority,u                ; aucune priorité = pas d'affichage
+        ; la routine principale ne fait pas jmp DisplaySprite, juste rts
+```
+
+### Objet self-referencing dans Main (suppression de slot)
+
+Quand un objet se supprime lui-même mais doit laisser passer au suivant sans crasher la chaîne :
+
+```asm
+Main
+        ; ... condition de suppression ...
+        ldb   render_flags,u
+        orb   #render_todelete_mask
+        stb   render_flags,u
+        ; le moteur sauvegarde run_object_next AVANT d'appeler la routine
+        ; donc la suppression auto fonctionne sans précautions
+        rts
+```
+
+---
+
+## Règles critiques à connaître (sous peine de sprite invisible)
+
+### 1. `render_overlay_mask` OBLIGATOIRE pour les variants ND*
+
+Si le sprite est déclaré dans `.properties` avec un variant `ND0`, `ND1`, `XD0`, `XD1`, `YD*`, `XYD*` (mode Draw seul, sans backup du fond), il faut **impérativement** poser `render_overlay_mask` dans `render_flags,u` dans la routine `Init` :
+
+```asm
+        lda   render_flags,u
+        ora   #render_overlay_mask
+        sta   render_flags,u
+```
+
+**Pourquoi** : sans ce flag, l'engine considère que le sprite est un sprite « backup-and-restore » et cherche le code d'erase compilé — qui n'existe pas pour les variants ND. Résultat : **le sprite ne s'affiche pas** (échec silencieux, aucune erreur).
+
+**Quand le flag est inutile** : pour les variants `NB0`/`NB1`/`XB*`/`YB*`/`XYB*` (mode Backup), `render_overlay_mask` doit rester à 0 (l'engine utilise alors le backup compilé).
+
+### 2. Position du centre du sprite = `ceil(taille/2)-1`
+
+Pour positionner un sprite avec sa convention CENTER (origine = centre interne), l'engine utilise comme offset interne :
+
+```
+center_internal_offset = ceil(sprite_size / 2) - 1
+```
+
+Pas `taille/2` direct. Pour les tailles paires, c'est **un pixel avant** ce qu'on attendrait :
+
+| Taille sprite | center_internal_offset | Pour centrer le sprite à l'écran X=80 |
+|---------------|------------------------|--------------------------------------|
+| 8 px | 3 | x_pixel = 80 - 3 = 77 |
+| 16 px | 7 | x_pixel = 80 - 7 = 73 |
+| 32 px | 15 | x_pixel = 80 - 15 = 65 |
+| 100 px | 49 | x_pixel = 80 - 49 = 31 |
+| 160 px | 79 | x_pixel = 80 - 79 = 1 |
+
+**Pour qu'un sprite 160 px occupe parfaitement les 160 colonnes de l'écran (0-159)** :
+- center_internal_offset = 79
+- top-left souhaité à x=0 → x_pixel = 79 (et non 80)
+
+**Risque si on se trompe d'un pixel** : le sprite peut déborder de l'écran. Et si `render_xloop_mask` n'est PAS activé, l'engine peut décider de **ne pas dessiner le sprite du tout** (clipping out total). Le sprite disparaît silencieusement → on se demande pourquoi pendant des heures.
+
+**Sécurité** : si le sprite est trop large/déborde par design, poser aussi `render_xloop_mask` pour permettre le wrap horizontal hors écran.
+
+---
+
+## Pitfalls
+
+- **`Init` qui ne fait pas `inc routine,u`** : la routine 0 est rappelée à chaque frame → l'objet ne fait jamais autre chose qu'initialiser.
+- **`asla` oublié** dans le saut indirect : `[a,x]` lit 1 octet au lieu de 2 → JMP vers une adresse fausse → crash.
+- **`<Name>_Routines` mal indexé** : si la table n'a que 2 entrées et que `routine,u = 2`, le `jmp [a,x]` lit la mémoire suivante (peut tomber sur du code valide → comportement erratique).
+- **Modifier `id,u` à 0 dans Main** : marque le slot comme libre et l'engine peut le réattribuer immédiatement.
+- **Oublier `jmp DisplaySprite` en fin de Main** : le sprite n'est pas affiché. Si on veut conditionnellement ne pas afficher, mettre `priority = 0`.
+- **Référencer un `Ani_X` non déclaré** dans le .properties de l'objet : `Undefined symbol` au build.
+- **Init qui place le sprite à une position avec `xy_pixel`, mais `render_flags` a le bit `render_playfieldcoord_mask`** : le moteur utilise `x_pos`/`y_pos` (qui valent 0), pas `xy_pixel`. Choisir l'un OU l'autre, cohérent avec le flag.
+- **`AnimateSpriteSync` sans gfxlock** : la sync utilise `gfxlock.frameDrop.count`, qui n'est pas mis à jour sans `_gfxlock.loop`. Utiliser `AnimateSprite` (non-sync) avec `WaitVBL`.

--- a/skills/thomson-to8-engine-new-game/references/project-organization.md
+++ b/skills/thomson-to8-engine-new-game/references/project-organization.md
@@ -1,0 +1,200 @@
+# Organisation d'un game-project — arborescence canonique
+
+Ce document décrit la **structure de dossiers** d'un game-project dans le repo `thomson-to8-game-engine`. Tous les game-projects vivent dans `game-projects/<nom>/`. Cette organisation est imposée par le builder Java (`BuildDisk`) et par les chemins relatifs codés dans le `config-<os>.properties`.
+
+---
+
+## Arborescence canonique
+
+```
+game-projects/<nom-du-jeu>/
+├── config-windows.properties          [obligatoire — au moins une variante]
+├── config-macos.properties            [optionnel]
+├── config-linux.properties            [optionnel]
+├── config-windows.t2.properties       [optionnel — build cartouche T2]
+├── config-<x>.t2flash.properties      [optionnel — build cartouche T2 flash SDDRIVE]
+├── README.md                          [optionnel]
+├── <jeu>.code-workspace               [optionnel — config VSCode]
+├── dcmoto.lnk                         [optionnel — raccourci émulateur Windows]
+├── to8.config.xml                     [optionnel — config TEO/autre émulateur]
+├── memmap.csv / memmap.html           [optionnel — sortie diagnostique de build]
+├── music.xml                          [optionnel — métadonnées musique]
+├── genfont.php                        [optionnel — script utilitaire spécifique au projet]
+│
+├── game-mode/                         [obligatoire — au moins un sous-dossier]
+│   ├── <mode-A>/
+│   │   ├── main.properties            [obligatoire]
+│   │   ├── main.asm                   [obligatoire — point d'entrée ASM]
+│   │   ├── ram-data.asm               [obligatoire — déclaration Dynamic_Object_RAM]
+│   │   ├── main.t2.properties         [optionnel — variante T2]
+│   │   ├── main.d7.properties         [optionnel — variante disquette d7]
+│   │   ├── images/                    [optionnel — images spécifiques au mode]
+│   │   └── music/                     [optionnel — fichiers musicaux du mode]
+│   ├── <mode-B>/
+│   └── ...
+│
+├── objects/                           [obligatoire dès qu'un object.X est référencé]
+│   ├── <objet-A>/
+│   │   ├── <objet-A>.properties       [obligatoire]
+│   │   ├── <objet-A>.asm              [obligatoire — code de l'objet]
+│   │   ├── image/                     [convention — PNG sources]
+│   │   │   ├── frame_001.png
+│   │   │   └── ...
+│   │   └── ...                        [optionnel — sous-dossiers libres]
+│   └── ...
+│
+├── global/                            [optionnel — code partagé entre game-modes]
+│   ├── macro.asm
+│   ├── variables.asm
+│   ├── object.const.asm
+│   ├── scale.asm
+│   └── objects/                       [objets globaux partagés (ex: r-type/global/objects/)]
+│
+├── cfg/                               [optionnel — fichiers de config émulateur DCMOTO/lwtools]
+├── resources/                         [optionnel — assets sources hors PNG (musique brute, etc.)]
+├── tmp/                               [optionnel — scratch, ignoré par .gitignore]
+│
+├── generated-code/                    [généré par le build — à mettre dans .gitignore]
+│   ├── debug/
+│   └── ... fichiers .asm intermédiaires
+│
+└── dist/                              [généré par le build — produit final]
+    ├── <diskName>.fd
+    ├── <t2Name>.t2
+    └── <t2Name>.t2flash
+```
+
+---
+
+## Fichiers obligatoires vs optionnels
+
+| Élément | Obligatoire ? | Référencé par |
+|---------|---------------|---------------|
+| `config-<os>.properties` (au moins un) | OUI | passé en argument au builder Java |
+| `game-mode/<X>/main.properties` | OUI (≥ 1) | `gameMode.<X>=...` dans config racine |
+| `engine.asm.mainEngine` (fichier asm) | OUI | dans `main.properties` du game-mode |
+| Au moins une `palette.X=...` | OUI | builder lève « palette not found » sinon |
+| Au moins un `object.X=...` | OUI | builder lève « object not found » sinon |
+| `actBoot` | recommandé | si absent, `LoadAct` est généré vide |
+| `act.<actBoot>.palette/screenBorder/backgroundImage` | recommandé | sinon l'écran reste tel quel au démarrage |
+| `ram-data.asm` | OUI | inclus depuis `main.asm` (sinon `Dynamic_Object_RAM` non défini → erreur LWASM) |
+
+---
+
+## Conventions de nommage
+
+Le builder ne **transforme pas** les noms : ce que tu écris dans le `.properties` devient la constante asm. Les conventions de fait observées dans le repo :
+
+### Game-modes (`gameMode.<X>=...`)
+- **PascalCase** pour les titres et écrans : `TitleScreen`, `LevelSelect`, `EHZ`, `Loading`
+- **Lowercase ou avec digits** pour les niveaux numérotés : `level01`, `bonneannee`, `gamescreen`, `01`, `02`
+- Le builder génère `GmID_<X>` → `GmID_TitleScreen`, `GmID_level01`
+
+### Objets (`object.<X>=...`)
+- **PascalCase** pour les types : `Player`, `Bubble`, `Background`, `Player1`, `Weapon`, `Pow`
+- Multi-mots avec préfixes de namespace : `Player1`, `dobkeratops_jaw`, `forcepod_simplefire`
+- Le builder génère `ObjID_<X>` → `ObjID_Player`, `ObjID_dobkeratops_jaw`
+
+### Palettes (`palette.<X>=...`)
+- **Toujours préfixé `Pal_`** : `Pal_Background`, `Pal_TitleScreen`, `Pal_black`, `Pal_game`, `Pal_messages`
+
+### Sprites (`sprite.Img_<X>=...`)
+- **Toujours préfixé `Img_`** : `Img_Idle_000`, `Img_Player_Run_001`, `Img_bink_0`
+- Numérotation par frame de l'animation source : `_000`, `_001`, ... ou `_001`, `_002` (au choix du projet)
+
+### Animations (`animation.Ani_<X>=...`)
+- **Toujours préfixé `Ani_`** : `Ani_Idle`, `Ani_Player_Wait`, `Ani_Player_Jump`
+- Lien direct avec les routines : `Ani_Player_Run` ↔ routine `Run` ou `Ground_routine`
+
+### Backgrounds d'act (`act.<X>.backgroundImage=...`)
+- Le builder génère un label `Bgi_<actName>` → `Bgi_default`, `Bgi_titleScreen`
+
+### Game-modes communs (`gameModeCommon.<n>=...`)
+- La clé est un **index numérique** (`gameModeCommon.0`, `gameModeCommon.1`), pas un nom
+- Le builder lève une exception sinon (cf. `GameMode.java`)
+
+---
+
+## Variantes par target (.t2, .d7, .fd)
+
+Le builder accepte plusieurs game-mode `.properties` cohabitant pour différents targets. Convention observée :
+
+- `main.properties` — variante par défaut (souvent .fd)
+- `main.t2.properties` — variante cartouche T2 (ressources en ROM Mega)
+- `main.d7.properties` — variante disquette d7 (organisation RAM différente)
+
+Le choix est fait au niveau du `config-<os>.properties` :
+```properties
+gameMode.level01=./game-mode/01/main.d7.properties     ← cible disquette
+# Pour cartouche T2, on aurait :
+# gameMode.level01=./game-mode/01/main.t2.properties
+```
+
+Les variantes diffèrent typiquement par :
+- la quantité d'objets / sons placés en RAM (`,RAM` suffix sur les déclarations)
+- les chemins vers des objets variantes (`./objects/X/obj.d7.properties` vs `./objects/X/obj.t2.properties`)
+- les images de fond (compression différente)
+
+---
+
+## Dossier `global/` (pattern goldorak et r-type)
+
+Pour les jeux complexes qui ont plusieurs game-modes partageant du code, la convention émergente est de placer dans `global/` :
+
+- des **macros locales** (`global/macro.asm`, `global/macros.asm`)
+- des **constantes/équivalences** (`global/variables.asm`, `global/object.const.asm`, `global/scale.asm`)
+- des **routines partagées** (`global/projectile.asm`, `global/checkpoint.asm`)
+- des **objets globaux** (`global/objects/createFoeFire.properties`)
+- éventuellement un **préambule/trailer d'includes** factorisés (`global/global-preambule-includes.asm`, `global/global-trailer-includes.asm` — pattern goldorak)
+
+Ce dossier est inclus depuis le `main.asm` de chaque game-mode :
+```asm
+        INCLUDE "./global/macro.asm"
+        INCLUDE "./global/variables.asm"
+```
+
+---
+
+## Dossiers générés par le build
+
+À ajouter au `.gitignore` :
+
+```
+dist/
+generated-code/
+tmp/
+memmap.csv
+memmap.html
+*.fd
+*.t2
+*.t2flash
+```
+
+- `dist/` : produits finaux (`.fd`, `.t2`, `.t2flash`)
+- `generated-code/` : asm intermédiaires générés par le builder (un sous-dossier par objet, contenant les sprites compilés `.asm`/`.bin`/`.lst`)
+- `generated-code/debug/` : versions debug (assemblées avec listings et symboles)
+- `tmp/` : scratch libre du développeur
+
+---
+
+## Référencer le moteur depuis le game-project
+
+Deux schémas observés selon que le game-project est dans le **même repo** que l'engine ou dans un repo séparé :
+
+### Game-project dans `thomson-to8-game-engine/game-projects/<X>/` (cas standard)
+Chemins relatifs **deux crans au-dessus** :
+```properties
+engine.asm.boot.fd=../../engine/boot/boot-fd.asm
+builder.lwasm.includeDirs=../..,.
+builder.lwasm=../../tools/win/lwasm.exe
+```
+
+### Game-project dans un repo séparé (cas r-type observé)
+Chemins relatifs **trois crans au-dessus** vers le repo engine voisin :
+```properties
+engine.asm.boot.fd=../../../thomson-to8-game-engine/engine/boot/boot-fd.asm
+builder.lwasm.includeDirs=.,../..
+builder.lwasm=../../../thomson-to8-game-engine/tools/win/lwasm.exe
+```
+
+Attention : `builder.lwasm.includeDirs` contrôle ce qui est résolu par les `INCLUDE` du code asm — il doit pointer la racine d'où partent les chemins `./engine/...` utilisés dans le code.

--- a/skills/thomson-to8-engine-object-management/SKILL.md
+++ b/skills/thomson-to8-engine-object-management/SKILL.md
@@ -1,0 +1,327 @@
+---
+name: thomson-to8-engine-object-management
+description: "Décrit le système de gestion d'objets du Thomson TO8/TO9 game engine (Bento8/wide-dot) : allocation dynamique d'objets via LoadObject_u / LoadObject_x, libération via UnloadObject, exécution cyclique RunObjects sur run-list doublement chaînée (run_object_prev / run_object_next), pile d'allocation STACK_SLOT_ADDRESS / STACK_POINTER, état OST (Object Status Table) avec offsets id, subtype, render_flags, priority, anim, x_pos, y_pos, x_pixel, y_pixel, x_vel, y_vel, x_acl, y_acl, routine, routine_secondary/tertiary/quaternary, déplacements ObjectMove / ObjectMoveSync (synchro framerate), gravité ObjectFall / ObjectFallSync, marquage hors-écran MarkObjGone / MarkObjGone2 / MarkObjGone3 avec respawn_index, Obj_GetOrientationToPlayer pour IA, ObjectWave et ObjectWave-subtype pour spawn d'ennemis par script, ObjectDp pour joueur en Direct Page, _MountObject / _RunObject / _RunObjectSwap / RunPgSubRoutine pour exécution cross-page, ManagedObjects_ClearAll pour reset complet. Utiliser pour comprendre le cycle de vie d'un objet, gérer l'allocation/libération de slots, lancer une routine d'objet depuis le code main, créer des sous-objets (LoadObject_x préserve u), gérer un joueur principal en Direct Page, scripter l'apparition d'ennemis par vagues, détruire automatiquement les objets sortis de l'écran, ou faire courir un objet sans qu'il soit dans la run-list. Mots-clés : LoadObject_u, LoadObject_x, UnloadObject_u, UnloadObject_x, RunObjects, RunFrozenObjects, ManagedObjects_ClearAll, InitStack, STACK_POINTER, STACK_SLOT_ADDRESS, Dynamic_Object_RAM, Dynamic_Object_RAM_End, nb_dynamic_objects, nb_graphical_objects, ext_variables_size, object_size, object_base_size, object_rsvd_size, object_list_first, object_list_last, object_list_next, run_object_prev, run_object_next, id, subtype, subtype_w, render_flags, render_xmirror_mask, render_ymirror_mask, render_overlay_mask, render_playfieldcoord_mask, render_xloop_mask, render_todelete_mask, render_subobjects_mask, render_hide_mask, priority, anim, prev_anim, sub_anim, anim_frame, anim_frame_duration, anim_flags, status_flags, status_xflip_mask, status_yflip_mask, image_set, x_pos, x_sub, y_pos, y_sub, xy_pixel, x_pixel, y_pixel, x_vel, y_vel, x_acl, y_acl, routine, routine_secondary, routine_tertiary, routine_quaternary, ObjectMove, ObjectMoveSync, ObjectFall, ObjectFallSync, MarkObjGone, MarkObjGone2, MarkObjGone3, Obj_respawn_index, Obj_respawn_data, Object_Respawn_Table, respawn_index, Obj_GetOrientationToPlayer, Gotp_Closest_Player, Gotp_Player_Is_Left, Gotp_Player_Is_Above, Gotp_Player_H_Distance, Gotp_Player_V_Distance, MainCharacter, Sidekick, ObjectWave, ObjectWave_Init, objectWave.do, objectWave.init, objectWave.data.page, objectWave.data.cursor, wave_frame_drop, ObjectDp_Clear, dp, dp_engine, dp_extreg, _MountObject, _RunObject, _RunObjectSwap, _RunObjectSwapRoutine, _RunObjectRoutineA, RunPgSubRoutine, PSR_Page, PSR_Address, PSR_Param, Obj_Index_Page, Obj_Index_Address, ObjID_, sub-routines, sub_anim, state machine."
+machines: [to8, to8d, to9, to9+]
+user-invocable: false
+---
+
+# Gestion d'objets — Thomson TO8/TO9 Game Engine
+
+Le système de gestion d'objets est le **cœur du framework**. Chaque entité du jeu (joueur, ennemi, projectile, décor, HUD) est un *objet* — une structure de données fixe en RAM (l'OST, *Object Status Table*) à laquelle est associé un code asm exécuté chaque frame par `RunObjects`.
+
+Ce skill couvre : allocation/libération d'objets, format de l'OST, exécution cyclique via la run-list, déplacements et gravité, scripts de spawn, IA via orientation joueur, exécution cross-page d'objets.
+
+---
+
+## Vue d'ensemble du cycle de vie
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  POOL D'OBJETS — Dynamic_Object_RAM (taille fixe)           │
+│  [slot 0] [slot 1] [slot 2] ... [slot N-1]                  │
+│                                                              │
+│  STACK_SLOT_ADDRESS → pile des slots libres                  │
+│  STACK_POINTER     → pointeur sommet de pile                 │
+└─────────────────────────────────────────────────────────────┘
+
+InitStack          ──→  remplit la pile avec tous les slots libres
+                       (au boot, dans main.asm)
+
+LoadObject_u/x     ──→  dépile un slot, l'ajoute en queue de run-list
+                       retourne u/x = slot, Z=0
+                       (Z=1 si pile vide → échec)
+
+[user code]        ──→  sta #ObjID_X, id,u   (lie le slot à un objet logique)
+
+RunObjects         ──→  parcourt object_list_first → ... → object_list_last
+                       (chaînée via run_object_next)
+                       pour chaque, mount sa page + jsr code
+                       (chaque frame, depuis MainLoop)
+
+UnloadObject_u/x   ──→  délink du chaînage, repush dans la pile
+                       efface l'OST (object_size bytes à 0)
+```
+
+---
+
+## Pool d'objets — `Dynamic_Object_RAM`
+
+Chaque objet occupe `object_size` octets. La taille de `object_size` est :
+
+```asm
+object_size = object_base_size + ext_variables_size + object_rsvd_size
+```
+
+| Composant | Valeur typique | Rôle |
+|-----------|----------------|------|
+| `object_base_size` | 38 octets | Champs standards (id, render_flags, x_pos, ..., routine_quaternary) |
+| `ext_variables_size` | 0-20 octets | Variables additionnelles spécifiques au jeu (déclaré dans `ram-data.asm`) |
+| `object_rsvd_size` | ~12 octets | Champs réservés engine (rsv_render_flags, rsv_mapping_frame, ...) |
+
+Donc en pratique `object_size ≈ 50-58` octets selon `ext_variables_size`.
+
+Le pool global est déclaré dans `ram-data.asm` :
+```asm
+nb_dynamic_objects                equ 22                ; nb max d'objets vivants
+ext_variables_size                equ 9                 ; pour 1 AABB par objet
+
+Dynamic_Object_RAM                
+                                  fill  0,nb_dynamic_objects*object_size
+Dynamic_Object_RAM_End
+```
+
+Voir [references/ost-layout.md](references/ost-layout.md) pour la liste exhaustive des offsets OST.
+
+---
+
+## Allocation — `LoadObject_u` / `LoadObject_x`
+
+Dépile un slot libre, le lie en queue de la run-list.
+
+```asm
+        jsr   LoadObject_u              ; retourne u = pointeur sur slot, Z=0 si OK
+        beq   @no_slot                  ; Z=1 → pile vide, échec
+        lda   #ObjID_Bullet
+        sta   id,u                      ; lier le slot à l'objet logique
+        ldd   #100
+        std   x_pos,u
+        ; ... autre init ...
+@no_slot
+```
+
+**Différence `_u` vs `_x`** :
+- `LoadObject_u` : retourne `u`, **préserve x** (utile dans une routine qui a déjà besoin de u après)
+- `LoadObject_x` : retourne `x`, **préserve u** (utile quand on appelle depuis une routine d'objet qui doit garder `u` pour l'OST du parent)
+
+Convention dans le repo : utiliser `_u` au boot dans `main.asm`, `_x` depuis une routine d'objet pour créer un enfant.
+
+Voir [references/allocation-and-deallocation.md](references/allocation-and-deallocation.md).
+
+---
+
+## Libération — `UnloadObject_u` / `UnloadObject_x`
+
+Délink l'objet du chaînage et efface ses `object_size` octets (utilise des `pshu d,x,y` pour effacer 6 octets à la fois, optimisé).
+
+```asm
+        jsr   UnloadObject_u            ; après cet appel, u n'est plus valide
+        rts                             ; sortir immédiatement
+```
+
+**Alternative recommandée** : poser `render_todelete_mask` dans `render_flags,u` et laisser le moteur supprimer l'objet à la prochaine `EraseSprites` :
+
+```asm
+        lda   render_flags,u
+        ora   #render_todelete_mask
+        sta   render_flags,u
+```
+
+Cette voie évite les pièges de désallocation manuelle et garantit que le moteur efface aussi le sprite avant de libérer le slot.
+
+---
+
+## Exécution — `RunObjects`
+
+Appelée chaque frame depuis `MainLoop`. Parcourt la run-list :
+
+```asm
+RunObjects
+        ldu   object_list_first         ; tête de liste
+        beq   @rts                      ; liste vide
+!       ldb   id,u                      ; objet logique du slot
+        beq   @skip                     ; slot booké mais sans ID → skip
+        ldx   #Obj_Index_Page
+        abx
+        lda   ,x                        ; charge la page mémoire de l'objet
+        _SetCartPageA                   ; mount cette page en zone cartouche
+        aslb                            ; *2 pour l'adresse (table 2 octets/entry)
+        ldx   #Obj_Index_Address
+        abx
+        ldd   run_object_next,u         ; sauve le suivant AVANT exec
+        std   object_list_next          ; (au cas où l'objet se supprime)
+        jsr   [,x]                      ; appel indirect du code de l'objet
+        ldu   run_object_next,u         ; passer au suivant
+        bne   <
+        ldu   #0
+object_list_next equ *-2
+        bne   <
+@rts    rts
+```
+
+Points clés :
+- L'engine **mount automatiquement la page mémoire** de l'objet avant son exécution (via `_SetCartPageA`). Le code de l'objet est résolu via `Obj_Index_Page[id]` + `Obj_Index_Address[id*2]`, deux tables générées par le builder Java.
+- Le `next` est **sauvegardé avant l'appel** : un objet peut donc se supprimer (ou créer un enfant) sans casser le parcours.
+- Un objet avec `id=0` est un slot **réservé mais pas encore initialisé** — il est skippé sans exécution.
+
+`RunFrozenObjects` : variante qui ne fait que **lever le flag `render_hide_mask`** sur tous les objets, sans exécuter leur code. Utile pour un mode pause/cinematic où les objets sont visibles mais figés.
+
+`ManagedObjects_ClearAll` : remise à zéro totale du pool. Utilisé lors d'une transition de game-mode (cf. `LoadGameMode`).
+
+Voir [references/runobjects-execution.md](references/runobjects-execution.md).
+
+---
+
+## OST — résumé des offsets clés
+
+Détails complets dans [references/ost-layout.md](references/ost-layout.md). Vue d'ensemble :
+
+| Offset | Symbole | Rôle |
+|--------|---------|------|
+| 0 | `id` | ObjID_ (0 = libre) |
+| 1 | `subtype` / `subtype_w` | Variante (1 ou 2 octets — overlap `render_flags`) |
+| 2 | `render_flags` | Bits de rendu |
+| 3-6 | `run_object_prev/next` | Chaînage run-list (engine) |
+| 7 | `priority` | 0=invisible, 1=front, 8=back |
+| 8-9 | `anim` | Pointeur `Ani_<X>` |
+| 12-13 | `anim_frame` / `anim_frame_duration` | État d'animation |
+| 14 | `status_flags` / `anim_flags` | Orientation (xflip/yflip) ou flags d'animation |
+| 16-17 | `image_set` | `Img_<X>` courant |
+| 18-23 | `x_pos`/`x_sub` + `y_pos`/`y_sub` | Position playfield 16.8 |
+| 24-25 | `xy_pixel` (= `x_pixel`+`y_pixel`) | Position écran 8 bits |
+| 26-29 | `x_vel` / `y_vel` | Vitesse signed 8.8 |
+| 30-33 | `x_acl` / `y_acl` | Accélération signed 8.8 (gravité) |
+| 34-37 | `routine` / `routine_secondary/tertiary/quaternary` | State machines |
+| 38+ | `ext_variables` | Espace utilisateur (AABB, compteurs, etc.) |
+
+---
+
+## Déplacements — `ObjectMove` / `ObjectMoveSync`
+
+Applique `x_vel`/`y_vel` à `x_pos`/`y_pos` (fixed-point 8.8). `ObjectMove` fait une seule passe, `ObjectMoveSync` multiplie par `gfxlock.frameDrop.count_w` (compatible framerate adaptatif).
+
+```asm
+        ; Dans la routine Main d'un objet
+        jsr   ObjectMove                ; non synchronisé
+        ; OU
+        jsr   ObjectMoveSync            ; synchro framerate
+```
+
+Pour la gravité : `ObjectFall` / `ObjectFallSync` ajoute `x_acl`/`y_acl` à `x_vel`/`y_vel`.
+
+Voir [references/move-and-physics.md](references/move-and-physics.md) pour les formules fixed-point, l'usage des sub-pixels, et les patterns plateformer.
+
+---
+
+## Marquer un objet hors-écran — `MarkObjGone` / `MarkObjGone2` / `MarkObjGone3`
+
+Utilisé en queue de `Main` à la place de `jmp DisplaySprite`. Compare `x_pos` à `glb_camera_x_pos_coarse` ; si l'objet est trop loin de la caméra, l'engine appelle `DeleteObject` ; sinon il appelle `DisplaySprite`.
+
+Variantes :
+- `MarkObjGone` : utilise `x_pos,u`, supprime si > $40+160+$20+$40 pixels hors écran (wide-dot factor)
+- `MarkObjGone2` : prend la position en `d` plutôt que via `x_pos,u`
+- `MarkObjGone3` : variante qui fait `rts` au lieu de `DisplaySprite` quand l'objet est dans l'écran (utile quand on a déjà appelé DisplaySprite ailleurs)
+
+Tous trois nettoient `Object_Respawn_Table` à `respawn_index,u` (clear du bit 7) pour permettre la re-spawn ultérieure de l'objet quand la caméra reviendra.
+
+Voir [references/respawn-and-cleanup.md](references/respawn-and-cleanup.md).
+
+---
+
+## IA — `Obj_GetOrientationToPlayer`
+
+Retourne dans des variables globales la position relative du joueur le plus proche par rapport à l'objet (`u`) :
+
+| Variable | Valeur |
+|----------|--------|
+| `Gotp_Closest_Player` | Pointeur vers `MainCharacter` ou `Sidekick` (le plus proche) |
+| `Gotp_Player_Is_Left` | 0 = joueur à gauche de l'objet, 2 = à droite |
+| `Gotp_Player_Is_Above` | 0 = joueur au-dessus, 2 = en-dessous |
+| `Gotp_Player_H_Distance` | Distance horizontale signée |
+| `Gotp_Player_V_Distance` | Distance verticale signée |
+
+Utilisé par les ennemis qui cherchent à se diriger vers le joueur, viser, etc. Suppose que `MainCharacter` (et optionnellement `Sidekick`) sont définis comme adresses globales.
+
+---
+
+## Spawn d'ennemis par script — `ObjectWave`
+
+Système déclaratif pour faire apparaître des objets à des moments précis basés sur un compteur (typiquement `gfxlock.frame.count`).
+
+Deux variantes :
+- **`objectWave.do`** (legacy, 8 octets par entrée) — `time + id + subtype + x_pos + y_pos`
+- **`ObjectWave` (`-subtype`)** (moderne, 5 octets par entrée) — `time + id + subtype_w(2 octets)`. `subtype_w` chevauche `render_flags` donc impose des précautions.
+
+Pattern d'usage :
+```asm
+        _objectWave.init #ObjID_LevelWave,#0       ; init pointeur cursor
+        ; ...
+        ; Dans MainLoop, à chaque frame
+        _objectWave.do gfxlock.frame.count
+```
+
+Le script lui-même est une liste binaire de tuples placée à une page connue (référencée par `objectWave.data.page` / `objectWave.data.cursor`). Le marker de fin est `0` (8-octet) ou `$FFFF` (5-octet subtype).
+
+Voir [references/objectwave-scripting.md](references/objectwave-scripting.md).
+
+---
+
+## Joueur en Direct Page — `ObjectDp`
+
+Optimisation : placer le joueur principal en Direct Page ($9F00-$9FFF) pour économiser un cycle par accès aux champs OST.
+
+```asm
+; Dans ram-data.asm
+player1                           equ   dp                ; alias DP
+
+; Dans le code du joueur
+        ldd   <x_pos                    ; (2 cycles) au lieu de ldd x_pos,u (3 cycles + offset)
+```
+
+L'objet n'est PAS dans la run-list — il faut le faire tourner manuellement depuis `MainLoop` :
+```asm
+        ldu   #player1
+        _RunObject ObjID_Player,#player1   ; macro qui mount la page + jsr
+```
+
+`ObjectDp_Clear` efface la zone DP (de `dp` à `dp_extreg`) au boot.
+
+---
+
+## Exécution cross-page — `_MountObject`, `_RunObject`, `_RunObjectSwap`, `RunPgSubRoutine`
+
+Quand on veut appeler une routine d'un autre objet **depuis le code d'un objet en cours d'exécution**, il faut gérer le changement de page mémoire (le code de l'objet appelé peut être dans une autre page que celui de l'appelant).
+
+| Macro | Quand utiliser |
+|-------|----------------|
+| `_MountObject ObjID_X` | Mount la page de l'objet X dans `A`, charge son adresse dans `X`. Ne saute pas. Utile pour appeler manuellement `jsr ,x`. Préserve la page sortante ? **NON**. Préférer `_RunObjectSwap` si on est dans une routine appelée par RunObjects. |
+| `_RunObject ObjID_X,#data` | Mount + ldu data + jsr. Pas de gestion de page de retour — usage limité. |
+| `_RunObjectSwap ObjID_X,#data` | Sauvegarde la page courante, mount X, exécute via `RunPgSubRoutine`, restaure la page. Sûr. |
+| `RunPgSubRoutine` | Sous-jacent : utilise `PSR_Page`, `PSR_Address`, `PSR_Param` pour appeler une routine et restaurer la page. |
+
+```asm
+; Appel manuel sécurisé depuis une routine d'objet
+        _RunObjectSwap ObjID_AudioController,#audio_data
+        ; à ce stade la page courante est restaurée
+```
+
+Voir [references/cross-page-execution.md](references/cross-page-execution.md).
+
+---
+
+## Pitfalls
+
+- **Sprite ND* sans `render_overlay_mask`** : sprite invisible, échec silencieux. Pour tout objet dont le sprite est compilé en variant `ND0`/`ND1`/`XD*`/`YD*`/`XYD*`, ajouter dans `Init` : `lda render_flags,u; ora #render_overlay_mask; sta render_flags,u`. Sinon l'engine cherche un code d'erase inexistant.
+- **Position du sprite calculée comme `taille/2`** : la convention CENTER utilise `ceil(taille/2)-1`. Sprite 160 px centré X = `x_pixel = 79`, pas 80. Si le sprite déborde et que `render_xloop_mask` n'est pas activé, l'engine ne dessine pas du tout.
+- **`InitStack` non appelé** au boot : `LoadObject_u` retourne toujours Z=1.
+- **`Dynamic_Object_RAM` sous-dimensionné** (`nb_dynamic_objects` trop petit) : échecs silencieux de `LoadObject_u` ; toujours tester Z après l'appel.
+- **`object_size` mal calculé** : si `ext_variables_size` est plus grand que ce que les variables locales utilisent, on gaspille de la RAM ; si plus petit, on déborde sur les `rsv_*`.
+- **Allouer un objet pendant `RunObjects` sans précautions** : OK car `object_list_next` est sauvé avant l'exec, mais le nouvel objet sera ajouté en queue et exécuté **dans la même frame** (utile ou non selon le besoin).
+- **Modifier `id,u` à 0 dans Main** : libère le slot pour `RunObjects` qui le skippera ; mais le slot n'est pas remis dans la pile → fuite. Préférer `UnloadObject_u` ou `render_todelete_mask`.
+- **Oublier `inc routine,u` dans Init** : l'init est rappelée à chaque frame, l'objet ne fait jamais autre chose.
+- **Appeler `_MountObject X` sans sauvegarder la page courante** depuis le code d'un objet : au retour, la page courante n'est plus celle du caller → crash. Utiliser `_RunObjectSwap` ou sauver/restaurer manuellement la page.
+- **`subtype_w` qui chevauche `render_flags`** (cas `ObjectWave-subtype`) : poser les `render_flags` AVANT de lire `subtype_w`, sinon on écrase un octet de subtype.
+- **Délier un objet via `UnloadObject_u` puis continuer à utiliser `u`** : crash silencieux (la mémoire est encore là mais peut être réallouée).
+
+---
+
+## Références détaillées
+
+- [references/ost-layout.md](references/ost-layout.md) — Layout complet de l'OST : tous les offsets de 0 à `object_size`, tailles, sémantique de chaque champ, dépendances entre champs (id+subtype, x_pos+x_sub, x_pixel+y_pixel), zone réservée engine (`rsv_*`), espace utilisateur `ext_variables`, calcul dimensionnel
+- [references/allocation-and-deallocation.md](references/allocation-and-deallocation.md) — `InitStack` initialisation, `LoadObject_u` vs `LoadObject_x` (sémantique pile et chaînage), `UnloadObject_u/x` avec génération dynamique d'instructions PSHU pour effacement rapide, `ManagedObjects_ClearAll`, comparaison avec `render_todelete_mask`, patterns d'erreur (slot épuisé)
+- [references/runobjects-execution.md](references/runobjects-execution.md) — `RunObjects` parcours détaillé, `object_list_first/last/next`, mécanisme `_SetCartPageA` cross-page, gestion de la self-suppression et création de fils en cours d'exécution, `RunFrozenObjects` (mode pause), `Obj_Index_Page`/`Obj_Index_Address` (tables générées par le builder Java)
+- [references/move-and-physics.md](references/move-and-physics.md) — `ObjectMove` détail asm avec sign extend, `ObjectMoveSync` boucle de multiplication par `gfxlock.frameDrop.count_w`, `ObjectFall`/`ObjectFallSync`, format fixed-point 8.8 pour `x_vel`/`y_vel`, `x_acl`/`y_acl`, patterns plateformer (h_top_speed, v_top_speed, gravity), sub-pixels et leur impact sur la précision
+- [references/respawn-and-cleanup.md](references/respawn-and-cleanup.md) — `MarkObjGone` / `MarkObjGone2` / `MarkObjGone3` comparaison, `Object_Respawn_Table`, `Obj_respawn_index`, `Obj_respawn_data`, `respawn_index` dans l'OST, sémantique du bit 7 (objet déjà spawné/à respawner), wide-dot factor, intégration avec scrolling
+- [references/objectwave-scripting.md](references/objectwave-scripting.md) — `objectWave.do` (legacy, 8 octets) vs `ObjectWave` subtype (5 octets), format binaire des scripts, marqueur de fin (`0` vs `$FFFF`), `_objectWave.init`/`do` macros, `wave_frame_drop` (pour reprendre l'animation à la frame correcte si plusieurs spawns ont été manqués), placement des scripts en page paginée, `gfxlock.frame.count` comme compteur de référence
+- [references/cross-page-execution.md](references/cross-page-execution.md) — `_MountObject` vs `_RunObject` vs `_RunObjectSwap` vs `_RunObjectSwapRoutine` vs `_RunObjectRoutineA`, sémantique de chaque, sécurité du retour de page, `RunPgSubRoutine` détail (sauvegarde page sortante, paramètre `PSR_Param`), patterns d'appel d'audio engine, de subroutine partagée
+- [references/direct-page-object.md](references/direct-page-object.md) — `ObjectDp_Clear`, alias `player1 equ dp`, accès direct-page `<x_pos`, économie de cycles, exécution manuelle hors run-list, contraintes (placement en début de page, taille limitée à 256 octets), interaction avec `dp_engine` / `dp_extreg`
+- [references/state-machines.md](references/state-machines.md) — Usage de `routine` primaire + `routine_secondary/tertiary/quaternary`, pattern jump-table-indexed, exemples de state machines en parallèle (animation séparée du déplacement), conventions `_routine` suffixe (`Init_routine equ 0`, `Ground_routine equ 1`, ...), interaction avec animation v00/v02 tag `_nextRoutine`

--- a/skills/thomson-to8-engine-object-management/references/allocation-and-deallocation.md
+++ b/skills/thomson-to8-engine-object-management/references/allocation-and-deallocation.md
@@ -1,0 +1,186 @@
+# Allocation et libération d'objets
+
+## Initialisation au boot — `InitStack`
+
+Au démarrage du game-mode, **avant tout `LoadObject_u`**, il faut initialiser la pile des slots libres :
+
+```asm
+        jsr   InitStack
+```
+
+`InitStack` remplit `STACK_SLOT_ADDRESS` avec les adresses de tous les slots du pool `Dynamic_Object_RAM` :
+
+```asm
+InitStack
+        ldu   #STACK_SLOT_ADDRESS_END
+        ldx   #Dynamic_Object_RAM_End-object_size
+@loop   pshu  x                              ; empile l'adresse du slot
+        leax  -object_size,x
+        cmpu  #STACK_SLOT_ADDRESS
+        bne   @loop
+        stu   STACK_POINTER                  ; pointe sur le sommet de pile
+        rts
+```
+
+Structure :
+- `STACK_SLOT_ADDRESS` (taille `nb_dynamic_objects*2`) : tableau d'adresses de slots
+- `STACK_POINTER` (2 octets) : pointeur courant ; pointe `STACK_SLOT_ADDRESS_END` quand vide
+
+## `LoadObject_u` — allocation, retour dans `u`
+
+```asm
+LoadObject_u
+        ldu   STACK_POINTER                  ; sommet de pile
+        cmpu  #STACK_SLOT_ADDRESS_END        ; pile vide ?
+        bne   @link
+        rts                                  ; ÉCHEC : retourne Z=1
+@link
+        pshs  x
+        leax  2,u                            ; dépile (2 octets = adresse)
+        stx   STACK_POINTER                  ; met à jour le sommet
+        ldu   ,u                             ; u = adresse du slot libre
+        ldx   object_list_last
+        beq   >                              ; liste vide → premier
+        stu   run_object_next,x              ; sinon → lie en queue
+        stu   object_list_last
+        stx   run_object_prev,u
+        puls  x,pc                           ; SUCCÈS : Z=0
+!       stu   object_list_last               ; cas liste vide
+        stu   object_list_first
+        puls  x,pc
+```
+
+Effets :
+- Dépile un slot de `STACK_SLOT_ADDRESS`
+- Le lie en **queue** de la run-list (chaînée via `run_object_prev/next`)
+- Retourne `u` = pointeur vers le slot, `Z=0` si succès, `Z=1` si pool plein
+
+## `LoadObject_x` — allocation, retour dans `x`
+
+Strictement identique mais retourne dans `x` (et préserve `u`). Implémentation symétrique.
+
+Usage typique : **depuis une routine d'objet** qui a `u` pointant sur son OST courant et qui veut créer un enfant sans perdre `u`.
+
+```asm
+; Dans une routine d'objet, créer un projectile fils
+        jsr   LoadObject_x              ; alloue dans x, u parent préservé
+        beq   @no_slot
+        lda   #ObjID_Bullet
+        sta   id,x
+        ldd   x_pos,u                   ; recopie position parent
+        std   x_pos,x
+        ldd   #-$200                    ; vitesse vers la gauche
+        std   x_vel,x
+@no_slot
+```
+
+## `UnloadObject_u` / `UnloadObject_x` — libération
+
+```asm
+UnloadObject_u
+        pshs  d,x,y,u
+        ldx   STACK_POINTER
+        stu   ,--x                      ; repush l'adresse dans la pile
+        stx   STACK_POINTER
+        cmpu  object_list_next          ; si on supprime le NEXT du parcours en cours
+        bne   >
+        ldy   run_object_next,u
+        sty   object_list_next          ; ajuster object_list_next
+        beq   @noNext
+!       ldy   run_object_next,u
+        beq   @noNext
+        ldx   run_object_prev,u
+        stx   run_object_prev,y
+        beq   @noPrev
+        sty   run_object_next,x
+        bra   @clearObj
+@noPrev sty   object_list_first
+        ; ... etc
+@clearObj
+        leau  object_size,u             ; pointer après l'objet
+UnloadObject_clear
+        ldd   #$0000
+        ldx   #$0000
+        leay  ,x
+        fill $36,(object_size/6)*2      ; pshu d,x,y répété (efface 6 octets/instruction)
+        ; ... suffix pour les derniers octets
+        puls  d,x,y,u,pc
+```
+
+Effets :
+- Délink l'objet du chaînage `run_object_prev/next`
+- Repush le slot dans `STACK_SLOT_ADDRESS`
+- Efface les `object_size` octets via une boucle `pshu d,x,y` **générée à la compilation** (très optimisée — 6 octets par instruction)
+- Gère le cas où l'objet supprimé est le `next` du parcours `RunObjects` en cours
+
+Après l'appel, **`u` n'est plus valide**. Toujours `rts` immédiatement après.
+
+## `ManagedObjects_ClearAll` — reset total
+
+```asm
+        jsr   ManagedObjects_ClearAll
+```
+
+Efface l'intégralité de `Dynamic_Object_RAM` (de `Dynamic_Object_RAM_End` jusqu'à `Dynamic_Object_RAM+6`) via `pshu d,x,y` puis `pshu a` pour les derniers octets, et remet `object_list_first` / `object_list_last` à 0.
+
+Usage : transition de game-mode (`LoadGameMode` appelle cette routine indirectement) pour repartir d'un pool propre.
+
+**Attention** : `ManagedObjects_ClearAll` ne reset PAS `STACK_SLOT_ADDRESS` / `STACK_POINTER`. Il faut rappeler `InitStack` après si on veut un état propre. Ou alors, c'est implicite dans le nouveau game-mode qui appelle `InitStack` au boot.
+
+## Comparaison `UnloadObject_u` vs `render_todelete_mask`
+
+| Approche | Quand | Pour | Précautions |
+|----------|-------|------|-------------|
+| `UnloadObject_u` | Suppression immédiate | Objet sans sprite, ou quand on veut être sûr du nettoyage | Pas d'effacement de sprite ; `u` invalide après ; appeler depuis init seulement ou éviter dans RunObjects |
+| `render_todelete_mask` | Suppression différée | Objet avec sprite à effacer proprement | Le moteur s'occupe de l'effacement écran via `EraseSprites` |
+
+Préférer `render_todelete_mask` dans la plupart des cas :
+
+```asm
+        lda   render_flags,u
+        ora   #render_todelete_mask
+        sta   render_flags,u
+        rts                             ; ne pas appeler DisplaySprite
+```
+
+## Cas limite : pile pleine
+
+Si `LoadObject_u` retourne Z=1, **ne pas modifier `u`** : il contient encore `STACK_POINTER` (qui pointe `STACK_SLOT_ADDRESS_END`). Modifier `id,u` à ce moment-là écraserait la mémoire de la pile.
+
+Pattern correct :
+```asm
+        jsr   LoadObject_u
+        beq   @failed                   ; sortir si pas de slot
+        ; ... usage de u ...
+        rts
+@failed
+        ; pas de slot disponible — alternative ou simplement ignorer
+        rts
+```
+
+## Diagnostic d'épuisement du pool
+
+Si `LoadObject_u` retourne souvent Z=1 :
+- Augmenter `nb_dynamic_objects` dans `ram-data.asm`
+- Vérifier qu'aucun objet ne fuit (création sans libération)
+- Vérifier les flags `render_todelete_mask` (l'objet est-il vraiment supprimé ou seulement masqué via `render_hide_mask` ?)
+- Compter les `LoadObject_u` vs `UnloadObject_u` via traces debug
+
+## Allocation pendant `RunObjects`
+
+Quand `LoadObject_u` est appelée **depuis une routine d'objet** (donc pendant `RunObjects`) :
+- Le nouvel objet est ajouté en **queue** (`object_list_last`)
+- `RunObjects` continue son parcours via `run_object_next`
+- **Le nouvel objet sera exécuté dans la MÊME frame** (utile pour un projectile qui doit bouger dès l'apparition, ou indésirable si on veut un délai d'une frame)
+
+Pour différer l'exécution d'une frame, il faut soit attendre la prochaine frame avant le `LoadObject_u`, soit utiliser un flag intermédiaire dans l'objet enfant.
+
+## Suppression pendant `RunObjects`
+
+Quand un objet se supprime lui-même via `UnloadObject_u` :
+- `object_list_next` est ajusté pour pointer vers le suivant (sauvegardé par `RunObjects` avant l'exécution)
+- Le parcours continue normalement
+
+Quand un objet supprime un AUTRE objet via `UnloadObject_u` ou `UnloadObject_x` :
+- Si la cible est le `next` du parcours en cours (`object_list_next`), l'engine met à jour `object_list_next` automatiquement
+- Sinon le parcours continue depuis `run_object_next` de l'objet courant, intact

--- a/skills/thomson-to8-engine-object-management/references/cross-page-execution.md
+++ b/skills/thomson-to8-engine-object-management/references/cross-page-execution.md
@@ -1,0 +1,212 @@
+# Exécution cross-page — `_MountObject`, `_RunObject*`, `RunPgSubRoutine`
+
+Le code asm de chaque objet est typiquement placé sur une page mémoire différente (placement automatique par le builder Java via knapsack packing). Pour appeler une routine d'un autre objet, il faut **mount sa page** avant l'appel.
+
+## Tables `Obj_Index_Page` et `Obj_Index_Address`
+
+Le builder génère deux tables résidentes (page 1, toujours accessibles) :
+
+| Table | Taille | Contenu |
+|-------|--------|---------|
+| `Obj_Index_Page` | 1 octet par ObjID_ | Numéro de page physique où réside le code de l'objet |
+| `Obj_Index_Address` | 2 octets par ObjID_ | Adresse du point d'entrée de l'objet dans sa page |
+
+Exemple généré :
+```asm
+Obj_Index_Page
+        fcb 0                   ; ObjID_0 (réservé)
+        fcb 4                   ; ObjID_Player (page 4)
+        fcb 4                   ; ObjID_Bubble (page 4)
+        fcb 5                   ; ObjID_Background (page 5)
+
+Obj_Index_Address
+        fdb 0                   ; ObjID_0
+        fdb $A100               ; ObjID_Player entry
+        fdb $A800               ; ObjID_Bubble entry
+        fdb $A000               ; ObjID_Background entry
+```
+
+## `_MountObject` — mount + setup, pas de jsr
+
+```asm
+_MountObject MACRO
+        ; param 1 : ObjID_
+        lda   Obj_Index_Page+\1         ; charge la page
+        _SetCartPageA                   ; mount en zone cartouche
+        ldx   Obj_Index_Address+2*\1    ; charge l'adresse
+ ENDM
+```
+
+Effets : `A` = page, `X` = adresse du point d'entrée, **page mountée**.
+
+Usage typique : on veut appeler l'objet avec un setup particulier (passer `U` à une adresse, appeler une routine spécifique) :
+```asm
+        _MountObject ObjID_MusicEngine
+        ldb   #1                        ; commande PLAY
+        jsr   ,x                        ; appelle l'objet
+```
+
+**ATTENTION** : `_MountObject` **ne sauvegarde pas** la page sortante. Si on est dans une routine appelée par `RunObjects` (qui a déjà mounté la page de l'objet courant), un `_MountObject X` casse cette page sans la restaurer. Le retour au code de l'objet courant après le `jsr ,x` se fait sur la page de X, qui peut contenir n'importe quoi à l'adresse du `rts`. **Crash garanti**.
+
+Pour appeler depuis une routine d'objet, utiliser `_RunObjectSwap` au lieu de `_MountObject`.
+
+## `_RunObject` — `_MountObject` + setup ldu + jsr
+
+```asm
+_RunObject MACRO
+        ; param 1 : ObjID_
+        ; param 2 : adresse RAM des données objet (typiquement #player1 ou autre OST)
+        _MountObject \1
+        ldu   \2
+        jsr   ,x
+ ENDM
+```
+
+Usage : exécuter le code d'un objet **non géré par `RunObjects`** (e.g. joueur en Direct Page) :
+
+```asm
+MainLoop
+        ; ... RunObjects (gère tous les objets dynamiques) ...
+        _RunObject ObjID_Player,#player1    ; exécute le joueur (en DP)
+        ; ... suite du main loop ...
+```
+
+Idem `_MountObject` : ne préserve pas la page sortante. À utiliser uniquement depuis la page **résidente** (page 1, contenant le `MainLoop` du game-mode), pas depuis le code d'un objet.
+
+## `_RunObjectSwap` — sécurisé pour usage cross-page
+
+```asm
+_RunObjectSwap MACRO
+        ; param 1 : ObjID_
+        ; param 2 : adresse RAM des données objet
+        lda   Obj_Index_Page+\1
+        sta   PSR_Page
+        ldd   Obj_Index_Address+2*\1
+        std   PSR_Address
+        ldu   \2
+        jsr   RunPgSubRoutine
+ ENDM
+```
+
+Préfère `_RunObjectSwap` à `_MountObject`+`jsr` ou `_RunObject` quand on est dans le code d'un objet. C'est la version sûre.
+
+## `RunPgSubRoutine` — sous-jacent
+
+```asm
+RunPgSubRoutine
+        _GetCartPageA                   ; sauve la page courante dans A
+        sta   @page                     ; stocke pour restauration
+        lda   #0
+PSR_Page equ *-1                        ; (modifié par _RunObjectSwap)
+        _SetCartPageA                   ; mount la page cible
+        lda   #0
+PSR_Param equ *-1                       ; paramètre optionnel
+        jsr   >0
+PSR_Address equ *-2                     ; (modifié par _RunObjectSwap)
+RunPgSubRoutine_return
+        lda   #0
+@page   equ *-1
+        _SetCartPageA                   ; restaure la page sortante
+        rts
+```
+
+Mécanique :
+1. Sauve la page courante via `_GetCartPageA` (= `lda $E7E6` ou routine T2)
+2. Mount la page cible (`PSR_Page`)
+3. Appelle l'adresse cible (`PSR_Address`)
+4. Au retour, restaure la page sauvée
+
+C'est du **code auto-modifié** : `_RunObjectSwap` écrit dans les opérandes `PSR_Page`, `PSR_Address`, `PSR_Param` avant l'appel.
+
+## Variantes
+
+### `_RunObjectSwapRoutine`
+
+Permet d'appeler une **routine spécifique** d'un objet (pas le point d'entrée principal). Utile pour appeler une sub-routine exportée :
+
+```asm
+_RunObjectSwapRoutine MACRO
+        ; param 1 : ObjID_
+        ; param 2 : adresse de la routine (e.g. #Player_GetHealth)
+        ; param 3 : adresse RAM des données objet
+        ; ...
+```
+
+### `_RunObjectRoutineA`
+
+```asm
+_RunObjectRoutineA MACRO
+        ; param 1 : ObjID_
+        ; param 2 : adresse de la routine
+        ; manual launch from resident page 1
+        _MountObject \1
+        ldx   \2
+        jsr   ,x
+ ENDM
+```
+
+Usage : exécuter une routine spécifique d'un objet, sans setup `ldu`. Comme `_RunObject` : à utiliser **uniquement depuis la page résidente**.
+
+## Quand utiliser quoi — décision
+
+```
+Tu es dans :         Tu veux appeler :          Macro à utiliser :
+------------         ----------------           -------------------
+MainLoop (rés.)      le point d'entrée          _RunObject (suffit)
+MainLoop (rés.)      une routine spécifique     _RunObjectRoutineA
+Code d'objet         le point d'entrée          _RunObjectSwap
+Code d'objet         une routine spécifique     _RunObjectSwapRoutine
+UserIRQ              le point d'entrée (audio)  _MountObject + jsr ,x
+                                                 (pas de cross-page risk car IRQ
+                                                  ne retournera pas dans un autre objet)
+```
+
+L'usage de `_MountObject` direct dans `UserIRQ` est fréquent pour les ticks audio (`_MountObject ObjID_ymm; _ymm.processFrame`) — c'est OK car l'IRQ n'a pas de contexte à préserver.
+
+## Cas d'usage typiques
+
+### Appel audio depuis UserIRQ
+
+```asm
+UserIRQ
+        jsr   gfxlock.bufferSwap.check
+        jsr   PalUpdateNow
+        _MountObject ObjID_ymm
+        _ymm.processFrame               ; macro qui fait jsr ,x avec B = commande
+        _MountObject ObjID_vgc
+        _MusicFrame_objvgc
+        rts
+```
+
+### Joueur en Direct Page
+
+```asm
+; ram-data.asm
+player1                  equ   dp
+
+; main.asm — MainLoop
+MainLoop
+        jsr   RunObjects                ; gère tous les objets sauf le joueur
+        _RunObject ObjID_Player,#player1 ; exécute le joueur manuellement
+        ; ... suite ...
+```
+
+### Communication entre objets
+
+L'objet A veut faire une action sur l'objet B (par exemple, lui infliger des dégâts) :
+
+```asm
+; Dans le code de l'objet A
+        ldu   B_ost_address             ; trouvé via une variable globale
+        _RunObjectSwapRoutine ObjID_B,#B_TakeDamage,u
+```
+
+ou plus simple : modifier directement les champs OST de B (si on connaît son adresse), sans passer par une routine. Souvent suffisant et plus rapide.
+
+## Pitfalls
+
+- **`_MountObject` depuis le code d'un objet sans restaurer** : crash après le retour
+- **Modifier `PSR_Page`/`PSR_Address` manuellement** sans utiliser `_RunObjectSwap` : à faire seulement si on est expert
+- **Appeler `_RunObjectSwap` pendant un `_RunObjectSwap` imbriqué** : la sauvegarde de page est dans `@page` (variable globale), pas re-entrante. Évite les appels récursifs cross-page.
+- **`_RunObjectSwap` depuis IRQ** : techniquement OK mais ajoute du delay au tick audio. Préférer `_MountObject` direct si le code IRQ ne navigue pas entre plusieurs pages.
+- **Confondre `_SetCartPageA` (instant) avec `jsr SetCartPageA` (T2)** : sous T2, `_SetCartPageA` se résout en `jsr` car la pagination demande plusieurs instructions ; sous FD, c'est juste `sta $E7E6`. Le `IFDEF T2` dans les macros engine gère ça automatiquement.

--- a/skills/thomson-to8-engine-object-management/references/direct-page-object.md
+++ b/skills/thomson-to8-engine-object-management/references/direct-page-object.md
@@ -1,0 +1,170 @@
+# Objet en Direct Page — optimisation accès OST
+
+Le 6809 a un mode d'adressage Direct Page (`<addr` ou setting du registre DP) qui économise 1 octet (1 cycle) par accès comparé à l'adressage indexé. Pour le joueur principal, qui est exécuté à chaque frame avec de nombreux accès à `x_pos`, `y_pos`, `x_vel`, etc., placer son OST en Direct Page peut représenter un gain notable.
+
+## Principe
+
+Le 6809 a un registre DP de 8 bits qui définit la page haute pour l'adressage direct. Si `DP = $9F`, alors `<x_pos` (avec `x_pos = 18`) accède à `$9F12`.
+
+L'engine réserve `$9F00-$9FFF` comme zone Direct Page utilisateur :
+```asm
+dp                            equ $9F00        ; user space (149 bytes max)
+glb_system_stack              equ dp
+```
+
+Les premiers 149 octets sont disponibles pour l'application. Le reste contient :
+- `dp_engine` (32 octets) — variables temporaires de l'engine
+- `dp_extreg` (28 octets) — registres étendus partagés
+
+## Pattern — joueur en DP
+
+### Déclaration dans `ram-data.asm`
+
+```asm
+player1                  equ   dp                ; alias pour l'OST du joueur en DP
+```
+
+### Init au boot du game-mode
+
+```asm
+        ; Init de la zone DP
+        jsr   ObjectDp_Clear            ; clear de dp à dp_extreg
+
+        ; Init du joueur en DP
+        lda   #ObjID_Player
+        sta   id+player1                ; = sta <id (équivalent)
+        ldd   #Ani_PlayerIdle
+        std   anim+player1
+        ldb   #4
+        stb   priority+player1
+        ; ... etc
+```
+
+### Exécution dans `MainLoop`
+
+```asm
+MainLoop
+        jsr   RunObjects                ; gère les objets dynamiques (ennemis, projectiles)
+        _RunObject ObjID_Player,#player1 ; exécute le joueur manuellement
+        ; ...
+```
+
+`_RunObject` charge `U = #player1` puis fait `jsr ,x` sur le code du joueur. Le code du joueur peut donc utiliser `U` comme d'habitude pour accéder à son OST.
+
+### Code du joueur en DP
+
+```asm
+Player
+        ; Le code peut utiliser AU CHOIX :
+        ; - U,offset (équivalent à un objet normal)
+        ; - <offset (direct page, plus rapide)
+        
+        lda   <routine                  ; = lda routine,u (mais 1 cycle plus rapide)
+        asla
+        ldx   #Player_Routines
+        jmp   [a,x]
+
+Player_Routines
+        fdb   Init
+        fdb   Main
+
+Init
+        ; ...
+        inc   <routine
+        rts
+
+Main
+        ldd   <x_pos                    ; accès direct-page rapide
+        ; ... logique ...
+        jsr   AnimateSprite
+        jmp   DisplaySprite
+```
+
+## `ObjectDp_Clear`
+
+```asm
+ObjectDp_Clear
+        ldx   #dp
+        lda   #0
+!       sta   ,x+
+        cmpx  #dp_extreg
+        bne   <
+        rts
+```
+
+Efface la zone DP utilisateur (de `dp` à `dp_extreg`). À appeler une seule fois au boot, ou à chaque transition de game-mode si on veut un état propre.
+
+## Sémantique du registre DP
+
+Par défaut, le 6809 a `DP = $00` au reset. L'engine **ne reset pas DP** explicitement (il reste à $00 sauf si tu le mets toi-même).
+
+Pour utiliser `<addr` correctement, il faut :
+1. Soit utiliser `tfr a,dp` pour positionner DP sur la bonne page haute
+2. Soit utiliser `setdp $9F` directive LWASM pour indiquer au compilateur la valeur de DP
+
+Le repo utilise typiquement la directive `setdp` :
+```asm
+        setdp $9F
+```
+
+Cela permet à LWASM de remplacer automatiquement `lda x_pos` (extended) par `lda <x_pos` (direct) quand l'adresse résolue est dans la page DP.
+
+> **Attention** : `setdp` n'**émet pas** d'instruction CPU. C'est juste une directive de compilation. Il faut **aussi** que `DP` soit positionné à runtime via `lda #$9F; tfr a,dp` (ce qui est fait par le boot loader engine).
+
+## Limites et précautions
+
+### Taille limitée à 256 octets
+
+DP couvre **256 octets** (`$9F00-$9FFF`). L'OST occupe `object_size ≈ 50-58` octets. Donc :
+- 1 joueur en DP = OK, reste ~200 octets pour d'autres variables globales
+- 2-3 objets en DP = OK
+- Tout le pool d'objets en DP = **impossible** (dépasse 256 octets)
+
+### Pas dans la run-list
+
+L'objet en DP n'est **pas dans `Dynamic_Object_RAM`**. Il faut le faire tourner manuellement (`_RunObject`) car `RunObjects` ne le voit pas.
+
+### Collisions et autres références
+
+Si l'objet en DP utilise des AABB de collision, ses listes `AABB_list_*` doivent pointer correctement vers son OST (en DP). Aucun problème particulier, mais l'adresse est `#player1`, pas un slot du pool dynamique.
+
+### Réutilisation par d'autres game-modes
+
+Quand on change de game-mode, la zone DP n'est pas forcément effacée. Si le nouveau game-mode utilise aussi un joueur en DP, il faut appeler `ObjectDp_Clear` ou réinitialiser explicitement.
+
+### Conflit avec engine
+
+`dp_engine` et `dp_extreg` (haut de la page DP) sont utilisés par l'engine pour des variables temporaires (e.g. registres étendus). **Ne pas placer un objet dans cette zone** — il serait écrasé par les routines engine.
+
+L'espace utilisateur disponible est de `dp` à `dp_engine` exclus, soit environ 149 octets. Pour 1 objet de ~58 octets, ça laisse ~91 octets pour des variables globales du game-mode.
+
+## Pattern r-type (player1)
+
+Dans r-type, le joueur est en DP via :
+```asm
+player1                       equ   dp
+palettefade                   fcb   ObjID_fade        ; objet fade pré-chargé après player1
+                              fill  0,object_size-1
+```
+
+`palettefade` (le fade) est aussi en DP, juste après player1. L'objet fade est créé au boot (`LoadObject_u`) mais son adresse est forcée à pointer juste après player1 dans la zone DP — pattern un peu hacky mais efficace.
+
+## Quand utiliser DP ?
+
+Critères pour mettre un objet en DP :
+- ✅ Objet exécuté à chaque frame (joueur principal)
+- ✅ Objet avec beaucoup d'accès à son OST (lecture/écriture `x_pos`, `x_vel`, etc.)
+- ✅ Code de l'objet relativement long (l'économie de cycles compte)
+- ❌ Objet peu actif (économie négligeable)
+- ❌ Objet temporaire (pas de bénéfice persistant)
+- ❌ Multiple instances (DP est limité)
+
+Pour la plupart des objets dynamiques (ennemis, projectiles, effets), le pool dynamique est suffisant. **DP est réservé au joueur principal** (et éventuellement à 1-2 objets singletons comme le fade).
+
+## Pitfalls
+
+- **`setdp` sans positionner DP runtime** : le code compilé utilise direct-page mais DP = $00 au runtime → accès à $0012 au lieu de $9F12 → crash
+- **DP changé par une routine appelée et non restauré** : si une routine fait `tfr a,dp` sans préserver DP, le code de retour utilise une mauvaise valeur. Toujours `pshs dp` au début et `puls dp` à la fin si on change DP
+- **Mélanger `<x_pos` et `x_pos,u` pour le même objet** : OK si U pointe sur DP, mais source de confusion. Préférer une convention cohérente (toujours `<` ou toujours `,u`)
+- **Effacer DP pendant une routine** (`ObjectDp_Clear` au mauvais moment) : efface l'objet courant
+- **Conflict avec `glb_system_stack`** : `dp = $9F00` et `glb_system_stack = dp` (alias). La pile **partage** la zone DP. La pile descend depuis le haut, l'OST monte depuis le bas. Vérifier qu'ils ne se rencontrent pas (pile typique 32-64 octets utilisés → ~$9FC0-$9FFF, OST de 58 octets → ~$9F00-$9F39, marge ~150 octets)

--- a/skills/thomson-to8-engine-object-management/references/move-and-physics.md
+++ b/skills/thomson-to8-engine-object-management/references/move-and-physics.md
@@ -1,0 +1,166 @@
+# Déplacements et physique des objets
+
+## Format fixed-point 8.8
+
+Les vitesses et accélérations sont stockées en **signed 8.8 fixed-point** (16 bits, partie entière 8 bits + partie fractionnaire 8 bits) :
+
+```
+x_vel = $0100 → +1.0 pixel/frame
+x_vel = $0080 → +0.5 pixel/frame
+x_vel = $FF80 → -0.5 pixel/frame  (256.0 - 0.5 = 255.5 en non-signé, donc -0.5 en signé)
+x_vel = $0040 → +0.25 pixel/frame
+```
+
+Les positions `x_pos`/`y_pos` sont en **signed 16.8 fixed-point** (3 octets) :
+- 2 octets de partie entière (`x_pos`, `y_pos`) — peut représenter une map de -32768 à +32767 pixels
+- 1 octet de partie fractionnaire (`x_sub`, `y_sub`) — sub-pixel pour précision
+
+C'est pour ça que `x_pos`+`x_sub` doivent être contigus : `addd x_pos+1,u` (avec `x_pos+1 = x_sub`) met à jour la partie basse en un coup.
+
+## `ObjectMove` — déplacement non-synchronisé
+
+```asm
+ObjectMove
+        ldb   x_vel,u
+        sex                             ; sign extend B → A (A = $00 ou $FF)
+        sta   @a+1                      ; modifie l'instruction adca # ci-dessous
+        ldd   x_vel,u
+        addd  x_pos+1,u                 ; addition basse partie (x_pos low + x_sub)
+        std   x_pos+1,u
+        lda   x_pos,u                   ; partie haute
+@a      adca  #$00                      ; <- modifié par le sex pour gérer la propagation signed
+        sta   x_pos,u
+        ; idem pour y
+        rts
+```
+
+Astuce : `sex` (sign extend) met `A = $00` si `B` positif, `$FF` si négatif. Le `sta @a+1` modifie l'opérande immédiat de `adca #$00` au-dessus, qui devient donc `adca #$FF` pour propager le bit de signe vers la partie haute. **Code auto-modifié** pour économiser une branche.
+
+Appel typique :
+```asm
+        jsr   ObjectMove
+```
+
+Effet : `x_pos += x_vel` et `y_pos += y_vel`, en signed 16.8.
+
+## `ObjectMoveSync` — synchronisé framerate
+
+Identique mais boucle `gfxlock.frameDrop.count_w` fois (nombre de frames 50 Hz écoulées depuis le dernier rendu) :
+
+```asm
+ObjectMoveSync
+        ldx   gfxlock.frameDrop.count_w
+        bne   @loop1
+        ldx   #1                         ; minimum 1 frame
+@loop1
+        ; ... même code que ObjectMove ...
+        leax  -1,x
+        bne   @loop1
+        rts
+```
+
+Utiliser quand on a `gfxlock` actif et qu'on veut un déplacement **stable visuellement** même si le rendu drop des frames. Sans sync, un drop entraîne un ralentissement perçu (l'objet se déplace moins par frame visible).
+
+## `ObjectFall` — gravité non-synchronisée
+
+```asm
+ObjectFall
+        ldd   x_vel,u
+        addd  x_acl,u                   ; x_vel += x_acl
+        std   x_vel,u
+        ldd   y_vel,u
+        addd  y_acl,u                   ; y_vel += y_acl
+        std   y_vel,u
+        rts
+```
+
+Applique `x_acl`/`y_acl` à `x_vel`/`y_vel`. C'est la **gravité** (ou une accélération constante).
+
+## `ObjectFallSync` — gravité synchronisée
+
+Identique mais boucle `gfxlock.frameDrop.count_w` fois.
+
+## Patterns d'usage
+
+### Plateformer avec saut (pattern bubble-bobble)
+
+```asm
+; Constantes
+h_top_speed      equ $A0     ; vitesse horizontale max (~0.625 px/frame)
+gravity          equ $40     ; gravité (~0.25 px/frame²)
+vel_jump         equ $4D0    ; vitesse initiale saut (~4.8 px/frame, ascendant)
+
+; Init
+Ground
+        lda   Dpad_Press
+        bita  #c1_button_up_mask
+        beq   @no_jump
+        ldd   #-vel_jump                ; saut → y_vel négative
+        std   y_vel,u
+        lda   #Jump_routine
+        sta   routine,u
+@no_jump
+
+Jump
+        ; appliquer gravité
+        ldd   y_acl,u
+        cmpd  #gravity                  ; (le calcul est ici simplifié)
+        bne   >
+        jsr   ObjectFallSync            ; y_vel += y_acl
+        jsr   ObjectMoveSync            ; y_pos += y_vel
+        ; vérifier si touche le sol et basculer en Ground
+        ; ...
+```
+
+### Shoot 'em up — projectile à vitesse constante
+
+```asm
+; Projectile init
+        ldd   #-$300                    ; vitesse horizontale = -3.0 pixels/frame
+        std   x_vel,u
+        ldd   #0
+        std   y_vel,u                   ; pas de gravité
+        std   x_acl,u
+        std   y_acl,u
+
+; Projectile main
+        jsr   ObjectMoveSync            ; déplacement
+        jmp   MarkObjGone               ; se supprime si hors écran
+```
+
+### Mouvement sinusoïdal
+
+Si on veut une trajectoire non-linéaire (vague, courbe), il faut soit utiliser `moveByScript` (cf. skill animation), soit calculer manuellement `x_vel`/`y_vel` à chaque frame en fonction d'un compteur :
+
+```asm
+        lda   <my_counter
+        jsr   CalcSine                  ; D = sin(my_counter), X = cos
+        ; ajuster y_vel selon D, etc.
+        std   y_vel,u
+        jsr   ObjectMoveSync
+```
+
+## Conversion playfield ↔ écran
+
+L'engine maintient deux jeux de coordonnées :
+
+- **Playfield** : `x_pos`/`y_pos` (16 bits), coordonnées absolues dans la map
+- **Écran** : `x_pixel`/`y_pixel` (8 bits), coordonnées dans l'écran visible
+
+La conversion est faite **automatiquement par les routines de rendu** (cf. `DrawSprites`) en utilisant la caméra :
+```
+x_pixel ≈ x_pos - glb_camera_x_pos
+y_pixel ≈ y_pos - glb_camera_y_pos
+```
+
+Le flag `render_playfieldcoord_mask` (`render_flags` bit 3) indique au moteur d'utiliser `x_pos`/`y_pos` (1) ou `xy_pixel` (0). À choisir selon que l'objet :
+- est dans le monde scrollé (HUD exclu) → playfield
+- est fixe à l'écran (HUD, menu) → écran
+
+## Pitfalls
+
+- **Oublier que `x_vel` est signed** : un objet immobile a `x_vel = 0`, pas `x_vel = $0100`
+- **Confondre `ObjectMove` et `ObjectMoveSync`** : sans gfxlock, `_Sync` ne sert à rien (frameDrop.count_w est toujours 1) mais consomme des cycles supplémentaires
+- **Modifier `x_pos` sans `x_sub`** : la partie haute change sans la basse, l'objet « saute » à l'écran. Toujours utiliser `ObjectMove` ou faire `std x_pos+1,u` puis adjuster `x_pos,u`
+- **Gravité trop forte** : un objet peut traverser le sol en une frame si `y_vel > épaisseur du sol`. Limiter avec un `cmpd #v_top_speed`
+- **Compteurs internes en 8.8** : si tu utilises `ext_variables` pour un compteur fixed-point, garder la convention 8.8 pour la cohérence (e.g. `my_speed_x = ext_variables` sur 2 octets)

--- a/skills/thomson-to8-engine-object-management/references/objectwave-scripting.md
+++ b/skills/thomson-to8-engine-object-management/references/objectwave-scripting.md
@@ -1,0 +1,256 @@
+# `ObjectWave` — spawn d'ennemis par script
+
+Le système `ObjectWave` permet de **scripter l'apparition d'objets** (typiquement des ennemis) à des moments précis basés sur un compteur de frames. Deux variantes existent : la **legacy 8-octets** et la **moderne 5-octets subtype**.
+
+## Variante moderne — `ObjectWave-subtype.asm`
+
+### Format binaire du script
+
+Chaque entrée = **5 octets** :
+
+```
+Offset | Taille | Contenu
+-------|--------|--------
+0      | 2      | timestamp (gfxlock.frame.count auquel spawner)
+2      | 1      | ObjID_ de l'objet à créer
+3      | 2      | subtype_w (16 bits, chevauche render_flags)
+```
+
+Marqueur de fin : `$FFFF` à la place du timestamp.
+
+```asm
+; Exemple de script
+wave_data
+        fdb   $0100                     ; à la frame 256
+        fcb   ObjID_PataPata
+        fdb   $0001                     ; subtype 1 (left), render_flags 0
+
+        fdb   $0150                     ; à la frame 336
+        fcb   ObjID_PataPata
+        fdb   $0102                     ; subtype 2, render_flags 1
+
+        fdb   $0200                     ; à la frame 512
+        fcb   ObjID_Bink
+        fdb   $0001
+
+        fdb   $FFFF                     ; fin
+```
+
+### Routine `ObjectWave`
+
+```asm
+ObjectWave
+        lda   #0
+object_wave_data_page equ *-1           ; modifié au init avec la page
+        _SetCartPageA
+        ldy   #0
+object_wave_data equ *-2                ; cursor courant
+        ldx   gfxlock.frame.count
+!       cmpx  ,y                        ; current frame >= timestamp ?
+        blo   @rts                      ; non, sortir
+        pshs  x,y
+        jsr   LoadObject_u
+        puls  x,y
+        beq   @bypass                   ; pas de slot, skip cet objet
+        lda   2,y
+        sta   id,u
+        ldd   3,y                       ; subtype_w (2 octets)
+        std   subtype_w,u               ; ECRASE render_flags
+        ldd   gfxlock.frame.count
+        subd  ,y
+        stb   wave_frame_drop,u         ; nb de frames de retard
+@bypass leay  5,y
+        bra   <
+@rts    sty   object_wave_data
+        rts
+```
+
+### Initialisation
+
+```asm
+ObjectWave_Init
+        pshs  a,x,y
+        lda   object_wave_data_page
+        _SetCartPageA
+        ldy   object_wave_data_start
+        ldx   gfxlock.frame.count
+        ; ... saute les entrées dont le timestamp < frame.count
+        ; (utile en cas de spawn pré-générés à des frames négatives ou démarrage tardif)
+        sty   object_wave_data
+        puls  a,x,y
+        rts
+```
+
+### Usage typique
+
+```asm
+; main.asm
+        lda   Obj_Index_Page+ObjID_LevelWave
+        sta   object_wave_data_page
+        ldd   Obj_Index_Address+2*ObjID_LevelWave
+        std   object_wave_data
+        std   object_wave_data_start
+        jsr   ObjectWave_Init
+
+MainLoop
+        jsr   ObjectWave                ; spawn les objets dont le timestamp est atteint
+        jsr   RunObjects
+        ; ...
+```
+
+`ObjectWave` est appelée **avant** `RunObjects` pour que les objets créés cette frame puissent être exécutés.
+
+### Attention au `subtype_w` qui chevauche `render_flags`
+
+Le `subtype_w` (offset 1, 2 octets) chevauche `render_flags` (offset 2). Si le script définit `subtype_w = $0102`, alors :
+- `subtype = $01` (octet bas du `subtype_w`)
+- `render_flags = $02` (octet haut du `subtype_w` = `render_ymirror_mask`)
+
+Donc le script peut **set render_flags via subtype_w**. C'est volontaire — permet de placer un ennemi avec un mirror Y prédéfini.
+
+**Précaution** : si on veut modifier `render_flags` après le spawn, il faut **lire d'abord `subtype` (octet bas)** avant d'écrire `render_flags` (octet haut) sinon on écrase l'info de subtype.
+
+```asm
+        lda   subtype,u                 ; AVANT toute écriture de render_flags
+        sta   <my_subtype_save          ; save somewhere
+        ; ... maintenant on peut écrire render_flags ...
+        lda   render_flags,u
+        ora   #render_overlay_mask
+        sta   render_flags,u
+```
+
+## Variante legacy — `objectWave.asm` (8 octets)
+
+### Format binaire
+
+Chaque entrée = **8 octets** :
+
+```
+Offset | Taille | Contenu
+-------|--------|--------
+0      | 2      | timestamp
+2      | 1      | ObjID_
+3      | 1      | subtype (8 bits — pas de chevauchement avec render_flags)
+4      | 2      | x_pos (position initiale playfield)
+6      | 2      | y_pos
+```
+
+Marqueur de fin : `0` (le timestamp 0 est traité comme fin de script).
+
+```asm
+wave_data_legacy
+        fdb   $0100                     ; frame 256
+        fcb   ObjID_Bug
+        fcb   1                         ; subtype
+        fdb   200                       ; x_pos
+        fdb   100                       ; y_pos
+
+        fdb   $0150
+        fcb   ObjID_Bug
+        fcb   2
+        fdb   220
+        fdb   120
+
+        fdb   0                         ; fin
+```
+
+### Macros
+
+```asm
+_objectWave.init MACRO
+        ldb   \1                        ; ObjID_ de l'objet de script
+        ldx   #Obj_Index_Page
+        lda   b,x
+        aslb
+        ldx   #Obj_Index_Address
+        ldy   b,x
+        ldx   \2                        ; cursor (typiquement #0)
+        jsr   objectWave.init
+ ENDM
+
+_objectWave.do MACRO
+        ldx   \1                        ; current time (typiquement gfxlock.frame.count)
+        jsr   objectWave.do
+ ENDM
+```
+
+### Routine `objectWave.do`
+
+```asm
+objectWave.do
+        lda   #0
+objectWave.data.page equ *-1
+        _SetCartPageA
+        ldy   #0
+objectWave.data.cursor equ *-2
+!       ldd   ,y
+        beq   @rts                      ; marker 0 = fin
+        cmpx  ,y
+        bhi   @rts                      ; current time > timestamp ? continue
+        pshs  x,y
+        jsr   LoadObject_u
+        puls  x,y
+        beq   @bypass
+        ldd   2,y                       ; id + subtype (8 bits)
+        std   id,u                      ; écrit id + subtype
+        ldd   4,y
+        std   x_pos,u
+        ldd   6,y
+        std   y_pos,u
+        ldd   ,y                        ; (compute missed frames)
+        subd  -4,s
+        stb   wave_frame_drop,u
+@bypass leay  8,y
+        bra   <
+@rts    sty   objectWave.data.cursor
+        rts
+```
+
+### Différence avec subtype-w
+
+- `subtype` est **1 octet** (pas de chevauchement avec render_flags)
+- `x_pos` et `y_pos` sont définis par le script
+- Marqueur de fin = `0` (pas `$FFFF`)
+
+## `wave_frame_drop` — gérer le retard
+
+Quand un objet est spawné avec un timestamp inférieur à la frame courante (cas d'un script qui démarre à une frame déjà avancée, ou d'un drop massif), la différence est stockée dans `wave_frame_drop,u` (= `anim_frame_duration`).
+
+L'animation peut ensuite utiliser cette valeur pour **rattraper** l'animation à la bonne frame :
+- Si l'objet apparaît avec un retard de 5 frames, son animation peut sauter 5 frames pour être au bon endroit du cycle visuel
+
+Cela suppose que l'objet utilise `AnimateSpriteSync` ou un système d'animation qui consulte `wave_frame_drop`.
+
+## Pattern de niveau (level structure)
+
+```asm
+; main.asm du game-mode level01
+        ; init wave data
+        _MountObject ObjID_LevelInit
+        jsr   ,x
+
+        _MountObject ObjID_LevelWave
+        jsr   ,x
+
+        ; ...
+
+MainLoop
+        ; tick wave (avant RunObjects pour que les objets spawnés bougent dès cette frame)
+        _objectWave.do gfxlock.frame.count
+        ; OU pour la variante subtype-w :
+        ; jsr ObjectWave
+        
+        jsr   RunObjects
+        ; ...
+```
+
+L'objet `LevelWave` n'est pas un objet « actif » au sens classique — c'est juste un container du script binaire. Son `code=` peut pointer vers un fichier asm vide (ou contenant juste une `rts`), et ses `data.X=...` (ou `sound.X`) contiennent le binaire du script.
+
+## Pitfalls
+
+- **Marqueur de fin oublié** : `objectWave.do` continue de lire au-delà du script → comportement erratique
+- **Script non trié par timestamp** : les entrées avec timestamp futur seront sautées si le cursor a dépassé
+- **`subtype_w` modifié sans précaution dans la variante moderne** : écrasement de `render_flags` accidentel
+- **Init pas fait** : `objectWave.data.cursor` reste à 0 → comportement aléatoire
+- **`LoadObject_u` échoue** (pool plein) : l'entrée est **skipée** sans réessai → l'objet est manqué pour toujours. Sur des scripts critiques, dimensionner large
+- **Compteur de référence** : si on utilise `gfxlock.frame.count` mais que le game-mode n'utilise pas `gfxlock`, le compteur ne progresse pas. Adapter à `IrqSync` ou un compteur global du game-mode.

--- a/skills/thomson-to8-engine-object-management/references/ost-layout.md
+++ b/skills/thomson-to8-engine-object-management/references/ost-layout.md
@@ -1,0 +1,223 @@
+# OST (Object Status Table) — layout complet
+
+L'OST est la structure de données associée à chaque objet vivant. Elle occupe **`object_size`** octets en RAM dans le pool `Dynamic_Object_RAM`. Tous les champs sont déclarés dans `engine/constants.asm`.
+
+## Calcul de `object_size`
+
+```asm
+object_base_size              equ 38                                   ; champs standards
+object_rsvd                   equ object_base_size+ext_variables_size  ; début des rsv_*
+object_size                   equ object_base_size+ext_variables_size+object_rsvd_size
+```
+
+Le `object_rsvd_size` est calculé selon le mode (overlay vs background-erase) :
+- En mode background-erase (par défaut), `object_rsvd_size` ≈ 12-15 octets selon les flags
+- En mode overlay (`OverlayMode equ 1`), généralement plus compact
+
+En pratique pour la plupart des jeux : `object_size ≈ 50-58` octets.
+
+`ext_variables_size` est **défini par le projet** dans `ram-data.asm` du game-mode. Valeurs observées :
+
+| `ext_variables_size` | Cas d'usage |
+|----------------------|-------------|
+| 0 | Objets simples sans variables locales (test, 2026 TitleScreen) |
+| 9 | 1 AABB par objet (bubble-bobble) |
+| 20 | Plusieurs AABB ou structs complexes (r-type) |
+
+## Layout complet (offsets fixes)
+
+```
+Offset  | Symbole              | Taille | Type        | Lecture/Écriture |
+--------|----------------------|--------|-------------|------------------|
+0       | id                   | 1      | ObjID_      | RW utilisateur   | (0 = slot libre)
+1       | subtype              | 1      | Sub_        | RW utilisateur   |
+1       | subtype_w            | 2      | Sub_ étendu | RW (overlap render_flags) |
+2       | render_flags         | 1      | bitfield    | RW utilisateur+engine |
+3-4     | run_object_prev      | 2      | ptr OST     | engine only      | (run-list)
+5-6     | run_object_next      | 2      | ptr OST     | engine only      | (run-list)
+7       | priority             | 1      | 0..8        | RW utilisateur   | (0=cache, 1=front, 8=back)
+8-9     | anim                 | 2      | Ani_        | RW utilisateur   |
+10-11   | prev_anim            | 2      | Ani_        | engine           |
+10-11   | sub_anim             | 2      | Ani_        | RW (overlap prev_anim) |
+12      | anim_frame           | 1      | index       | engine           |
+13      | anim_frame_duration  | 1      | 0..127      | engine           |
+13      | wave_frame_drop      | 1      | (overlap)   | objectWave only  |
+14      | anim_flags           | 1      | flags v02   | RW (anim système) |
+14      | status_flags         | 1      | bitfield    | RW utilisateur   | (xflip/yflip)
+16-17   | image_set            | 2      | Img_        | engine (mis à jour par AnimateSprite) |
+18-19   | x_pos                | 2      | s16.8 high  | RW utilisateur   |
+20      | x_sub                | 1      | s16.8 low   | RW (lié à x_pos) |
+21-22   | y_pos                | 2      | s16.8 high  | RW utilisateur   |
+23      | y_sub                | 1      | s16.8 low   | RW (lié à y_pos) |
+24      | x_pixel (= xy_pixel) | 1      | 0..159      | RW (mode screen) |
+25      | y_pixel              | 1      | 0..199      | RW (mode screen) |
+26-27   | x_vel                | 2      | s8.8        | RW utilisateur   |
+28-29   | y_vel                | 2      | s8.8        | RW utilisateur   |
+30-31   | x_acl                | 2      | s8.8        | RW utilisateur   |
+32-33   | y_acl                | 2      | s8.8        | RW utilisateur   |
+34      | routine              | 1      | index       | RW utilisateur   |
+35      | routine_secondary    | 1      | index       | RW utilisateur   |
+36      | routine_tertiary     | 1      | index       | RW utilisateur   |
+37      | routine_quaternary   | 1      | index       | RW utilisateur   |
+38..N   | ext_variables (espace utilisateur) | ext_variables_size | RW utilisateur |
+N+1..   | rsv_render_flags     | 1      | engine      | engine only      |
+        | rsv_prev_anim        | 2      | (...)       | engine only      |
+        | rsv_image_center_offset | 1   |             | engine only      |
+        | rsv_image_subset     | 2      |             | engine only      |
+        | rsv_mapping_frame    | 2      |             | engine only      |
+        | rsv_erase_nb_cell    | 1      |             | engine only      |
+        | rsv_page_draw_routine| 1      |             | engine only      |
+        | rsv_draw_routine     | 2      |             | engine only      |
+```
+
+## Dépendances inter-champs (CRITIQUE)
+
+Plusieurs champs sont contraints à être contigus en mémoire :
+
+| Contrainte | Raison |
+|------------|--------|
+| `subtype` (1) doit suivre `id` (0) | `ldd id,u` permet de lire les deux d'un coup |
+| `x_sub` (20) doit suivre `x_pos` (18-19) | `addd x_pos+1,u` met à jour `x_pos+x_sub` ensemble |
+| `y_sub` (23) doit suivre `y_pos` (21-22) | Idem |
+| `y_pixel` (25) doit suivre `x_pixel` (24) | `ldd xy_pixel,u` = x+y ensemble |
+| `render_flags` bits 0/1 sont xmirror/ymirror (DEPENDENCY explicit dans le code) | `AnimateSprite` applique `status_flags & 3` xor `render_flags & 3` |
+
+## Bits de `render_flags`
+
+### Mode background-erase (par défaut)
+
+```
+Bit | Mask  | Symbole                       | Effet
+----|-------|-------------------------------|-----
+0   | $01   | render_xmirror_mask           | Sprite miroir horizontal
+1   | $02   | render_ymirror_mask           | Sprite miroir vertical
+2   | $04   | render_overlay_mask           | Sprite compilé sans backup de fond
+3   | $08   | render_playfieldcoord_mask    | Coord playfield (x_pos/y_pos) vs écran (x_pixel/y_pixel)
+4   | $10   | render_xloop_mask             | Loop X hors écran (en coord écran)
+5   | $20   | render_todelete_mask          | Marquer pour suppression engine
+6   | $40   | render_subobjects_mask        | Rendre les sous-objets
+7   | $80   | render_hide_mask              | Cacher (préserve priority/mapping)
+```
+
+### Mode overlay (`OverlayMode equ 1`)
+
+Mêmes bits 0/1/3/4/6/7. Différences :
+- Bit 2 (`render_overlay_mask`) : **absent**
+- Bit 5 : `render_no_range_ctrl_mask` (skip vérif out-of-range — DANGEREUX, peut corrompre la mémoire)
+
+## Bits de `status_flags`
+
+```
+Bit | Mask  | Symbole                  | Effet
+----|-------|--------------------------|-----
+0   | $01   | status_xflip_mask        | Flip horizontal (appliqué pendant AnimateSprite)
+1   | $02   | status_yflip_mask        | Flip vertical
+```
+
+## Bits de `anim_flags` (mode v02 ou link)
+
+```
+Bit | Mask  | Symbole              | Effet
+----|-------|----------------------|-----
+2   | $04   | anim_link_mask       | Charger une nouvelle animation sans reset anim_frame
+```
+
+En mode v02 (advanced), `anim_flags` est utilisé comme offset dans une LUT applicative pour déclencher des callbacks à des frames spécifiques.
+
+## Bits de `rsv_render_flags` (zone réservée engine)
+
+```
+Bit | Mask  | Symbole                       | Effet
+----|-------|-------------------------------|-----
+0   | $01   | rsv_render_checkrefresh_mask  | EraseSprite + DisplaySprite traités cette frame
+1   | $02   | rsv_render_erasesprite_mask   | Sprite à effacer
+2   | $04   | rsv_render_displaysprite_mask | Sprite à dessiner
+3   | $08   | rsv_render_outofrange_mask    | Sprite out-of-range full-rendering
+7   | $80   | rsv_render_onscreen_mask      | A été rendu sur le dernier buffer
+```
+
+Ces flags sont gérés par le moteur (`CheckSpritesRefresh`, `DrawSprites`, `EraseSprites`). Ne pas modifier depuis le code utilisateur sauf cas spécifique (`glb_force_sprite_refresh`).
+
+## Variables locales dans `ext_variables`
+
+Si `ext_variables_size > 0`, on peut réserver des slots :
+
+```asm
+; Dans le code de l'objet
+my_health       equ ext_variables       ; 1 octet à l'offset 38
+my_target_addr  equ ext_variables+1     ; 2 octets à l'offset 39-40
+AABB_0          equ ext_variables       ; 9 octets pour 1 AABB de collision
+```
+
+Conventions observées :
+- `AABB_0`, `AABB_1`, ... pour les zones de collision
+- `player_pos_ring_buffer_ptr` (r-type) pour des historiques de position
+- Variables métier libres au choix du développeur
+
+## ⚠️ Règles critiques à connaître pour `render_flags` et `xy_pixel`
+
+### `render_overlay_mask` OBLIGATOIRE pour sprites variant `D*` (Draw seul)
+
+Si le sprite associé à l'objet est compilé avec un variant `ND0`/`ND1`/`XD*`/`YD*`/`XYD*` (= mode Draw seul, sans backup du fond), il faut **impérativement** poser `render_overlay_mask` dans `render_flags,u` à l'init :
+
+```asm
+        lda   render_flags,u
+        ora   #render_overlay_mask
+        sta   render_flags,u
+```
+
+Sans ce flag, l'engine cherche un code d'erase compilé qui n'existe pas pour les variants D → **sprite invisible** sans message d'erreur.
+
+Pour les variants `NB*`/`XB*`/`YB*`/`XYB*` (mode Backup), `render_overlay_mask` doit rester à 0.
+
+### Position du centre : `ceil(taille/2)-1` (pas `taille/2`)
+
+Quand on positionne un sprite via `xy_pixel` (= `x_pixel` + `y_pixel`), la convention CENTER de l'engine considère le centre interne du sprite à l'offset `ceil(sprite_size/2)-1`. Pour les tailles paires, ce centre est **un pixel avant** le milieu mathématique :
+
+| Taille | Centre interne | `x_pixel` pour top-left à x=0 |
+|--------|----------------|-------------------------------|
+| 16 px | 7 | 7 |
+| 32 px | 15 | 15 |
+| 100 px | 49 | 49 |
+| 160 px | 79 | 79 |
+
+Si on se trompe d'un pixel et que le sprite déborde, et que `render_xloop_mask` n'est PAS posé, le sprite **n'est pas dessiné** (clipping out total, silencieux).
+
+---
+
+## Initialisation d'un slot fraîchement alloué
+
+Après `LoadObject_u`, le slot est **garanti à zéro** (sauf `id` que tu vas mettre toi-même). C'est `UnloadObject_*` qui efface tous les octets via une boucle `pshu d,x,y` optimisée. Donc tous les champs `render_flags`, `priority`, `x_vel`, etc. valent 0 par défaut.
+
+Init typique :
+```asm
+        jsr   LoadObject_u
+        beq   @noslot
+        lda   #ObjID_X
+        sta   id,u
+        ldd   #Ani_X_default
+        std   anim,u
+        ldb   #4
+        stb   priority,u
+        ldd   #$80AF                    ; xy_pixel = $80 (x), $AF (y)
+        std   xy_pixel,u
+        ; le reste (render_flags, x_vel, etc.) reste à 0
+@noslot
+```
+
+## Diagramme mémoire d'un slot
+
+```
+   u → ┌──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┐
+       │id│st│RF│prev │next │pr│anim │panim│af│ad│sf│  │
+       ├──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┤
+       │image_set│ x_pos  │xs│ y_pos  │ys│xp│yp│ x_vel│
+       ├──────────────────────────────────────────────┤
+       │ y_vel│ x_acl│ y_acl│r1│r2│r3│r4│              │
+       ├──────────────────────────────────────────────┤
+       │     ext_variables (taille variable)          │
+       │ ... (AABB, vars locales, etc.)               │
+       ├──────────────────────────────────────────────┤
+       │     rsv_* (zone réservée engine)             │
+u+os → └──────────────────────────────────────────────┘
+```

--- a/skills/thomson-to8-engine-object-management/references/respawn-and-cleanup.md
+++ b/skills/thomson-to8-engine-object-management/references/respawn-and-cleanup.md
@@ -1,0 +1,150 @@
+# Marquer un objet hors-écran — `MarkObjGone` / `Object_Respawn_Table`
+
+Les routines `MarkObjGone*` permettent de supprimer automatiquement un objet quand il sort de la zone autour de la caméra, **tout en mémorisant qu'il a été supprimé** afin de pouvoir le re-spawner si la caméra revient sur sa position d'origine.
+
+## `Object_Respawn_Table` — table globale
+
+```asm
+Object_Respawn_Table
+Obj_respawn_index    fdb    0           ; indices des prochains objets pour movement L/R
+Obj_respawn_data     fill   0,$7C       ; max d'entrées (124 paires)
+Obj_respawn_data_End
+```
+
+Format : table de paires `(2 octets index + 1 octet flag)` (3 octets par entrée, max 124 entrées). Le bit 7 du flag est mis à 1 quand l'objet est « live » (spawné), 0 quand il a été marqué supprimé et peut respawn.
+
+Chaque objet a un champ `respawn_index,u` (typiquement dans `ext_variables`) qui pointe vers son entrée dans la table. À noter : ce champ doit être déclaré dans le projet — il n'a pas d'offset standard dans `engine/constants.asm`.
+
+## `MarkObjGone` — version standard
+
+```asm
+MarkObjGone
+        ldd   x_pos,u                   ; position playfield X
+MarkObjGone2
+        andb  #$C0                      ; wide-dot factor (align sur 64 pixels)
+        subd  glb_camera_x_pos_coarse   ; relative à caméra
+        cmpd  #$40+160+$20+$40          ; $E0 = limite hors écran
+        bhi   >                         ; > limite → supprimer
+        jmp   DisplaySprite             ; toujours dans la zone → afficher
+
+!       ldx   #Object_Respawn_Table
+        ldb   respawn_index,u           ; entry dans la table
+        beq   >                         ; pas d'entrée respawn → skip
+        addb  #2                        ; offset vers le flag
+        lda   b,x
+        anda  #%01111111                ; clear bit 7 (mark as despawnable)
+        sta   b,x
+!       jmp   DeleteObject
+```
+
+Sémantique :
+- Si l'objet est dans la zone autour de la caméra (`x_pos ≤ camera + 320 px env.`), appeler `DisplaySprite`
+- Sinon : nettoyer son entrée respawn (clear bit 7) et appeler `DeleteObject` (= unload + erase)
+
+Le `wide-dot factor` (`andb #$C0`) aligne sur 64 pixels — c'est lié à la résolution effective du TO8 en mode wide-dot (160 colonnes).
+
+## `MarkObjGone2`
+
+Variante qui prend la position dans `D` plutôt que via `x_pos,u`. Utile si on a déjà calculé une position modifiée :
+
+```asm
+        ldd   computed_x_pos
+        jsr   MarkObjGone2              ; D = position à comparer
+```
+
+## `MarkObjGone3`
+
+Différence : si l'objet est encore dans la zone, fait **`rts`** au lieu de `DisplaySprite`. Utile quand on a déjà affiché l'objet plus tôt dans la routine.
+
+```asm
+        ; ... logique ...
+        jsr   DisplaySprite             ; on affiche déjà
+        ; ... autre logique ...
+        jmp   MarkObjGone3              ; check unload seulement (sans réafficher)
+```
+
+## Le wide-dot factor expliqué
+
+```asm
+cmpd  #$40+160+$20+$40
+```
+
+- `160` = largeur visible en pixels (mode 160x200 BM16)
+- `$40` à gauche = marge avant la caméra (64 pixels)
+- `$20` à droite = round-up de 160 sur multiple de 64
+- `$40` supplémentaire = marge après la caméra
+
+Total $E0 = 224 pixels de tolérance autour de la caméra avant de supprimer l'objet.
+
+> **Note** : la version asm du repo a `wide-dot factor` (factor 64 = `$C0` mask) car le TO8 utilise un mode 160 pixels où chaque pixel est 2 pixels physiques (wide-dot). En mode 80 colonnes ou autre, ajuster.
+
+## Système respawn — flux complet
+
+```
+1. Niveau démarre, ObjectWave crée des ennemis aux frames prédéfinies
+   → chaque ennemi a un respawn_index unique pointant dans Object_Respawn_Table
+   → bit 7 = 1 (live)
+
+2. Joueur progresse, certains ennemis sortent par la gauche
+   → MarkObjGone détecte, clear bit 7, DeleteObject
+
+3. Joueur fait demi-tour, la caméra revient sur la zone
+   → ObjectWave (en re-scrolling arrière) check le bit 7
+   → bit 7 = 0 → respawn l'objet (re-LoadObject_u)
+   → bit 7 = 1 (live à nouveau)
+
+4. Joueur tue l'ennemi (game logic)
+   → KillObject met bit 7 à 1 ET ajoute un flag « killed » dans la table
+   → l'objet ne respawn plus, même si la caméra revient
+```
+
+## Object_Respawn_Table — entrées
+
+Format d'une entrée (3 octets) :
+```
+Offset | Taille | Contenu
+-------|--------|--------
+0      | 2      | (réservé pour index ou pointeur)
+2      | 1      | flags
+              bit 7 = 1 si live (spawné)
+              bit 7 = 0 si peut respawn
+              autres bits = libre pour usage applicatif
+```
+
+Le code engine ne touche que le bit 7. Les autres bits sont à disposition du jeu (e.g. bit 6 = « killed définitivement »).
+
+## Intégration avec `ObjectWave`
+
+`ObjectWave` (ou `objectWave.do`) parcourt le script de spawn. Pour chaque entrée :
+- Lit le timestamp et compare à `gfxlock.frame.count`
+- Si timestamp atteint, alloue l'objet
+- **Si l'objet a un `respawn_index`**, set le bit 7 dans la table
+
+Quand `MarkObjGone` est appelé, l'objet est supprimé mais le bit 7 est claré → si on revient sur la zone, `ObjectWave` détectera l'entrée non-live et re-spawnera.
+
+## Pitfalls
+
+- **`respawn_index` non initialisé** : `MarkObjGone` skip le clear de bit 7 (cf. `beq` après `ldb respawn_index,u`), pas grave mais l'objet ne pourra pas respawn
+- **Wide-dot factor incorrect** pour le mode graphique utilisé : utiliser `$C0` (64 pixels) en mode 160 pixels, `$F8` (8 pixels) en mode 320 pixels (ajuster `andb`)
+- **Limite hors écran** trop serrée : objets supprimés trop tôt (avant de sortir visuellement). Augmenter le `cmpd #...` si nécessaire (au prix de plus d'objets actifs)
+- **Confusion avec `render_todelete_mask`** : `MarkObjGone` appelle `DeleteObject` (= unload+erase). Pas besoin de poser `render_todelete_mask` en plus
+- **`Object_Respawn_Table` placée sur une page paginable** : doit être en zone résidente (page 1) ou explicitement mountée. Sinon `MarkObjGone` lit/écrit sur une page random
+- **`MarkObjGone` appelé sur un objet sans sprite** (priority=0) : `DisplaySprite` ne fait rien, mais le check de zone reste utile. OK.
+
+## Pattern d'usage
+
+```asm
+; Objet ennemi typique
+Ennemi
+        lda   routine,u
+        ; ...
+
+Main
+        ; ... logique ...
+        jsr   ObjectMoveSync
+        jsr   AnimateSprite
+        jmp   MarkObjGone               ; au lieu de jmp DisplaySprite
+                                        ; → display si visible, delete sinon
+```
+
+C'est le pattern standard pour les ennemis qui peuvent sortir/rentrer de l'écran (shoot 'em up à scrolling).

--- a/skills/thomson-to8-engine-object-management/references/runobjects-execution.md
+++ b/skills/thomson-to8-engine-object-management/references/runobjects-execution.md
@@ -1,0 +1,144 @@
+# `RunObjects` — exécution cyclique des objets
+
+`RunObjects` est appelée chaque frame depuis la `MainLoop` du game-mode. C'est elle qui exécute le code de chaque objet vivant.
+
+## Algorithme
+
+```asm
+RunObjects
+        ldu   object_list_first         ; tête de liste
+        beq   @rts                      ; liste vide
+!       ldb   id,u                      ; ObjID logique
+        beq   @skip                     ; slot booké mais id=0 → skip
+        ldx   #Obj_Index_Page
+        abx
+        lda   ,x                        ; page mémoire de l'objet
+        _SetCartPageA                   ; mount cette page en cartouche
+        aslb                            ; *2 (adresse 2 octets/entry)
+        ldx   #Obj_Index_Address
+        abx
+        ldd   run_object_next,u         ; sauve le suivant AVANT exec
+        std   object_list_next          ; (cf. self-suppression)
+        jsr   [,x]                      ; saut indirect vers le code
+        ldu   run_object_next,u
+        bne   <
+        ldu   #0
+object_list_next equ *-2
+        bne   <
+@rts    rts
+@skip   ldu   run_object_next,u
+        bne   <
+        rts
+```
+
+## Mécanique du cross-page mount
+
+Le code asm de chaque objet est typiquement placé sur une page différente que celle qui exécute `RunObjects` (la page « résidente », contenant le main engine du game-mode).
+
+L'engine mount automatiquement la bonne page avant d'appeler la routine :
+
+```
+Obj_Index_Page[ObjID_X]    = 4    ; l'objet X est en page 4
+Obj_Index_Address[ObjID_X] = $A100 ; et son entry point est à $A100
+```
+
+Ces deux tables sont **générées par le builder Java** (cf. `BuildDisk.java` — fonctions `writeObjIndex` etc.). Elles sont placées en zone résidente (page 1), accessibles depuis n'importe où.
+
+Le `_SetCartPageA` est équivalent à `sta $E7E6` (mappe la page A en zone cartouche $0000-$3FFF) — sur les variantes T2, c'est `jsr SetCartPageA` qui passe via la routine engine.
+
+## Sauvegarde du `next` avant exécution
+
+```asm
+        ldd   run_object_next,u         ; sauve AVANT exec
+        std   object_list_next
+        jsr   [,x]                      ; exec — l'objet peut se supprimer
+        ldu   run_object_next,u         ; mais on lit le next sauvé via object_list_next
+```
+
+Cette indirection est cruciale : si l'objet se supprime via `UnloadObject_u`, son `run_object_next` est mis à 0 ET `object_list_next` est mis à jour par `UnloadObject_u` pour pointer vers le bon objet suivant. Sans cette sauvegarde, on accéderait à un slot effacé.
+
+## Création d'un objet fils pendant l'exécution
+
+L'allocation via `LoadObject_u`/`x` ajoute en queue (`object_list_last`). Si on est en train de parcourir et qu'on est avant la queue, le nouvel objet **sera exécuté dans la même frame** car le parcours va l'atteindre.
+
+Si on est l'objet en queue (dernier de la liste), le nouvel objet est en queue mais **ne sera pas exécuté immédiatement** car le parcours sort de la boucle avec `ldu run_object_next,u → 0`. Néanmoins, l'engine fait :
+
+```asm
+        ldu   run_object_next,u         ; obj courant.next (peut être le nouvel objet)
+        bne   <
+        ldu   #0
+object_list_next equ *-2                ; lecture de object_list_next
+        bne   <
+```
+
+Le `object_list_next` est consulté en fallback → si entre-temps un fils a été créé et `object_list_next` mis à jour, le parcours reprend. Donc en pratique tous les objets créés pendant la frame sont exécutés dans la frame.
+
+## `RunFrozenObjects` — mode pause
+
+```asm
+RunFrozenObjects
+        ldu   object_list_first
+        beq   @rts
+!       lda   render_flags,u
+        anda  #^render_hide_mask        ; unset hide flag
+        sta   render_flags,u
+        ldu   run_object_next,u
+        bne   <
+@rts    rts
+```
+
+Ne **n'exécute pas** le code des objets. Se contente de lever le bit `render_hide_mask` sur tous les objets. Utilisé pour faire réapparaître les sprites figés à la sortie d'une pause/cinematic.
+
+## Diagrammes — chaînage de la run-list
+
+```
+object_list_first ──→ Obj A
+                       prev = 0
+                       next ──→ Obj B
+                                 prev ──→ Obj A
+                                 next ──→ Obj C
+                                            prev ──→ Obj B
+                                            next = 0
+                                            ←─ object_list_last
+```
+
+Lors d'un `UnloadObject_u(B)` :
+1. `B.prev (A).next = B.next (C)`
+2. `B.next (C).prev = B.prev (A)`
+3. `B` est effacé et son adresse repush dans `STACK_SLOT_ADDRESS`
+
+```
+object_list_first ──→ Obj A
+                       prev = 0
+                       next ──→ Obj C   ← maintenant direct
+                                 prev ──→ Obj A
+                                 next = 0
+                                 ←─ object_list_last
+```
+
+## Cas particulier : `id=0` (slot réservé)
+
+Un slot peut être alloué mais avec `id=0`. Dans ce cas `RunObjects` le **skip sans erreur** et passe au suivant. Pattern d'usage : réserver un slot maintenant pour un objet à initialiser plus tard.
+
+## Ordre d'exécution
+
+L'ordre est **strictement celui d'insertion** (FIFO sur la chaîne). Si on veut un ordre de priorité différent, il faut le gérer applicativement (pas de tri automatique sur `priority`, `priority` ne sert que pour l'**affichage**).
+
+## Coût CPU
+
+À chaque appel `RunObjects` : pour chaque objet,
+- 4-5 instructions de setup (~20 cycles)
+- 1 `_SetCartPageA` (~10 cycles en T2 via routine, ~6 cycles en FD via store direct)
+- 1 `jsr [,x]` (~9 cycles)
+- 4-5 instructions de fin de tour (~20 cycles)
+- Soit ~60 cycles de bookkeeping par objet, hors code utilisateur
+
+Avec 22 objets et un budget 50 Hz (~20000 cycles/frame), on a ~19000 cycles pour le code utilisateur de tous les objets — soit ~860 cycles/objet en moyenne. Suffisant pour la plupart des objets simples ; les boss/joueurs principaux mangent plus.
+
+## Pitfalls
+
+- **Ne pas modifier `run_object_next,u`** depuis le code utilisateur — c'est géré par l'engine
+- **Modifier `id,u` à 0 sans `UnloadObject_u`** : le slot n'est pas remis dans la pile, fuite
+- **Allouer un objet pendant que la pile est presque vide** : un autre objet pourrait avoir le même slot ; gérer le Z=1
+- **Mounter manuellement une page dans un objet** : doit être restauré avant `rts` (ou utiliser `_RunObjectSwap`)
+- **Compter sur l'ordre d'exécution** : si tu inserts un objet après le tien, il sera exécuté dans la frame ; si avant, dans la prochaine

--- a/skills/thomson-to8-engine-object-management/references/state-machines.md
+++ b/skills/thomson-to8-engine-object-management/references/state-machines.md
@@ -1,0 +1,217 @@
+# State machines — `routine` et `routine_secondary/tertiary/quaternary`
+
+Chaque objet a **4 indices de routine** indépendants permettant d'implémenter jusqu'à 4 state machines en parallèle :
+
+| Offset | Symbole | Usage typique |
+|--------|---------|---------------|
+| 34 | `routine` | State machine principale (Init/Main/Die) |
+| 35 | `routine_secondary` | Animation / déplacement secondaire |
+| 36 | `routine_tertiary` | IA / comportement scripté |
+| 37 | `routine_quaternary` | Effets visuels / sub-effects |
+
+## Pattern de base — `routine` principale
+
+```asm
+<Name>
+        lda   routine,u
+        asla                            ; *2 (fdb = 2 octets)
+        ldx   #<Name>_Routines
+        jmp   [a,x]                     ; saut indirect
+
+<Name>_Routines
+        fdb   Init                      ; routine 0
+        fdb   Main                      ; routine 1
+        fdb   Die                       ; routine 2
+
+Init
+        ; ... config initiale ...
+        inc   routine,u                 ; passe en routine 1
+        rts
+
+Main
+        ; ... logique frame par frame ...
+        jsr   AnimateSprite
+        jmp   DisplaySprite
+
+Die
+        ; ... animation de mort ...
+        lda   render_flags,u
+        ora   #render_todelete_mask
+        sta   render_flags,u
+        rts
+```
+
+## Sous-state machine — `routine_secondary`
+
+```asm
+Main
+        ; Dispatcher principal
+        ldb   routine,u
+        ; ... main logic ...
+        
+        ; Dispatcher secondaire (e.g. animation)
+        lda   routine_secondary,u
+        asla
+        ldx   #Anim_SubRoutines
+        jmp   [a,x]
+
+Anim_SubRoutines
+        fdb   AnimWalk
+        fdb   AnimRun
+        fdb   AnimJump
+
+AnimWalk
+        ldd   #Ani_Walk
+        std   anim,u
+        jsr   AnimateSprite
+        rts
+
+; ...
+```
+
+## Patterns observés
+
+### Convention `_routine` suffixe
+
+Plutôt que de hardcoder les indices (0, 1, 2), définir des constantes nommées au début de l'objet :
+
+```asm
+Init_routine       equ 0
+Ground_routine     equ 1
+Jump_routine       equ 2
+Fall_routine       equ 3
+FallSlowly_routine equ 4
+Fly_routine        equ 5
+```
+
+Et basculer entre états en nommé :
+```asm
+        lda   #Jump_routine
+        sta   routine,u
+```
+
+C'est le pattern de bubble-bobble. Bien plus lisible que `lda #2; sta routine,u`.
+
+### Pattern Init terminé par routine choisie
+
+Plutôt que `inc routine,u` (qui passe en routine 1 systématiquement), choisir explicitement :
+
+```asm
+Init
+        ; ... config initiale ...
+        lda   #Ground_routine           ; passe directement en Ground
+        sta   routine,u
+        ; pas de rts ici, on tombe sur le code de Ground
+        ; (ou rts si on veut attendre la prochaine frame)
+Ground
+        ; ...
+```
+
+Permet de chaîner immédiatement (gain d'une frame) ou différer (`rts` à la fin de Init).
+
+### Sub-routines pour animation découplée
+
+L'animation peut avoir sa propre state machine indépendante du déplacement :
+
+```asm
+Main
+        ; déplacement (routine principale)
+        ; ...
+        
+        ; animation (routine_secondary)
+        lda   routine_secondary,u
+        asla
+        ldx   #Anim_Routines
+        jmp   [a,x]
+
+Anim_Routines
+        fdb   AnimIdle
+        fdb   AnimAttack
+        fdb   AnimDamage
+
+AnimIdle
+        ldd   #Ani_Idle
+        std   anim,u
+        rts
+
+; transition depuis un autre point du code :
+        lda   #Anim_Attack
+        sta   routine_secondary,u
+```
+
+### Triple state machine (routine + secondary + tertiary)
+
+Pattern observé chez r-type (player1) :
+- `routine` : état physique (Air, Ground, ChargingBeam)
+- `routine_secondary` : forme du tir (Wave, Reflect, Search)
+- `routine_tertiary` : forcepod actif ou non
+
+Permet de combiner ces états sans explosion combinatoire de routines.
+
+## Interaction avec animation v00/v02 — tag `_nextRoutine`
+
+L'animation v00 peut terminer par `_nextRoutine` :
+```properties
+animation.Ani_Die=2;Img_die_a;Img_die_b;Img_die_c;_nextRoutine
+```
+
+Quand `AnimateSprite` rencontre ce tag, il appelle `inc routine,u`. Cela permet de **chaîner une transition d'état via l'animation** : « quand l'animation de mort est finie, passer à la routine suivante (typiquement la libération du slot) ».
+
+Variante : `_resetAnimAndSubRoutine` (clear `routine_secondary` à 0 et reset l'anim), `_nextSubRoutine` (`inc routine_secondary,u`).
+
+## Cas pratique — objet ennemi avec 3 phases
+
+```asm
+Spider
+        lda   routine,u
+        asla
+        ldx   #Spider_Routines
+        jmp   [a,x]
+
+Spider_Routines
+        fdb   Init                      ; 0 : entrer
+        fdb   Patrol                    ; 1 : patrouille
+        fdb   Attack                    ; 2 : attaque
+        fdb   Stunned                   ; 3 : sonné
+        fdb   Die                       ; 4 : mort
+
+Init
+        ldd   #Ani_Spider_Walk
+        std   anim,u
+        ldb   #3
+        stb   priority,u
+        ; ... AABB ...
+        inc   routine,u
+        rts
+
+Patrol
+        ; déplacement
+        jsr   ObjectMoveSync
+        ; détection joueur
+        jsr   Obj_GetOrientationToPlayer
+        ldd   Gotp_Player_H_Distance
+        cmpd  #100
+        bhs   @no_attack
+        lda   #2                        ; routine Attack
+        sta   routine,u
+@no_attack
+        jsr   AnimateSprite
+        jmp   DisplaySprite
+
+Attack
+        ; ... ouvre la mâchoire, etc ...
+
+Stunned
+        ; ... timer ...
+
+Die
+        ; ... animation puis suppression ...
+```
+
+## Pitfalls
+
+- **Oublier `inc routine,u` ou `sta routine,u` à la fin d'Init** : Init est rappelée à chaque frame
+- **Modifier `routine_secondary,u` sans avoir initialisé la sub-state machine** : crash sur jump indirect
+- **Confondre `routine` (8 bits, 0-127) et `anim` (16 bits, pointeur)** : `routine` est un index, `anim` est une adresse
+- **`asla` après une routine > 127** : on déborde sur le bit de signe, la table d'adresses indirecte plante. Limiter à 128 routines max (de toute façon irréaliste)
+- **Modifier `routine,u` avec la routine actuellement en cours** : OK, le changement prend effet à la frame suivante (sauf si on continue à exécuter du code après le changement, attention à pas faire les deux logiques en parallèle)

--- a/skills/thomson-to8-engine-palette/SKILL.md
+++ b/skills/thomson-to8-engine-palette/SKILL.md
@@ -1,0 +1,355 @@
+---
+name: thomson-to8-engine-palette
+description: "Décrit le système de palette du Thomson TO8/TO9 game engine (Bento8/wide-dot) : double buffer Pal_current / Pal_buffer (32 octets, 16 couleurs sur 2 octets chacune), flag PalRefresh (-1 = pas de refresh, 0 = refresh demandé), routines PalUpdateNow (boucle déroulée optimisée) et PalUpdateNowLean (boucle compacte avec ldd ,x++), accès hardware via $E7DA (donnée couleur, auto-incrément) et $E7DB (index couleur), couleur de bordure $E7DD, palette cycling rotatif PalCycling sur les 3 premières couleurs, effets raster PalRaster_1c pour changer 1 couleur par scanline (lecture $E7 pour wait spot column), structure d'une couleur (2 octets : VVVVRRRR puis XXXMBBBB avec M = bit de marquage incrustation), palettes engine Pal_black et Pal_white (constantes), objet PaletteFade pour transition progressive (init source/dest, nb_frames, mask alternance V/R, callback fin, auto-unload), objet raster-fade pour fade par scanline avec subtypes (Sub_RasterFadeInColor, Sub_RasterFadeOutColor, Sub_RasterMain, Sub_RasterCycle), intégration avec gfxlock.screenBorder.update, palette générée par builder depuis PNG (Palette.java + PaletteTO8.getPaletteData). Utiliser pour comprendre comment charger une palette, déclencher un fade, faire du cycling, programmer un effet raster, gérer la bordure d'écran, ou implémenter une transition d'écran avec PaletteFade. Mots-clés : Pal_current, Pal_buffer, PalRefresh, PalUpdateNow, PalUpdateNowLean, PalCycling, PalCyc_frames, PalCyc_frames_init, PalRaster_1c, PalRas_page, PalRas_start, PalRas_end, $E7DA, $E7DB, $E7DD, $E7DC, $E7E5, Pal_black, Pal_white, ObjID_fade, ObjID_PaletteFade, ObjID_raster-fade, PaletteFade, PaletteFade_Init, PaletteFade_Wait, PaletteFade_Main, PaletteFade_Idle, o_fade_src, o_fade_dst, o_fade_mask, o_fade_cycles, o_fade_save, o_fade_idx, o_fade_curwait, o_fade_wait, o_fade_callback, o_fade_sleep, o_fade_unload, o_fade_routine_idle, raster_pal_dst, raster_nb_fade_colors, raster_cycle_idx, raster_color, raster_cycles, raster_inc, raster_frames, raster_cur_frame, raster_nb_colors, raster_cycle_frame, Sub_RasterFadeInColor, Sub_RasterFadeOutColor, Sub_RasterMain, Sub_RasterCycle, PALETTE_FADER, NO_CALLBACK, MUSIC_LOOP, gfxlock.screenBorder.color, gfxlock.screenBorder.update, _palette.set, _palette.show, _palette.fade, color VVVVRRRR XXXMBBBB, 16 couleurs, 4096 couleurs, fondu, transition, screen border, incrustation."
+machines: [to8, to8d, to9, to9+]
+user-invocable: false
+---
+
+# Palette — Thomson TO8/TO9 Game Engine
+
+Le TO8 dispose d'une palette de **16 couleurs** simultanément affichables, choisies parmi 4096 (4 bits par composante R/V/B). La palette est stockée dans un buffer de 32 octets (2 octets par couleur) et appliquée au hardware via des registres I/O.
+
+Ce skill couvre : le **buffer palette** et son refresh, les routines `PalUpdateNow*`, le **palette cycling**, les **effets raster** (changement à mi-écran), l'objet **PaletteFade** pour transitions progressives, et l'objet **raster-fade** pour fades par scanline.
+
+---
+
+## Format d'une couleur
+
+Chaque couleur occupe **2 octets** :
+
+```
+Octet 1 :  V V V V  R R R R
+           |─bleu*─| (fond. V)  |─rouge─|  (fond. R)
+
+Octet 2 :  X X X M  B B B B
+           bit marquage         |─bleu─|  (fond. B)
+           (incrustation)
+```
+
+> **Note hardware** : Le bit M (marquage / incrustation vidéo) sert au mode incrustation (mixing avec source vidéo externe). À 0 pour usage standard.
+
+Donc une couleur prend les 2 octets `$VR $MB` :
+- `V` (vert) : 4 bits
+- `R` (rouge) : 4 bits
+- `M` (marquage) : 1 bit
+- `B` (bleu) : 4 bits (les bits XXX en haut sont ignorés)
+
+Pour 16 couleurs : 32 octets en mémoire.
+
+---
+
+## Buffer palette
+
+```asm
+PalRefresh      fcb   $FF              ; -1 = pas de refresh demandé, 0 = refresh à faire
+Pal_current     fdb   Pal_buffer       ; pointeur vers la palette courante (lue par PalUpdateNow)
+Pal_buffer      fill  0,$20            ; 32 octets de palette
+```
+
+Trois éléments :
+- `PalRefresh` : flag de demande de refresh. À `$FF` (positif après `tst`), `PalUpdateNow` est skipée. À `$00` ou `$80` (négatif après `tst`), le refresh est exécuté.
+- `Pal_current` : pointeur 2 octets vers la palette **active**. Peut pointer vers `Pal_buffer` (palette modifiable) ou vers une palette en ROM (`Pal_game`, `Pal_black`, etc.).
+- `Pal_buffer` : palette de travail (32 octets, modifiable par fade/cycling).
+
+### Pattern d'usage
+
+```asm
+        ; Activer une palette en ROM
+        ldd   #Pal_TitleScreen          ; généré par builder depuis palette.Pal_TitleScreen=...
+        std   Pal_current
+        clr   PalRefresh                ; demander refresh
+        jsr   PalUpdateNow              ; appliquer immédiatement
+```
+
+Le `clr PalRefresh` (mettre à 0) est interprété par `PalUpdateNow` comme « refresh demandé » (`bne @rts` ne saute pas).
+
+> **Sens inversé du flag** : si on lit `PalRefresh` avec `tst`, **0 = refresh demandé**, **non-0 = ignorer**. Le `com PalRefresh` à la fin de `PalUpdateNow` remet à `$FF` (donc « plus de refresh ») et la prochaine appel sera ignoré.
+
+---
+
+## `PalUpdateNow` — application instantanée
+
+```asm
+PalUpdateNow
+        tst   PalRefresh                ; 0 = refresh demandé
+        bne   @rts                      ; sinon, sortir
+        pshs  dp
+        ldd   #$E7
+        tfr   b,dp                      ; positionner DP à $E7
+        ldx   Pal_current               ; X = adresse de la palette à appliquer
+        sta   <$DB                      ; écrit l'index dans $E7DB (auto-init à 0)
+!       ldd   ,x                        ; lit la couleur
+        sta   <$DA                      ; écrit V/R dans $E7DA (auto-increment)
+        stb   <$DA                      ; écrit M/B
+        ldd   2,x                       ; couleur 2
+        sta   <$DA
+        stb   <$DA
+        ; ... 16 fois en tout (boucle déroulée)
+        com   PalRefresh                ; flag à $FF (plus de refresh)
+        puls  dp,pc
+@rts    rts
+```
+
+Approche **boucle déroulée** : 16 paires de `ldd; sta <$DA; stb <$DA` pour les 16 couleurs. Optimisé pour la vitesse (~150 cycles vs ~250 avec une boucle).
+
+Variables hardware :
+- `$E7DB` : index de la couleur à modifier (0-15)
+- `$E7DA` : donnée de couleur, **auto-incrémente** l'index après chaque écriture
+
+Donc une seule `sta <$DB` au début (index 0), puis 32 écritures successives à `$E7DA` (pour 16 couleurs × 2 octets).
+
+### `PalUpdateNowLean` — version compacte
+
+```asm
+PalUpdateNow 
+        tst   PalRefresh
+        bne   @rts
+        pshs  dp
+        ldd   #$E7
+        tfr   b,dp  
+        ldx   Pal_current
+        leay  32,x
+        sty   @end
+        sta   <$DB
+!       ldd   ,x++                      ; auto-increment X
+        sta   <$DA
+        stb   <$DA
+        cmpx  #0
+@end    equ   *-2
+        bne   <
+        com   PalRefresh
+        puls  dp,pc
+@rts    rts
+```
+
+Boucle compacte avec `ldd ,x++` (auto-incr). Plus court en mémoire (~50 octets vs ~150) mais ~50% plus lent à l'exécution (~225 cycles).
+
+À utiliser quand on a beaucoup de palettes différentes (ROM compact) et qu'on peut tolérer le délai.
+
+---
+
+## `PalCycling` — rotation des 3 premières couleurs
+
+```asm
+PalCyc_frames      fcb 0
+PalCyc_frames_init fcb 0
+
+PalCycling
+        dec   PalCyc_frames
+        bne   >
+        lda   PalCyc_frames_init
+        sta   PalCyc_frames
+        clr   PalRefresh
+        ldx   Pal_current
+        ldu   4,x
+        ldd   2,x
+        std   4,x
+        ldd   ,x
+        std   2,x
+        stu   ,x
+!       jmp   PalUpdateNow
+```
+
+Tous les `PalCyc_frames_init` frames, rotate les **3 premières couleurs** : `[0,1,2] → [2,0,1]`.
+
+Pré-requis : `PalCyc_frames_init` initialisé à la cadence souhaitée (e.g. 4 = rotation tous les 4 frames).
+
+Usage typique : effet d'eau, lave, feu, plasma — palette qui « bouge ».
+
+```asm
+        ; Init
+        lda   #4
+        sta   PalCyc_frames_init
+        sta   PalCyc_frames             ; pour le premier tour
+
+        ; Dans MainLoop
+        jsr   PalCycling                ; à chaque frame
+```
+
+**Limites** : rotate seulement les 3 premières couleurs. Pour cycling sur d'autres couleurs ou plus de slots, écrire une variante custom.
+
+---
+
+## `PalRaster_1c` — palette à mi-écran (raster effect)
+
+Change **1 couleur de la palette** à chaque scanline pour produire un effet visuel impossible avec une palette statique (dégradé, halo, plasma).
+
+```asm
+PalRas_page   fdb $00                   ; page mémoire des données raster
+PalRas_start  fdb $0000                 ; adresse début des données
+PalRas_end    fdb $0000                 ; adresse fin
+
+PalRaster_1c 
+        lda   PalRas_page
+        _SetCartPageA
+        ldx   PalRas_start
+        lda   #32        
+!       bita  <$E7                      ; attend que le spot soit hors zone visible
+        beq   <
+!       bita  <$E7 
+        bne   <                         ; attend que le spot soit dans zone visible
+        mul                             ; tempo (sync précise)
+        ; ...
+        ldd   1,x                       ; lit la donnée raster
+        sta   <$DB
+        ldd   #0
+        stb   <$DA 
+        sta   <$DA
+        leax  3,x                       ; 3 octets par entrée
+        cmpx  PalRas_end
+        bne   <
+        rts
+```
+
+Données raster : suite de tuples `(index_couleur, blue_green, marker_red)` (3 octets).
+
+À appeler depuis `UserIRQ` (sur synchronisation VBL) pour avoir le bon timing.
+
+Voir [references/raster-effects.md](references/raster-effects.md).
+
+---
+
+## Palettes engine prédéfinies
+
+- `Pal_black.asm` : palette tout-noir (32 octets de 0)
+- `Pal_white.asm` : palette tout-blanc
+
+Constantes générées : `Pal_black`, `Pal_white` (pointeurs).
+
+Usage : transitions (fade vers/depuis noir/blanc).
+
+```asm
+        ldd   #Pal_black
+        std   Pal_current
+        clr   PalRefresh
+        jsr   PalUpdateNow
+```
+
+---
+
+## Couleur de bordure — `$E7DD`
+
+La bordure d'écran (zone hors viewport) est gérée séparément par `$E7DD` :
+
+```asm
+        lda   $E7DD
+        anda  #$F0                      ; préserver bits hauts
+        ora   #couleur_index            ; ajouter index 0-15
+        sta   $E7DD
+```
+
+Le builder Java génère ce code automatiquement dans `LoadAct` quand `act.X.screenBorder=N` est défini.
+
+`gfxlock.screenBorder.update` est la routine engine recommandée :
+
+```asm
+        ldb   #couleur_index
+        jsr   gfxlock.screenBorder.update
+```
+
+Cela synchronise aussi `gfxlock.screenBorder.color` (utilisé par `gfxlock.bufferSwap.do`).
+
+---
+
+## Objet PaletteFade (`engine/objects/palette/fade/`)
+
+Objet engine prêt à l'emploi pour faire un **fade progressif** d'une palette source vers une palette destination.
+
+### `fade.equ` — offsets OST
+
+```asm
+o_fade_src       equ ext_variables       ; ptr palette source
+o_fade_dst       equ ext_variables+2     ; ptr palette destination
+o_fade_mask      equ ext_variables+4     ; masque alternance V/R par frame
+o_fade_cycles    equ ext_variables+5     ; nb de pas (16 typiquement)
+o_fade_save      equ ext_variables+6     ; buffer temporaire
+o_fade_idx       equ ext_variables+8     ; index courant
+o_fade_curwait   equ ext_variables+9     ; wait time courant
+o_fade_wait      equ ext_variables+10    ; wait time entre pas
+o_fade_callback  equ ext_variables+11    ; routine à appeler à la fin (2 octets)
+o_fade_sleep     equ ext_variables+13    ; prochain trigger
+o_fade_unload    equ ext_variables+15    ; 0 = pas de unload, non-zero = auto-unload
+```
+
+### Pattern d'usage
+
+```asm
+        jsr   LoadObject_u
+        beq   @no_slot
+        lda   #ObjID_fade
+        sta   id,u
+        ldd   Pal_current
+        std   o_fade_src,u              ; palette source
+        ldd   #Pal_game
+        std   o_fade_dst,u              ; palette destination
+        lda   #10
+        sta   o_fade_wait,u             ; 10 frames entre chaque pas
+        ; (callback et unload optionnels)
+@no_slot
+```
+
+L'objet exécute automatiquement le fade frame par frame, modifie `Pal_buffer`, met `PalRefresh = 0` pour déclencher le refresh.
+
+À la fin (16 pas), si `o_fade_unload != 0`, l'objet se supprime automatiquement.
+
+Si `o_fade_callback` est non-null, la routine est appelée à la fin du fade (callback applicatif).
+
+Voir [references/fade-object.md](references/fade-object.md).
+
+---
+
+## Objet raster-fade
+
+Variante plus avancée qui combine **fade + raster** : la palette est faite avec des couleurs différentes à différentes scanlines.
+
+### Subtypes
+
+```asm
+Sub_RasterFadeInColor  equ 1            ; fade-in à une couleur cible
+Sub_RasterFadeOutColor equ 2            ; fade-out depuis couleur source
+Sub_RasterMain         equ 3            ; affichage permanent avec raster
+Sub_RasterCycle        equ 4            ; cycling
+```
+
+Voir [references/raster-fade-object.md](references/raster-fade-object.md).
+
+---
+
+## Build pipeline — palette depuis PNG
+
+Le builder Java (`Palette.java` + `PaletteTO8.getPaletteData`) lit la palette du PNG indiqué dans `palette.Pal_<X>=path.png` et génère 32 octets de palette au bon format.
+
+```properties
+palette.Pal_TitleScreen=./game-mode/00/images/logo_pal.png
+```
+
+Génère un label `Pal_TitleScreen` (adresse 2 octets) pointant vers les 32 octets palette dans le code asm. Utilisé dans le code : `ldd #Pal_TitleScreen; std Pal_current`.
+
+Le PNG doit être en **palette indexée** (4-bit ou 8-bit, max 16 couleurs effectives).
+
+---
+
+## Pitfalls
+
+- **Confusion index PNG vs index runtime Thomson** : le builder `PaletteTO8.java` lit les couleurs du PNG aux index 1..16 et les écrit dans les slots Thomson 0..15 (shift de -1, car PNG idx 0 = transparent implicite). Dans le code asm (tables raster, `sta $E7DB`), il faut utiliser les **index runtime 0..15**. Erreur classique : commenter « idx 1 = HERBE » d'après ce que montre GIMP, puis écrire `fcb $01,...` → on adresse en fait la 2ème couleur. Cf. [references/palette-system.md](references/palette-system.md) section "Index couleur : PNG vs runtime Thomson".
+- **Ordre des bytes inversé dans la table raster** (`PalRaster_1c`) : chaque entrée DOIT être `fcb idx, M_B, V_R` — l'octet `M_B` (bleu+marquage) AVANT `V_R` (vert+rouge). Contre-intuitif mais imposé par la séquence `stb` puis `sta` sur `$E7DA` (auto-incrémenté) qui écrit `byte[2]` à position N (= V_R) puis `byte[1]` à position N+1 (= M_B). Si on inverse, les couleurs sont visuellement aberrantes (vert ↔ bleu) sans aucune erreur. Cf. [references/raster-effects.md](references/raster-effects.md) section "ORDRE BYTES CRITIQUE".
+- **Sens inversé de `PalRefresh`** : `$FF` = pas de refresh, `0` = refresh demandé. Erreur classique.
+- **`PalUpdateNow` sans `clr PalRefresh`** avant : la routine est skipée silencieusement
+- **Modifier `Pal_buffer` directement** sans `clr PalRefresh` : changement non appliqué visuellement (jusqu'au prochain trigger)
+- **Pointer `Pal_current` vers une zone non-résidente** : si la palette est sur une page commutable et que la page n'est pas mountée au moment du refresh, lecture aléatoire → couleurs cassées
+- **Appeler `PalUpdateNow` pendant une frame de rendu** : possible glitches visuels (changement de palette en milieu d'image). Préférer l'appel depuis `UserIRQ` (sur VBL)
+- **`PalCycling` sans `PalCyc_frames_init`** : décrément infini, jamais de rotate
+- **`PalRaster_1c` mal timé** : le `bita <$E7` synchronise sur le spot, mais le délai initial doit matcher exactement la première scanline du raster. Calibrage critique
+- **Bordure changée sans `gfxlock.screenBorder.update`** : `gfxlock.bufferSwap.do` peut overwriter à la prochaine VBL
+- **PNG palette mal indexée** : le builder peut générer du n'importe quoi si le PNG n'est pas en mode palette
+
+---
+
+## Références détaillées
+
+- [references/palette-system.md](references/palette-system.md) — Buffer Pal_buffer/Pal_current, PalRefresh sémantique, format couleur 16-bit (V/R puis M/B), accès hardware $E7DA/$E7DB/$E7DD, comparaison PalUpdateNow vs Lean (boucle déroulée vs compacte), génération depuis PNG par builder Java (Palette.java, PaletteTO8)
+- [references/palette-cycling.md](references/palette-cycling.md) — `PalCycling` algorithme, rotation des 3 premières couleurs, `PalCyc_frames`/`PalCyc_frames_init`, patterns water/lava/plasma, variantes custom (cycling sur d'autres couleurs ou plus de slots)
+- [references/raster-effects.md](references/raster-effects.md) — `PalRaster_1c` détaillé : synchronisation spot via `bita <$E7`, format données raster (3 octets/entrée : color_idx + V_R + M_B), placement dans UserIRQ, timing critique, exemples sky gradient / horizon
+- [references/fade-object.md](references/fade-object.md) — `PaletteFade` objet engine complet : 4 routines (Init/Wait/Main/Idle), offsets OST détaillés, exemple chargement, callback applicatif, auto-unload, masque alternance V/R par frame (16 pas = 16 niveaux entre source et dest), interaction avec Pal_buffer
+- [references/raster-fade-object.md](references/raster-fade-object.md) — `raster-fade` objet avancé : subtypes (FadeIn/FadeOut/Main/Cycle), offsets OST raster_*, intégration avec PalRaster_1c, patterns dégradé d'écran (sky, sunset, eau), cycling raster
+- [references/screen-border.md](references/screen-border.md) — Couleur bordure `$E7DD`, `gfxlock.screenBorder.color`, `gfxlock.screenBorder.update`, intégration avec `gfxlock.bufferSwap.do`, `act.X.screenBorder` property et code généré par builder, conventions de couleur (typiquement noir 0 ou couleur de la palette)

--- a/skills/thomson-to8-engine-palette/references/fade-object.md
+++ b/skills/thomson-to8-engine-palette/references/fade-object.md
@@ -1,0 +1,202 @@
+# Objet `PaletteFade` — transition progressive
+
+L'objet engine `PaletteFade` (à `engine/objects/palette/fade/`) gère une **transition progressive** d'une palette source vers une palette destination, sur N frames.
+
+## `fade.properties`
+
+```properties
+code=./engine/objects/palette/fade/fade.asm
+```
+
+À déclarer dans le game-mode :
+```properties
+object.fade=./engine/objects/palette/fade/fade.properties
+# ou via gameModeCommon
+```
+
+Génère `ObjID_fade` et `ObjID_PaletteFade`.
+
+## Offsets OST
+
+```asm
+o_fade_src       equ ext_variables       ; ptr palette source (2)
+o_fade_dst       equ ext_variables+2     ; ptr palette destination (2)
+o_fade_mask      equ ext_variables+4     ; masque alternance V/R (1)
+o_fade_cycles    equ ext_variables+5     ; nb pas (typiquement 16) (1)
+o_fade_save      equ ext_variables+6     ; buffer compare (2)
+o_fade_idx       equ ext_variables+8     ; index couleur courant (1)
+o_fade_curwait   equ ext_variables+9     ; wait courant (1)
+o_fade_wait      equ ext_variables+10    ; wait entre pas (1)
+o_fade_callback  equ ext_variables+11    ; routine callback fin (2)
+o_fade_sleep     equ ext_variables+13    ; prochain trigger (2)
+o_fade_unload    equ ext_variables+15    ; 0 = pas unload, !0 = auto-unload (1)
+```
+
+Total : 16 octets dans `ext_variables`. Pré-requis : `ext_variables_size >= 16` dans `ram-data.asm`.
+
+## Routines
+
+```asm
+PaletteFade_Routines
+        fdb   PaletteFade_Init           ; 0
+        fdb   PaletteFade_Wait           ; 1
+        fdb   PaletteFade_Main           ; 2
+        fdb   PaletteFade_Idle           ; 3
+```
+
+État machine :
+- **Init (0)** : recopie la palette source dans `Pal_buffer`, prépare les compteurs
+- **Wait (1)** : attend `o_fade_curwait` frames avant chaque pas
+- **Main (2)** : applique un pas de fade (modifie 1 ou 2 composantes de la palette en cours)
+- **Idle (3)** : fade terminé, attend ou se supprime
+
+## Pattern d'usage — chargement
+
+```asm
+        jsr   LoadObject_u
+        beq   @no_slot
+        lda   #ObjID_fade
+        sta   id,u
+        
+        ldd   Pal_current               ; source = palette actuelle
+        std   o_fade_src,u
+        
+        ldd   #Pal_game                  ; destination
+        std   o_fade_dst,u
+        
+        lda   #10                        ; 10 frames entre pas
+        sta   o_fade_wait,u
+        
+        ldd   #my_callback               ; (optionnel) routine à appeler à la fin
+        std   o_fade_callback,u
+        
+        lda   #1                         ; auto-unload à la fin
+        sta   o_fade_unload,u
+@no_slot
+```
+
+## Mécanique du fade
+
+1. **Init** : recopie `Pal_buffer = source`. Init `o_fade_cycles = $10` (16 pas), `o_fade_mask = $0F`.
+2. **Pas par pas** :
+   - Compare `Pal_buffer[i]` avec `dest[i]`
+   - Si différent, incrémente/décrémente la composante (V, R, ou B selon mask)
+   - L'alternance V/R par frame permet de faire un fade plus visible (chaque composante avance ~1 niveau par 2 frames)
+3. **Wait** : entre chaque pas, `o_fade_wait` frames d'attente
+4. **Fin** : quand toutes les couleurs égalent la destination, appelle `o_fade_callback` (si non-null) puis :
+   - Si `o_fade_unload != 0` : `UnloadObject_u`
+   - Sinon : passe en `PaletteFade_Idle`
+
+## Durée totale
+
+`durée_totale = o_fade_cycles × o_fade_wait` frames
+
+Avec `o_fade_cycles = 16` (constante) et `o_fade_wait = 10` : 160 frames = ~3.2s à 50 Hz.
+
+Pour un fade plus rapide : `o_fade_wait = 5` → 80 frames = 1.6s.
+Pour très rapide : `o_fade_wait = 1` → 16 frames = 320 ms.
+
+## Callback de fin
+
+```asm
+my_callback
+        ; ce code s'exécute quand le fade est terminé
+        ; ... (e.g. déclencher un changement de game-mode, jouer un son, ...)
+        rts
+```
+
+Permet de chaîner des actions au moment précis de fin de fade.
+
+## Auto-unload
+
+Si `o_fade_unload != 0`, l'objet se supprime après la fin. Pratique pour les fades one-shot (intro, transition).
+
+Si `o_fade_unload = 0`, l'objet reste en routine `Idle` — peut être réutilisé en remettant `o_fade_src`/`o_fade_dst` et en passant `routine = 0` (re-init).
+
+## Patterns courants
+
+### Fade-in (apparition)
+
+```asm
+        ; à l'init du game-mode
+        ldd   #Pal_black
+        std   Pal_current               ; commence en noir
+        clr   PalRefresh
+        jsr   PalUpdateNow
+
+        ; lancer le fade vers la palette du niveau
+        jsr   LoadObject_u
+        beq   @no_slot
+        lda   #ObjID_fade
+        sta   id,u
+        ldd   #Pal_black
+        std   o_fade_src,u
+        ldd   #Pal_game
+        std   o_fade_dst,u
+        lda   #6
+        sta   o_fade_wait,u
+        lda   #$FF
+        sta   o_fade_unload,u
+@no_slot
+```
+
+### Fade-out (disparition)
+
+```asm
+        ; trigger : fin du niveau
+        jsr   LoadObject_u
+        beq   @no_slot
+        lda   #ObjID_fade
+        sta   id,u
+        ldd   Pal_current
+        std   o_fade_src,u
+        ldd   #Pal_black
+        std   o_fade_dst,u
+        lda   #6
+        sta   o_fade_wait,u
+        ldd   #ChangeToNextLevel        ; callback déclenche le change
+        std   o_fade_callback,u
+        lda   #$FF
+        sta   o_fade_unload,u
+@no_slot
+```
+
+### Cross-fade entre palettes
+
+```asm
+        ; bascule de Pal_level1 vers Pal_level2 sans passer par noir
+        ldd   #Pal_level1
+        std   o_fade_src,u
+        ldd   #Pal_level2
+        std   o_fade_dst,u
+        ; ...
+```
+
+## Pattern goldorak — `_palette.fade` macro
+
+Dans goldorak (cf. `global/global-macros.asm`), une macro encapsule l'init :
+
+```asm
+_palette.fade #Pal_black,#Palette_splash,PALETTE_FADER,#$60,#NO_CALLBACK,#$FF
+```
+
+Paramètres :
+- `\1` : source
+- `\2` : destination
+- `\3` : objet ID du fader
+- `\4` : wait time
+- `\5` : callback (ou `NO_CALLBACK`)
+- `\6` : unload flag
+
+Pattern d'abstraction qui pourrait être intégré dans `engine/` (cf. note utilisateur sur l'école goldorak).
+
+## Pitfalls
+
+- **`o_fade_src` / `o_fade_dst` mal pointés** : crash (palette lue à mauvaise adresse)
+- **`o_fade_wait = 0`** : fade instantané (en 16 frames) — pas un bug mais surprenant
+- **`o_fade_callback` à une adresse invalide** : crash en fin de fade
+- **`o_fade_unload = 0` mais on relance un autre fade** : il faut re-init `routine = 0`
+- **Plusieurs `PaletteFade` actifs simultanément** : conflit sur `Pal_buffer` (les deux modifient en même temps) → résultat imprévisible. Toujours un seul fade actif à la fois
+- **Fade source = `Pal_buffer`** : OK, mais alors le fade modifie sa propre source (la source change pendant le fade). Pas un bug, mais subtil
+- **Modifier `Pal_current` pendant un fade** : le fade continue d'écrire dans `Pal_buffer` mais le hardware affiche autre chose
+- **`ext_variables_size < 16`** : les offsets du fade débordent → corruption mémoire

--- a/skills/thomson-to8-engine-palette/references/palette-system.md
+++ b/skills/thomson-to8-engine-palette/references/palette-system.md
@@ -1,0 +1,304 @@
+# Système de palette — buffer, refresh, hardware
+
+## ⚠️ Index couleur : PNG vs runtime Thomson — DISTINCTION CRITIQUE
+
+Quand on travaille avec une palette générée depuis un PNG, **les index dans le PNG ne sont PAS les mêmes que les index runtime utilisés par le hardware Thomson**. Il y a un décalage de -1, dû à la convention « index 0 = transparent » dans le PNG.
+
+### Le décalage
+
+Le builder Java (`PaletteTO8.getPaletteData`) lit le PNG ainsi :
+
+```java
+// fr.bento8.to8.image.PaletteTO8 (extrait)
+for (int colorIndex = 1; colorIndex < 17; colorIndex++) {
+    Color couleur = new Color(colorModel.getRGB(colorIndex));
+    // couleur écrite dans le slot (colorIndex - 1) de la palette Thomson
+}
+```
+
+Donc :
+
+| PNG (côté éditeur image)         | Thomson (runtime, registre `$E7DB`) |
+|----------------------------------|-------------------------------------|
+| index 0 = transparent (implicite) | (rien — la transparence est gérée par le sprite, pas la palette) |
+| index 1 = première couleur       | slot 0                              |
+| index 2 = deuxième couleur       | slot 1                              |
+| ...                              | ...                                 |
+| index 16 = seizième couleur      | slot 15                             |
+
+### Conséquence pratique
+
+Quand on écrit du code qui adresse la palette via `$E7DB` (ou les routines `PalRaster_1c`, `PalUpdateNow`), on utilise **les index runtime 0..15**, PAS les index PNG 1..16.
+
+**Exemple concret — table raster pour un sprite road dont la palette PNG contient :**
+
+| PNG index | Couleur sémantique | Index runtime à utiliser dans `fcb idx, M_B, V_R` |
+|-----------|-------------------|---------------------------------------------------|
+| 0         | (transparent, n'apparaît pas dans la palette Thomson) | — |
+| 1         | HERBE             | **0**                                             |
+| 2         | BORDURE           | **1**                                             |
+| 3         | ROUTE             | **2**                                             |
+| 4         | MARQUAGE          | **3**                                             |
+
+```asm
+; Table raster — index runtime, pas index PNG !
+pal_RoadRaster
+        fcb   $00,$00,$80   ; idx 0 = HERBE (PNG idx 1)
+        fcb   $01,$00,$0F   ; idx 1 = BORDURE (PNG idx 2)
+        fcb   $02,$04,$44   ; idx 2 = ROUTE (PNG idx 3)
+        fcb   $03,$0F,$FF   ; idx 3 = MARQUAGE (PNG idx 4)
+```
+
+### Vérification
+
+Pour vérifier le shift sur un PNG donné, regarder `PaletteTO8.java` ligne ~50 : la boucle `for (int colorIndex = 1; colorIndex < 17; colorIndex++)` est la source de vérité.
+
+### Pourquoi cette convention
+
+Le PNG-8 garde l'index 0 pour la transparence (utilisé par l'engine au moment du draw du sprite : pixels à 0 ne sont pas écrits). Les couleurs effectivement encodées dans la palette Thomson sont donc PNG[1..16].
+
+**Pitfall classique** : commenter une table raster avec « idx 1 = HERBE » parce que c'est ce qu'on voit dans GIMP/Photoshop, puis écrire `fcb $01,...` dans la table → on tape sur la BORDURE, pas l'HERBE. Bug silencieux, couleurs décalées de 1 slot.
+
+---
+
+## Format d'une couleur
+
+Chaque couleur du TO8 = 2 octets. Décomposition :
+
+```
+Octet 1 (haut) :  V V V V  R R R R     ; vert (4 bits) + rouge (4 bits)
+Octet 2 (bas)  :  X X X M  B B B B     ; bit marquage + bleu (4 bits)
+```
+
+- `V` (Vert) : 4 bits = 16 niveaux (0=noir, 15=max)
+- `R` (Rouge) : 4 bits
+- `B` (Bleu) : 4 bits
+- `M` (Marquage) : 1 bit pour incrustation vidéo (mixing avec vidéo externe). À 0 pour usage standard
+- `XXX` : bits ignorés (peuvent être à 0)
+
+Total : 4096 couleurs possibles (16^3), 16 affichables simultanément.
+
+## Table canonique des niveaux RGB (datasheet EF9369)
+
+Le hardware Thomson (gate array palette EF9369) ne produit pas les 16 niveaux de manière linéaire — ils sont espacés selon une courbe logarithmique propre au DAC. La table de conversion officielle est dans `java-generator/src/main/java/fr/bento8/to8/image/PaletteTO8.java` :
+
+```java
+private static int to8RGB[] = {0, 97, 122, 143, 158, 171, 184, 194,
+                               204, 212, 219, 227, 235, 242, 250, 255};
+// relevé de voltage datasheet EF9369
+```
+
+| Nibble | RGB 8-bit | Niveau visuel |
+|--------|-----------|---------------|
+| `$0` | 0 | noir total |
+| `$1` | 97 | très foncé |
+| `$2` | 122 | foncé |
+| `$3` | 143 | gris foncé |
+| `$4` | 158 | gris moyen-foncé |
+| `$5` | 171 | **gris moyen** |
+| `$6` | 184 | gris moyen-clair |
+| `$7` | 194 | clair |
+| `$8` | 204 | plus clair |
+| `$9` | 212 | clair-saturé |
+| `$A` | 219 | saturé |
+| `$B` | 227 | saturé+ |
+| `$C` | 235 | très saturé |
+| `$D` | 242 | très saturé+ |
+| `$E` | 250 | quasi max |
+| `$F` | 255 | max |
+
+**Important** : la courbe n'est PAS `255 * (n/15)` — c'est plus tassé vers le haut. Pour avoir un « gris à 50% perceptuel », `$5` = 171 est plus juste que `$8` = 204.
+
+### Couleurs de référence pour le gameplay
+
+| Couleur voulue | V | R | B | V_R | M_B | RGB rendu |
+|----------------|---|---|---|-----|-----|-----------|
+| Noir | 0 | 0 | 0 | `$00` | `$00` | (0,0,0) |
+| Blanc | F | F | F | `$FF` | `$0F` | (255,255,255) |
+| Rouge pur | 0 | F | 0 | `$0F` | `$00` | (255,0,0) |
+| Vert pur | E | 0 | 0 | `$E0` | `$00` | (0,250,0) |
+| Bleu pur | 0 | 0 | F | `$00` | `$0F` | (0,0,255) |
+| Gris moyen | 5 | 5 | 5 | `$55` | `$05` | (171,171,171) |
+| Gris clair | 8 | 8 | 8 | `$88` | `$08` | (204,204,204) |
+| Cyan | F | 0 | F | `$F0` | `$0F` | (0,255,255) |
+| Magenta | 0 | F | F | `$0F` | `$0F` | (255,0,255) |
+| Jaune | F | F | 0 | `$FF` | `$00` | (255,255,0) |
+
+**À utiliser** pour les tables raster ou les `Pal_X` custom. Évite de tâtonner et de tomber sur des couleurs visuellement bizarres.
+
+## Buffer en mémoire
+
+```asm
+PalRefresh      fcb   $FF              ; flag de refresh
+Pal_current     fdb   Pal_buffer       ; pointeur vers la palette courante
+Pal_buffer      fill  0,$20            ; 32 octets (16 couleurs × 2)
+```
+
+### `PalRefresh` — sémantique inversée
+
+| Valeur | Effet |
+|--------|-------|
+| `$FF` (positif après `tst`) | Pas de refresh demandé, `PalUpdateNow` skip |
+| `$00` (zéro, neutre) | Refresh demandé, `PalUpdateNow` s'exécute |
+| Toute valeur != $FF | Refresh demandé |
+
+> Le `com PalRefresh` à la fin de `PalUpdateNow` flip $00 → $FF, marquant la fin.
+
+Usage :
+```asm
+        clr   PalRefresh                ; demander refresh
+        ; ... éventuellement modifier Pal_buffer ...
+        ; à la prochaine PalUpdateNow (typiquement depuis UserIRQ), le refresh s'applique
+```
+
+### `Pal_current`
+
+Pointeur 2 octets vers la palette **active**. Peut pointer :
+- Vers `Pal_buffer` (palette modifiable en RAM)
+- Vers une palette en ROM (`Pal_TitleScreen`, `Pal_game`, `Pal_black`, ...)
+
+Switch de palette :
+```asm
+        ldd   #Pal_TitleScreen          ; palette en ROM
+        std   Pal_current
+        clr   PalRefresh                ; demander refresh
+        jsr   PalUpdateNow              ; appliquer
+```
+
+Pour modifier la palette dynamiquement (fade, cycling), pointer vers `Pal_buffer` et modifier directement les 32 octets.
+
+## Accès hardware
+
+| Registre | Adresse | Sémantique |
+|----------|---------|------------|
+| Index couleur | `$E7DB` | Pose l'index 0-15 de la couleur à modifier |
+| Donnée | `$E7DA` | Écrit un octet de couleur, auto-incrémente l'index après chaque écriture |
+| Bordure | `$E7DD` | Couleur de la bordure (bits 0-3 = index) |
+| Mode page | `$E7E5/$E7E6/$E7E7` | Sélection pages physiques (cf. autre skill) |
+
+Pour écrire les 16 couleurs (32 octets) :
+```asm
+        lda   #0
+        sta   $E7DB                     ; init index = 0
+        ; pour chaque couleur (16 fois) :
+        lda   #couleur_V_R
+        sta   $E7DA                     ; index incrémente automatiquement
+        lda   #couleur_M_B
+        sta   $E7DA
+```
+
+L'auto-incrément évite d'avoir à toucher `$E7DB` pour chaque couleur.
+
+## `PalUpdateNow` — algorithme
+
+```asm
+PalUpdateNow 
+        tst   PalRefresh
+        bne   @rts                      ; $FF → skip
+        pshs  dp
+        ldd   #$E7
+        tfr   b,dp                      ; DP = $E7 pour adressage direct
+        ldx   Pal_current               ; X = adresse palette
+        sta   <$DB                      ; index 0 dans $E7DB (A déjà à 0 ?)
+        
+        ; Boucle déroulée — 16 itérations de :
+        ldd   ,x                        ; load couleur 0
+        sta   <$DA                      ; V_R dans $E7DA
+        stb   <$DA                      ; M_B dans $E7DA (auto-inc)
+        ldd   2,x                       ; couleur 1
+        sta   <$DA
+        stb   <$DA
+        ; ... 14 fois de plus
+        
+        com   PalRefresh                ; flag → $FF (plus de refresh)
+        puls  dp,pc
+@rts    rts
+```
+
+### Boucle déroulée vs lean
+
+`PalUpdateNow` (déroulée) :
+- ~150 cycles d'exécution
+- ~140 octets de code
+
+`PalUpdateNowLean` (compacte) :
+- ~225 cycles
+- ~50 octets
+
+Choix : la déroulée est utilisée par défaut (perf > taille). Lean utilisée par r-type (cf. `PalUpdateNowLean.asm` inclus dans le main.asm).
+
+### Setup DP
+
+`PalUpdateNow` utilise DP=$E7 temporairement pour accéder à `<$DA` et `<$DB` (=`$E7DA`, `$E7DB`). C'est plus rapide que `sta $E7DA` (mode direct vs étendu).
+
+`pshs dp` au début et `puls dp,pc` à la fin pour préserver le DP de l'appelant.
+
+## Quand appeler `PalUpdateNow`
+
+Cas typiques :
+
+### Au boot du game-mode
+
+```asm
+        ldd   #Pal_TitleScreen
+        std   Pal_current
+        clr   PalRefresh
+        jsr   PalUpdateNow              ; appliquer immédiatement
+```
+
+### Depuis UserIRQ (recommandé)
+
+```asm
+UserIRQ
+        jsr   gfxlock.bufferSwap.check
+        jsr   PalUpdateNow              ; refresh palette à chaque VBL
+        ; ... audio ...
+        rts
+```
+
+C'est le pattern le plus courant : `PalUpdateNow` est appelée à chaque VBL, mais ne fait rien si `PalRefresh = $FF`. Quand un fade/cycling/changement met `PalRefresh = 0`, le refresh s'applique au prochain VBL.
+
+Avantage : pas de tearing palette (la palette change pendant la VBL, donc invisible).
+
+### En milieu de frame (raster)
+
+Pour des effets raster, `PalRaster_1c` change la palette pendant le tracé (cf. `raster-effects.md`).
+
+## Pipeline build — palette depuis PNG
+
+```properties
+palette.Pal_TitleScreen=./game-mode/00/images/title.png
+```
+
+Le builder (`Palette.java` + `PaletteTO8.getPaletteData`) :
+1. Lit le PNG (mode palette indexée, max 16 couleurs)
+2. Extrait les 16 couleurs (RGB)
+3. Convertit en format TO8 (4 bits par composante, format V_R / M_B)
+4. Génère 32 octets dans le code asm, label `Pal_TitleScreen`
+
+Exemple généré :
+```asm
+Pal_TitleScreen
+        fcb $00,$00     ; couleur 0 = noir
+        fcb $FF,$0F     ; couleur 1 = blanc
+        fcb $0F,$00     ; couleur 2 = rouge
+        ; ... 13 couleurs supplémentaires
+```
+
+### Quirks du builder
+
+- PNG en mode RGB sans palette : le builder peut échouer ou prendre les 16 premières couleurs trouvées
+- PNG avec moins de 16 couleurs : les slots non utilisés sont à 0 (noir)
+- Mode palette 8-bit avec > 16 couleurs : tronqué aux 16 premières
+
+Convention : utiliser GIMP / Photoshop pour exporter en PNG palette indexée 4-bit.
+
+## Pitfalls
+
+- **Sens inversé de `PalRefresh`** : confusion classique. `clr` = refresh, `lda #$FF; sta` = skip
+- **`Pal_current` mal aligné** : 2 octets bien sûr, mais la palette doit être à une adresse paire ? Non, `ldd` accepte n'importe quelle adresse.
+- **Pointer `Pal_current` vers une page non-mountée** : lecture aléatoire au refresh. Toujours pointer vers du code/data résident OU mount avant le refresh
+- **Modifier `Pal_buffer` puis basculer `Pal_current` vers une autre palette** : les modifications de Pal_buffer sont perdues si on n'y repointe pas après
+- **Appeler `PalUpdateNow` depuis le code utilisateur** sans coordination avec UserIRQ : possible race condition, glitches visuels
+- **PNG palette non indexée** : le builder peut générer une palette n'importe comment. Toujours vérifier en mode palette indexée 4-bit
+- **Mettre le bit M (marquage)** par erreur : peut produire un effet d'incrustation indésirable. À 0 pour usage standard

--- a/skills/thomson-to8-engine-palette/references/raster-effects.md
+++ b/skills/thomson-to8-engine-palette/references/raster-effects.md
@@ -1,0 +1,221 @@
+# Effets raster — `PalRaster_1c` et palette à mi-écran
+
+Les effets raster consistent à **changer la palette pendant le tracé de l'écran**, pour obtenir des dégradés ou des effets de couleur impossibles avec une palette statique unique.
+
+## Principe hardware
+
+Le TO8 a une palette de 16 couleurs. Si on change une couleur **juste après que le faisceau cathodique soit passé sur une scanline**, les pixels suivants utiliseront la nouvelle couleur. En répétant à chaque scanline, on peut afficher des dégradés verticaux dans le même slot palette.
+
+Le bit utile pour la synchro est dans `$E7` : 0 = spot dans zone visible, 1 = spot dans zone non-visible (HBlank).
+
+## `PalRaster_1c` — change 1 couleur par scanline
+
+```asm
+PalRas_page   fdb $00                   ; page mémoire des données
+PalRas_start  fdb $0000                 ; adresse début
+PalRas_end    fdb $0000                 ; adresse fin
+
+PalRaster_1c 
+        lda   PalRas_page
+        _SetCartPageA                   ; mount la page des données raster
+        ldx   PalRas_start
+        lda   #32        
+!       bita  <$E7                      ; attend zone non-visible
+        beq   <
+!       bita  <$E7 
+        bne   <                         ; attend zone visible (= début scanline)
+        mul                             ; tempo
+        mul
+        nop
+!       tfr   a,b                       ; tempo
+        tfr   a,b
+        tfr   a,b
+        ldd   1,x                       ; lit V_R, M_B (octets 1-2 de l'entrée)
+        std   >*+8                      ; auto-modif pour l'instruction qui suit
+        lda   ,x                        ; lit index couleur (octet 0)
+        sta   <$DB                      ; pose l'index
+        ldd   #0                        ; (auto-modifié plus haut)
+        stb   <$DA 
+        sta   <$DA
+        leax  3,x                       ; 3 octets par entrée
+        cmpx  PalRas_end
+        bne   <
+        rts
+```
+
+## ⚠️ Index couleur runtime, pas index PNG
+
+Le premier octet de chaque entrée (`color_idx`) est l'**index RUNTIME** Thomson (0..15), à poser tel quel dans `$E7DB`. Si la palette vient d'un PNG, le builder fait un shift `PNG[1..16] → Thomson[0..15]`, donc **l'idx PNG est = idx runtime + 1**.
+
+Pour adresser la couleur dont l'index visible dans GIMP est 3 (= 3ème couleur du PNG après le 0 transparent), il faut écrire `fcb $02,...` (pas `$03,...`). Cf. [palette-system.md](palette-system.md) section « Index couleur : PNG vs runtime Thomson ».
+
+## Format des données raster — ⚠️ ORDRE BYTES CRITIQUE
+
+Chaque entrée = **3 octets** dans l'ordre :
+
+```
+Offset | Taille | Contenu                  | Sémantique
+-------|--------|--------------------------|--------------------------------------------------
+0      | 1      | Index couleur (0-15)     | Slot palette à modifier
+1      | 1      | M_B = (M<<4)|B           | bleu — écrit en SECOND à $E7DA (position N+1)
+2      | 1      | V_R = (V<<4)|R           | vert+rouge — écrit en PREMIER à $E7DA (position N)
+```
+
+**L'ordre M_B AVANT V_R dans la table est contre-intuitif** mais **obligatoire**. Pourquoi :
+
+1. **Format Thomson palette** : pour la couleur d'index N, 2 octets contigus en mémoire :
+   - position N   = `VVVV RRRR` (vert + rouge)
+   - position N+1 = `XXXM BBBB` (marquage + bleu)
+
+2. **PalRaster_1c** lit l'entrée et l'écrit en 2 fois à `$E7DA` (auto-incrément interne) :
+   ```asm
+   ldd   1,x        ; A = byte[1], B = byte[2]
+   std   >*+8       ; mémorise dans ldd #imm ci-dessous
+   lda   ,x
+   sta   <$DB       ; pose l'index de la couleur cible
+   ldd   #0         ; (modifié → ldd #imm avec A=byte[1], B=byte[2])
+   stb   <$DA       ; écrit B (= byte[2]) EN PREMIER → position N = V_R
+   sta   <$DA       ; écrit A (= byte[1]) EN SECOND → position N+1 = M_B
+   ```
+
+3. **Conséquence pour la table** :
+   - `byte[2]` (offset 2) doit contenir `V_R` (pour aller en position N)
+   - `byte[1]` (offset 1) doit contenir `M_B` (pour aller en position N+1)
+
+### Vérification via `Pal_white`
+
+Le fichier `engine/palette/color/Pal_white.asm` contient pour chaque couleur :
+```asm
+fdb $ff0f
+```
+Soit en mémoire `[$FF, $0F]` :
+- byte[0] = `$FF` → `V=F, R=F` (= blanc V_R)
+- byte[1] = `$0F` → `M=0, B=F` (= bleu max M_B)
+
+Cohérent avec la convention « V_R en premier en mémoire, M_B après ». Pour une entrée raster, on a juste un index couleur ajouté **avant**, donc structure : `[idx, M_B, V_R]` car les bytes [1,2] vont être écrits dans l'ordre inverse de leur lecture par `std`.
+
+### Exemple d'entrée — ciel bleu clair (idx 0)
+
+Niveaux Thomson : voir [palette-system.md](palette-system.md) section « Table canonique des niveaux RGB ». La courbe n'est PAS linéaire ; nibble `$F` = 255, `$5` = 171, `$0` = 0.
+
+Pour faire un bleu clair avec V=4, R=4, B=15 (= 0x4, 0x4, 0xF) :
+```
+V_R = (4<<4) | 4 = $44
+M_B = (0<<4) | $F = $0F     (marquage=0)
+```
+
+Rendu Thomson : `V=4` → 158, `R=4` → 158, `B=15` → 255 = RGB(158, 158, 255) = bleu clair désaturé.
+
+Dans la table raster :
+```asm
+fcb   $00,$0F,$44     ; idx=0 (ciel), puis M_B, puis V_R
+```
+
+**Si on inverse l'ordre** (`fcb $00,$44,$0F`), les couleurs sont aussi inversées : V_R devient $0F (V=0, R=15) = rouge pur, et M_B devient $44 (M=4 → incrustation activée!, B=4) → jaune-orange étrange. C'est le bug typique.
+
+### Couleurs « primaires » prêtes à l'emploi
+
+Pour les tables raster, voici les codes des couleurs canoniques (cf. table to8RGB) :
+
+| Couleur | `fcb idx, M_B, V_R` |
+|---------|---------------------|
+| Noir | `fcb $XX,$00,$00` |
+| Blanc | `fcb $XX,$0F,$FF` |
+| Rouge pur | `fcb $XX,$00,$0F` |
+| Vert pur (V=E plutôt que F pour éviter saturation) | `fcb $XX,$00,$E0` |
+| Bleu pur | `fcb $XX,$0F,$00` |
+| Gris moyen | `fcb $XX,$05,$55` |
+| Cyan | `fcb $XX,$0F,$F0` |
+| Jaune | `fcb $XX,$00,$FF` |
+| Magenta | `fcb $XX,$0F,$0F` |
+
+### Pour un dégradé
+
+Pour un dégradé sur 200 lignes : 200 × 3 = 600 octets de données.
+
+## Pré-requis et synchronisation
+
+`PalRaster_1c` doit être appelée depuis **UserIRQ** (au déclenchement du VBL) pour avoir le bon timing. La boucle interne attend chaque scanline via `bita <$E7`.
+
+```asm
+UserIRQ
+        jsr   PalRaster_1c              ; effet raster pour cette frame
+        ; ... autres ...
+        rts
+```
+
+⚠️ **Pas appelable depuis MainLoop** : la synchro spot serait perdue.
+
+## Setup typique
+
+```asm
+        ; au boot du game-mode
+        ldd   #raster_data_pal_page     ; page contenant les données
+        std   PalRas_page
+        ldd   #raster_data_start
+        std   PalRas_start
+        ldd   #raster_data_end
+        std   PalRas_end
+
+raster_data_start
+        fcb   0, $80, $0F               ; ligne X : couleur 0 = bleu clair
+        fcb   0, $70, $0E               ; ligne X+1 : couleur 0 = légèrement plus foncé
+        fcb   0, $60, $0D
+        ; ...
+raster_data_end
+```
+
+Effet : la couleur 0 change graduellement au fil des scanlines, créant un dégradé vertical.
+
+## Tempo et calibrage
+
+Les instructions `mul` / `nop` / `tfr a,b` dans le code servent de **tempo** pour synchroniser précisément avec le timing scanline. Le 6809 à 1 MHz fait ~250 cycles par scanline visible (TO8 a ~63µs/scanline = 63 cycles à 1 MHz × ... — chiffres à vérifier).
+
+Le calibrage est délicat : si on est en retard, on change la couleur au milieu de la scanline → glitch. Si on est en avance, on attend trop → on rate la scanline.
+
+Code optimal pour un changement = ~30 cycles. Au-delà, on peut louper une scanline.
+
+## Cas d'usage
+
+### Sky gradient
+
+```
+ligne 0..30 : couleur 0 = bleu très clair (haut du ciel)
+ligne 31..60 : transitions...
+ligne 61..90 : bleu plus foncé
+ligne 91..120 : couleurs sunset (orange/rouge)
+ligne 121..150 : transitions
+ligne 151..200 : noir (silhouette)
+```
+
+Génère un dégradé de coucher de soleil en utilisant seulement 1 slot palette (la couleur 0 du fond).
+
+### Horizon
+
+Changement d'index 1 couleur à la ligne où l'horizon coupe l'image → permet d'avoir un ciel et un sol avec la même slot palette.
+
+### Effet plasma vertical
+
+Combiner cycling temporel + change spatial pour créer un plasma.
+
+## Variantes
+
+L'engine ne fournit que `PalRaster_1c` (1 couleur). Pour changer plusieurs couleurs par scanline, il faudrait :
+- Augmenter le tempo pour chaque écriture supplémentaire (1 couleur prend ~10 cycles)
+- Vérifier que le total tient dans le HBlank (~50 cycles disponibles)
+
+Pratique : `PalRaster_2c` (2 couleurs) serait faisable. `PalRaster_3c` (3 couleurs) tendu.
+
+Sonic-2 utilise `PalRaster_1c` extensivement (cf. game-mode/title-screen).
+
+## Pitfalls
+
+- **Ordre des bytes inversé** (V_R avant M_B dans la table) : couleurs visuellement fausses (canal vert ↔ canal bleu). Le code compile et tourne, mais les teintes sont absurdes (e.g. ciel jaunâtre au lieu de bleu). Bug très piégeux car aucune erreur ne remonte. Ordre correct : **`idx, M_B, V_R`** — cf. section dédiée plus haut.
+- **Appel depuis MainLoop** : sync spot perdue, glitches visuels
+- **`PalRas_page` non mountée** : lecture de données aléatoires, couleurs random
+- **`PalRas_end` < `PalRas_start`** : boucle infinie
+- **`PalRas_start` mal aligné** : décalage de scanline (raster qui « bouge » d'une ligne au tour suivant)
+- **Tempo modifié dans `PalRaster_1c`** : le calibrage est perdu, glitches
+- **Mode graphique modifié au milieu du raster** : le timing change avec la résolution
+- **Trop de scanlines à parcourir** : si la routine n'a pas fini avant la fin de la frame, le débordement écrase la trame suivante
+- **Conflit avec `PalUpdateNow`** : si `PalRaster_1c` et `PalUpdateNow` sont appelés tous deux dans UserIRQ, le `PalUpdateNow` doit être avant (ou après mais sans débordement)

--- a/skills/thomson-to8-engine-scrolling/SKILL.md
+++ b/skills/thomson-to8-engine-scrolling/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: thomson-to8-engine-scrolling
+description: "Décrit les systèmes de scrolling du Thomson TO8/TO9 game engine (Bento8/wide-dot) : scrolling vertical (vscroll) avec macros _vscroll.setMap / _vscroll.setMapHeight / _vscroll.setTileset256 / _vscroll.setTileset512 / _vscroll.setTileNb / _vscroll.setBuffer / _vscroll.setCameraPos / _vscroll.setCameraSpeed / _vscroll.setViewport, scrolling horizontal (horizontal-scroll) avec scroll-map-buffered / scroll-map-buffered-even / scroll-map-buffered-odd / scroll-map-buffered-16x16, système caméra (AutoScroll, AutoScroll.equ, CheckCameraMove) avec glb_camera_x_pos / glb_camera_y_pos / glb_camera_x_pos_coarse / glb_camera_width / glb_camera_height / glb_camera_x_min_pos / glb_camera_y_max_pos / glb_camera_x_offset / glb_camera_y_offset / glb_camera_move / glb_camera_x_min / glb_camera_y_min / glb_camera_x_max / glb_camera_y_max / glb_vp_x_min / glb_vp_y_min / glb_auto_scroll_state / glb_auto_scroll_frames / glb_auto_scroll_step / glb_auto_scroll_step_remainder, scroll_state_stop, vscroll.camera.y / vscroll.obj.map.page / vscroll.obj.map.address / vscroll.map.height / vscroll.obj.tile.pages / vscroll.tiles.dyncall / vscroll.tiles.updateTilesForNLines.address / vscroll.tiles.nbLinesByPage, TilemapBuffer pour buffer cyclique 2 Ko 32x16 tiles, scroll.doOneLoop / scroll.goUntil pour scroll programmé, conversion stm vers bin via stm2bin -obd 12 -mul 2, png2bin -lb 4 -pb 8 -p 2 -pd 4 -vs -slc pour buffers de départ, format binaire tileset 512 tiles 8192 pixels hauteur, intégration avec gfxlock pour le double buffer, choix du mode tileset 256 vs 512 selon taille. Utiliser pour implémenter un scrolling vertical (shoot ou plateformer), horizontal (shoot type r-type), gérer la caméra auto-scroll (cinématiques, traveling), définir les limites de scroll, générer les assets de scroll depuis Pro Motion, calibrer la vitesse du scroll (8.8 sub-pixel), gérer le rebouclage en fin de map. Mots-clés : vscroll, _vscroll.setMap, _vscroll.setMapHeight, _vscroll.setTileset256, _vscroll.setTileset512, _vscroll.setTileNb, _vscroll.setBuffer, _vscroll.setCameraPos, _vscroll.setCameraSpeed, _vscroll.setViewport, _vscroll.buffer.line, vscroll.do, vscroll.move, vscroll.camera.y, vscroll.obj.map.page, vscroll.obj.map.address, vscroll.map.height, vscroll.obj.tile.pages, scroll.doOneLoop, scroll.goUntil, scroll.goUntil.pos, scroll-map-buffered, scroll-map-buffered-even, scroll-map-buffered-odd, scroll-map-buffered-16x16, horizontal-scroll, AutoScroll, CheckCameraMove, glb_camera_x_pos, glb_camera_y_pos, glb_camera_x_pos_coarse, glb_camera_width, glb_camera_height, glb_camera_x_min_pos, glb_camera_y_min_pos, glb_camera_x_max_pos, glb_camera_y_max_pos, glb_camera_x_offset, glb_camera_y_offset, glb_camera_move, glb_camera_x_min, glb_camera_y_min, glb_camera_x_max, glb_camera_y_max, glb_vp_x_min, glb_vp_y_min, glb_vp_x_max, glb_vp_y_max, glb_auto_scroll_state, glb_auto_scroll_frames, glb_auto_scroll_step, glb_auto_scroll_step_remainder, scroll_state_stop, TilemapBuffer, tileset 256 tiles, tileset 512 tiles, stm2bin, png2bin, pro motion, viewport, scroll vertical BM16, sub-pixel scroll 8.8."
+machines: [to8, to8d, to9, to9+]
+user-invocable: false
+---
+
+# Scrolling — Thomson TO8/TO9 Game Engine
+
+L'engine propose deux systèmes de scrolling :
+
+1. **`vscroll`** — scrolling vertical avec tileset 256 ou 512 tiles, utilisé par bubble-bobble (BM16, 160×200) et goldorak (BM16)
+2. **`horizontal-scroll`** — scrolling horizontal pour shoot'em up, utilisé par r-type (variantes buffered, even, odd, 16x16)
+
+Plus un **système caméra** (`AutoScroll`) pour piloter le scroll automatiquement (cinématiques, traveling).
+
+Ce skill couvre les deux systèmes, leurs macros, leurs variables globales et le pipeline de génération d'assets.
+
+---
+
+## `vscroll` — scrolling vertical
+
+### Composants
+
+```
+Map  : tableau 2D de tile IDs (e.g. 38x16 tiles = 760 entrées)
+Tileset : 256 ou 512 tiles graphiques (tile id → bitmap 16x16 ou 8x8)
+Buffer A/B : objets buffer de tiles (double-buffer cyclique)
+Camera : pointe la position courante dans la map
+```
+
+### Setup au boot du game-mode
+
+```asm
+        _vscroll.setMap #ObjID_levelMap
+        _vscroll.setMapHeight #38*16
+        _vscroll.setTileset256 ObjID_levelTileA0,ObjID_levelTileB0
+        _vscroll.setTileNb #61
+        _vscroll.setBuffer #ObjID_scrollA,#ObjID_scrollB
+        _vscroll.setCameraPos #0
+        _vscroll.setCameraSpeed #$0100
+        _vscroll.setViewport #0,#200
+```
+
+| Macro | Effet |
+|-------|-------|
+| `_vscroll.setMap` | Pointe la map (ObjID de l'objet `levelMap`) |
+| `_vscroll.setMapHeight` | Hauteur de la map en pixels (= rows × 16) |
+| `_vscroll.setTileset256` | Mode 256 tiles (1 octet par tile id) |
+| `_vscroll.setTileset512` | Mode 512 tiles (2 octets par tile id, plus de variété) |
+| `_vscroll.setTileNb` | Nombre de tiles uniques dans le tileset (par exemple 61) |
+| `_vscroll.setBuffer` | 2 objets buffer (double-buffer alterné) |
+| `_vscroll.setCameraPos` | Position Y initiale de la caméra (playfield) |
+| `_vscroll.setCameraSpeed` | Vitesse 8.8 (`$0100` = 1 px/frame, `$0080` = 0.5 px/frame) |
+| `_vscroll.setViewport` | Y min et Y max du viewport (zone visible à l'écran) |
+
+### MainLoop
+
+```asm
+MainLoop
+        jsr   RunObjects
+        ; ... collision ...
+        jsr   CheckSpritesRefresh
+        _gfxlock.on
+        jsr   EraseSprites
+        jsr   vscroll.do                ; dessine les tiles dans le buffer
+        jsr   vscroll.move              ; avance la caméra selon speed
+        jsr   UnsetDisplayPriority
+        jsr   DrawSprites
+        _gfxlock.off
+        _gfxlock.loop
+        bra   MainLoop
+```
+
+### Macro `_vscroll.buffer.line`
+
+Utilisée à l'intérieur des objets buffer (cycle de lignes) — pas pour usage utilisateur direct.
+
+### Scroll programmé — `scroll.goUntil`
+
+Pattern bubble-bobble pour faire un scroll auto jusqu'à une position cible :
+
+```asm
+        ldd   #200                      ; position cible
+        std   scroll.goUntil.pos
+        jsr   scroll.goUntil            ; bloquant : scroll progressivement
+
+; routine définie applicativement :
+scroll.goUntil.pos fdb 0
+scroll.goUntil
+@loop
+        jsr   scroll.doOneLoop
+        ldd   scroll.goUntil.pos
+        subd  #10
+        cmpd  vscroll.camera.y
+        bhi   @loop
+        ; fine scroll
+        _vscroll.setCameraSpeed #$0040
+@loop2
+        jsr   scroll.doOneLoop
+        ldd   scroll.goUntil.pos
+        subd  #1
+        cmpd  vscroll.camera.y
+        bhi   @loop2
+        _vscroll.setCameraSpeed #0
+        rts
+```
+
+Voir [references/vertical-scroll.md](references/vertical-scroll.md).
+
+---
+
+## `horizontal-scroll` — pour r-type
+
+Variants disponibles :
+- `scroll-map-buffered.asm` — version standard
+- `scroll-map-buffered-even.asm` — pour positions paires
+- `scroll-map-buffered-odd.asm` — pour positions impaires
+- `scroll-map-buffered-16x16.asm` — tiles 16×16 au lieu de 8×16
+
+Pattern d'usage (r-type) :
+```asm
+        INCLUDE "./engine/graphics/tilemap/horizontal-scroll/scroll-map-buffered-even.asm"
+```
+
+Voir [references/horizontal-scroll.md](references/horizontal-scroll.md).
+
+---
+
+## Système caméra
+
+### Variables globales
+
+```asm
+glb_camera_x_pos               ; position X caméra dans le playfield (16.8 signed)
+glb_camera_y_pos               ; position Y
+glb_camera_x_pos_coarse        ; ((x_pos - 64) / 64) * 64 — pour alignement scroll
+glb_camera_width               ; largeur du viewport visible
+glb_camera_height              ; hauteur
+glb_camera_x_min_pos           ; bornes de scroll
+glb_camera_x_max_pos
+glb_camera_y_min_pos
+glb_camera_y_max_pos
+glb_camera_x_offset            ; offset coord écran (init = screen_left)
+glb_camera_y_offset            ; offset Y
+glb_camera_move                ; flag : la caméra a-t-elle bougé cette frame ?
+```
+
+### `AutoScroll` (engine/graphics/camera/AutoScroll.asm)
+
+Permet de **programmer un déplacement caméra automatique** sur N frames à une vitesse donnée.
+
+```asm
+glb_auto_scroll_state               fcb   scroll_state_stop
+glb_auto_scroll_frames              fdb   0
+glb_auto_scroll_step                fdb   0     ; msb : px/frame, lsb : sub-pixel
+glb_auto_scroll_step_remainder      fdb   0
+```
+
+États (`AutoScroll.equ`) :
+- `scroll_state_stop` : pas de scroll
+- `scroll_state_up` : monte
+- `scroll_state_down` : descend
+- (et variantes horizontales)
+
+Usage :
+```asm
+        ; Programmer un scroll vers le bas sur 100 frames à 1.5 px/frame
+        lda   #scroll_state_down
+        sta   glb_auto_scroll_state
+        ldd   #100
+        std   glb_auto_scroll_frames
+        ldd   #$0180                    ; 1.5 px/frame (8.8)
+        std   glb_auto_scroll_step
+
+        ; Dans MainLoop
+        jsr   AutoScroll
+```
+
+### `CheckCameraMove`
+
+Détecte si la caméra a bougé cette frame (`glb_camera_move`). Utile pour forcer un refresh des sprites en coord playfield.
+
+```asm
+        jsr   CheckCameraMove           ; met glb_camera_move = 1 si bougé
+        lda   <glb_camera_move
+        beq   @no_move
+        lda   #1
+        sta   <glb_force_sprite_refresh ; force refresh global
+@no_move
+```
+
+Voir [references/camera-system.md](references/camera-system.md).
+
+---
+
+## Pipeline de génération d'assets — vscroll
+
+D'après `engine/graphics/tilemap/vscroll/vscroll.md` :
+
+### 1. Export depuis Pro Motion
+
+- Format map : `.stm`
+- Tileset : 1 fichier image, 1 colonne, tiles 16×16
+- Destination : `objects/scroll/levelX/`
+
+### 2. Conversion map STM → BIN
+
+```bash
+stm2bin -f="path/level1.stm" -obd=12 -mul=2
+```
+
+- `obd=12` : output bit depth 12 bits par tile id
+- `mul=2` : multiplier le tile id par 2 (valeurs paires uniquement)
+
+### 3. Génération des buffers de départ
+
+```bash
+png2bin -f level1.start.png -lb 4 -pb 8 -p 2 -pd 4 -vs -slc
+```
+
+- `lb=4` : 4 bits par pixel dans un plan
+- `pb=8` : 8 bits par plan
+- `p=2` : 2 plans mémoire
+- `pd=4` : 4 bits par pixel
+- `vs` : output pour vertical scroll
+- `slc` : shift colors indexes left by 1
+
+### 4. Génération du tileset
+
+Tileset fixe 512 tiles, image 8192 pixels de haut. Outils dans `6809-game-builder`.
+
+### Format des buffers
+
+Dans les objets buffer :
+```asm
+        INCLUDE "./engine/graphics/tilemap/vscroll/vscroll.macro.asm"
+@loop
+        INCLUDEBIN "./objects/scroll/levelX/level.start.0.0.bin.vscroll"
+        _vscroll.buffer.line
+        jmp   @loop
+```
+
+Le `_vscroll.buffer.line` est ajouté entre chaque INCLUDEBIN pour gérer le découpage en lignes.
+
+---
+
+## Variables internes vscroll
+
+```asm
+vscroll.camera.y                fdb 0       ; position Y caméra
+vscroll.obj.map.page            fcb 0       ; page de la map
+vscroll.obj.map.address         fdb 0       ; adresse de la map
+vscroll.map.height              fdb 0       ; hauteur map en pixels
+vscroll.obj.tile.pages          fill 0,8    ; pages des tiles (8 octets selon mode)
+vscroll.tiles.dyncall           fill 0,...  ; routines dynamiques par tile
+```
+
+---
+
+## `TilemapBuffer` (engine/graphics/tilemap/TilemapBuffer.asm)
+
+Buffer cyclique 2 Ko (32×16 tiles) pour tilemap. Utilisé par wide-dot-engine. Permet d'afficher une portion de map plus grande que l'écran, en streaming les tiles au fur et à mesure du scroll.
+
+---
+
+## Choix : vscroll vs horizontal-scroll
+
+| Genre | Système recommandé |
+|-------|--------------------|
+| Shoot vertical | `vscroll` |
+| Shoot horizontal | `horizontal-scroll` |
+| Plateformer 2D | `vscroll` (pour des écrans verticaux) ou tilemap statique |
+| Cinématique linéaire | `AutoScroll` |
+| Vue de dessus 4 directions | tilemap classique (cf. autre skill) |
+
+---
+
+## Pitfalls
+
+- **`_vscroll.setMap` non appelée** avant `vscroll.do` : pointe à 0, crash
+- **`_vscroll.setMapHeight` incorrecte** : scroll dépasse la fin de map, lecture aléatoire
+- **`_vscroll.setTileset256` mais le tileset a 512 tiles** : moitié non utilisée
+- **Speed > taille tile par frame** : tearing visuel (saut perceptible)
+- **Camera position dépasse `glb_camera_x_max_pos`** : peut générer un wrap-around ou un crash selon le mode
+- **Buffer A et B mal configurés** : double-buffer cassé, tearing
+- **Modifier `glb_camera_x_pos` manuellement pendant un scroll auto** : conflit avec `AutoScroll`
+- **Génération assets sans `stm2bin -mul=2`** : tile IDs impairs, format binaire incompatible
+- **PNG d'origine pas en 160×200** : viewport plus petit, mais nécessite ajuster `glb_camera_width`/`height`
+
+---
+
+## Références détaillées
+
+- [references/vertical-scroll.md](references/vertical-scroll.md) — `vscroll` complet : macros setMap/MapHeight/Tileset256/Tileset512/TileNb/Buffer/CameraPos/CameraSpeed/Viewport, `vscroll.do`/`vscroll.move`, variables internes (`vscroll.camera.y`, `obj.map.page`, etc.), pattern `scroll.goUntil`, `_vscroll.buffer.line`, pipeline d'assets stm2bin/png2bin, formats binaires des buffers
+- [references/horizontal-scroll.md](references/horizontal-scroll.md) — `scroll-map-buffered` et variants (even/odd/16x16), pattern r-type, buffers, intégration avec map de niveau, conversion playfield
+- [references/camera-system.md](references/camera-system.md) — Variables `glb_camera_*`, conversion playfield → écran, bornes min/max, `AutoScroll` (états, vitesse 8.8, sub-pixel remainder, `glb_auto_scroll_*`), `CheckCameraMove`, intégration avec `glb_force_sprite_refresh`, `screen_left`/`screen_top` initialisation

--- a/skills/thomson-to8-engine-scrolling/references/camera-system.md
+++ b/skills/thomson-to8-engine-scrolling/references/camera-system.md
@@ -1,0 +1,188 @@
+# Système caméra — variables et `AutoScroll`
+
+Le système caméra gère la position du **viewport visible** dans la map. Les sprites en coord playfield sont automatiquement convertis vers coord écran via la caméra.
+
+## Variables globales
+
+Définies dans `engine/constants.asm` (zone `glb_*`) :
+
+```asm
+glb_camera_x_pos                  ; position X caméra (s16.8)
+glb_camera_x_sub                  ; sub-pixel X
+glb_camera_y_pos                  ; position Y caméra
+glb_camera_y_sub                  ; sub-pixel Y
+glb_camera_x_pos_coarse           ; ((x_pos - 64) / 64) * 64
+glb_camera_width                  ; largeur viewport
+glb_camera_height                 ; hauteur viewport
+glb_camera_x_min_pos              ; borne min X (scroll-left limite)
+glb_camera_y_min_pos              ; borne min Y
+glb_camera_x_max_pos              ; borne max X
+glb_camera_y_max_pos              ; borne max Y
+glb_camera_x_offset               ; offset coord écran (= screen_left init)
+glb_camera_y_offset               ; offset Y
+glb_camera_move                   ; flag : caméra a bougé cette frame ?
+```
+
+## Conversion playfield → écran
+
+Pour un sprite avec `render_playfieldcoord_mask` :
+```
+x_pixel_effective = x_pos - glb_camera_x_pos + glb_camera_x_offset
+y_pixel_effective = y_pos - glb_camera_y_pos + glb_camera_y_offset
+```
+
+Calculé par `DrawSprites` (avant de dessiner).
+
+`glb_camera_x/y_offset` est typiquement `screen_left`/`screen_top` (~48 / ~28 selon mode). Initialisé par `InitDrawSprites`.
+
+## `AutoScroll`
+
+Permet de **programmer un déplacement caméra automatique** sur N frames à une vitesse donnée.
+
+### Variables
+
+```asm
+glb_auto_scroll_state               fcb   scroll_state_stop
+glb_auto_scroll_frames              fdb   0     ; nb de frames restantes
+glb_auto_scroll_step                fdb   0     ; msb: px/frame, lsb: sub-pixel
+glb_auto_scroll_step_remainder16bit fcb   $00
+glb_auto_scroll_step_remainder      fdb   0     ; accumulator pour sub-pixel
+```
+
+### États (`AutoScroll.equ`)
+
+```asm
+scroll_state_stop                 equ   0
+scroll_state_up                   equ   1
+scroll_state_down                 equ   2
+; (variantes horizontales possibles)
+```
+
+### Algorithme
+
+```asm
+AutoScroll
+        lda   glb_auto_scroll_state
+        beq   ATS_Return                ; stop → rien
+        ldd   glb_auto_scroll_frames
+        subd  #1
+        bmi   ATS_Stop                  ; plus de frames → arrêt
+        
+ATS_Up
+        std   glb_auto_scroll_frames
+        lda   glb_auto_scroll_state
+        deca
+        bne   ATS_Down                  ; pas Up → Down
+        
+        ldd   glb_auto_scroll_step_remainder
+        addd  glb_auto_scroll_step      ; ajoute la step au remainder
+        std   glb_auto_scroll_step_remainder
+        ldd   <glb_camera_y_pos
+        subd  glb_auto_scroll_step_remainder16bit
+        clr   glb_auto_scroll_step_remainder
+        cmpd  glb_camera_y_min
+        blt   ATS_Stop
+        std   <glb_camera_y_pos
+        rts
+        
+ATS_Down
+        ; ... symétrique pour Down ...
+```
+
+### Sub-pixel accumulator
+
+La step est 8.8 (msb = px entiers, lsb = sub-pixel). À chaque frame, on accumule dans `step_remainder`. Quand le total dépasse 1 pixel entier, on bouge la caméra.
+
+Exemple : step = `$0080` (0.5 px/frame). Après 2 frames, remainder = `$0100` (1 px). On bouge la caméra de 1 px et reset remainder.
+
+### Usage
+
+```asm
+        ; Programmer un scroll vers le bas sur 100 frames à 1.5 px/frame
+        lda   #scroll_state_down
+        sta   glb_auto_scroll_state
+        ldd   #100
+        std   glb_auto_scroll_frames
+        ldd   #$0180                    ; 1.5 px/frame
+        std   glb_auto_scroll_step
+        clr   glb_auto_scroll_step_remainder      ; reset remainder
+        clr   glb_auto_scroll_step_remainder+1
+
+        ; Dans MainLoop :
+        jsr   AutoScroll
+```
+
+À la fin des 100 frames (ou si la caméra atteint la borne), `AutoScroll` met `state = stop` automatiquement.
+
+## `CheckCameraMove`
+
+```asm
+CheckCameraMove
+        ldd   glb_camera_x_pos
+        cmpd  prev_glb_camera_x_pos
+        bne   @moved
+        ldd   glb_camera_y_pos
+        cmpd  prev_glb_camera_y_pos
+        beq   @same
+@moved
+        lda   #1
+        sta   <glb_camera_move
+        ; ... update prev values ...
+        rts
+@same
+        clr   <glb_camera_move
+        rts
+```
+
+Met `glb_camera_move = 1` si la caméra a bougé depuis la dernière frame, 0 sinon.
+
+Usage : trigger un refresh des sprites en coord playfield :
+```asm
+        jsr   CheckCameraMove
+        lda   <glb_camera_move
+        beq   @no_refresh
+        lda   #1
+        sta   <glb_force_sprite_refresh
+@no_refresh
+```
+
+Sans ça, les sprites peuvent rester à l'ancienne position visuellement.
+
+## Bornes de scroll
+
+```asm
+glb_camera_x_min_pos              ; (et y_min)
+glb_camera_x_max_pos              ; (et y_max)
+```
+
+À initialiser au début du game-mode :
+```asm
+        ldd   #0
+        std   glb_camera_x_min_pos
+        ldd   #map_width-160            ; scroll jusqu'à voir la dernière colonne
+        std   glb_camera_x_max_pos
+```
+
+`AutoScroll` consulte ces bornes pour arrêter le scroll automatiquement.
+
+`vscroll.move` consulte aussi (logique applicative).
+
+## Pattern goldorak — macros caméra
+
+goldorak factorise dans `global/global-macros.asm` :
+```asm
+_camera.set #pos                       ; macro pour positionner la caméra
+_camera.move #speed                    ; macro pour démarrer un AutoScroll
+```
+
+(macros locales au projet)
+
+## Pitfalls
+
+- **`glb_camera_x_offset` / `y_offset` non init** : sprites mal placés (sortie de `InitDrawSprites` cf. graphics-pipeline)
+- **`AutoScroll` sans `clr glb_auto_scroll_step_remainder`** : valeurs résiduelles du précédent scroll → comportement erratique
+- **`glb_camera_x_pos > glb_camera_x_max_pos`** : selon le contexte, peut continuer à scroller (illégalement) ou être bloqué
+- **Modifier `glb_camera_x_pos` manuellement pendant un AutoScroll** : conflit, valeurs override
+- **`CheckCameraMove` mais pas de `glb_force_sprite_refresh`** : sprites en coord playfield ne se redessinent pas
+- **Sub-pixel remainder pas reset entre scrolls** : précision de plus en plus mauvaise
+- **Mode 320×200 vs 160×200** : `glb_camera_width` et `glb_camera_x_offset` doivent matcher le mode

--- a/skills/thomson-to8-engine-scrolling/references/horizontal-scroll.md
+++ b/skills/thomson-to8-engine-scrolling/references/horizontal-scroll.md
@@ -1,0 +1,120 @@
+# Scrolling horizontal — `scroll-map-buffered*`
+
+Le scrolling horizontal de l'engine est utilisé exclusivement par r-type. Quatre variantes existent :
+
+| Fichier | Usage |
+|---------|-------|
+| `scroll-map-buffered.asm` | Version générique 8×16 tiles |
+| `scroll-map-buffered-even.asm` | Optimisée pour positions paires |
+| `scroll-map-buffered-odd.asm` | Optimisée pour positions impaires |
+| `scroll-map-buffered-16x16.asm` | Tiles 16×16 (au lieu de 8×16) |
+
+## Concept
+
+Comme `vscroll`, le scrolling horizontal fait :
+1. Une **map** de tile IDs
+2. Un **tileset** de bitmaps
+3. Des **buffers** double-buffer
+4. Une **caméra** qui glisse horizontalement
+
+Différence majeure : le scroll horizontal sur TO8/BM16 est **plus complexe** car les pixels sont organisés en plans (RAMA/RAMB) et l'écran fait 160 colonnes (= 40 octets en mode 4-pixel/octet).
+
+## Pattern r-type — usage
+
+Dans `r-type/game-mode/01/main.asm` :
+```asm
+        INCLUDE "./engine/graphics/tilemap/horizontal-scroll/scroll-map-buffered-even.asm"
+```
+
+L'inclusion expose les routines et variables nécessaires.
+
+## Choix even/odd/buffered
+
+Le choix entre `even`/`odd`/`buffered` (générique) dépend de la **position X du buffer** par rapport au pixel-shift courant :
+
+- **even** : optimisée quand la caméra est à une position paire (alignement pixel)
+- **odd** : optimisée pour positions impaires (décalage 1 pixel)
+- **buffered** : générique (gère les deux cas mais plus lent)
+
+L'engine peut switch automatiquement entre even et odd selon la parité de `glb_camera_x_pos`.
+
+## Variantes 8x16 vs 16x16
+
+- **8×16 tiles** : tiles plus petites, plus de variété par écran, mais map plus longue à stocker (plus de tiles à scroller)
+- **16×16 tiles** : tiles plus grandes, moins de variété, mais scroll plus efficient (moins de calculs par frame)
+
+## Pipeline d'assets
+
+Similaire à `vscroll`, mais avec une orientation horizontale :
+- Map : stockage en colonnes
+- Tileset : tiles 8×16 ou 16×16
+- Buffers : adapter aux dimensions et au mode pixel
+
+Outils (`6809-game-builder`) à utiliser avec les bons paramètres `-hs` (horizontal scroll) au lieu de `-vs`.
+
+## Setup typique (r-type level01)
+
+```asm
+        ; Setup objects
+        _MountObject ObjID_LevelInit
+        jsr   ,x                        ; init du niveau (charge map, tileset)
+
+        _MountObject ObjID_LevelWave
+        jsr   ,x                        ; init des vagues d'ennemis
+
+        ; Init scroll
+        jsr   InitScroll                ; routine custom du game-mode
+```
+
+`InitScroll` configure les variables internes du scroll horizontal (adresses map/tileset, buffers, position initiale).
+
+## MainLoop
+
+```asm
+MainLoop
+        jsr   ReadJoypads
+        jsr   RunObjects
+        ; ... collisions ...
+        jsr   CheckSpritesRefresh
+        _gfxlock.on
+        jsr   EraseSprites
+        ; (scroll horizontal s'intègre ici, mais via routines spécifiques r-type)
+        jsr   UnsetDisplayPriority
+        jsr   DrawSprites
+        _gfxlock.off
+        _gfxlock.loop
+        bra   MainLoop
+```
+
+## Intégration avec terrainCollision
+
+Le scrolling horizontal va souvent de pair avec `terrainCollision` (collisions avec les murs/sols qui défilent). Cf. skill `engine-collision/references/terrain-collision.md`.
+
+## Différences avec vscroll
+
+| Aspect | vscroll | horizontal-scroll |
+|--------|---------|-------------------|
+| Direction | Y | X |
+| Mode pixel | BM16 16x16 tiles | BM16 8x16 ou 16x16 |
+| Variantes | 256 vs 512 tiles | even/odd/buffered/16x16 |
+| Bénéfice maj | Speed-up vertical | Alignement pixel-shift |
+| Usage repo | bubble-bobble, goldorak | r-type |
+
+## Pitfalls
+
+- **Confondre even/odd selon la parité de la position** : impacte les performances mais pas la justesse fonctionnelle
+- **Mélanger 8×16 et 16×16** : crash de format
+- **Map mal alignée** : décalage visuel
+- **Tileset partiel** : tiles manquantes affichées en noir ou random
+- **Pas d'usage observé dans d'autres game-projects** : la documentation est moins complète. Pour les autres genres, préférer `vscroll` ou tilemap statique
+
+## Notes
+
+Le scrolling horizontal est moins documenté que `vscroll` dans le repo. Pour des détails sur les variantes, lire les fichiers `.asm` correspondants et consulter le code de r-type pour les patterns d'intégration.
+
+Pour des features comme :
+- Parallax (plusieurs couches de scroll)
+- Looping scroll (cyclique)
+- Scroll bidirectionnel
+
+— elles ne sont **pas standard** dans l'engine. À implémenter applicativement ou ajouter à l'engine.

--- a/skills/thomson-to8-engine-scrolling/references/vertical-scroll.md
+++ b/skills/thomson-to8-engine-scrolling/references/vertical-scroll.md
@@ -1,0 +1,282 @@
+# `vscroll` — scrolling vertical
+
+Le système `vscroll` permet un scrolling vertical fluide avec tileset (BM16, 160×200). Utilisé par bubble-bobble et goldorak.
+
+## Composants
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Map (objet levelMap) : grille 2D de tile IDs       │
+│  ex: 38 rows × 16 cols, chaque tile = 16x16 px      │
+│  Mode 256 tiles : 1 octet/id                        │
+│  Mode 512 tiles : 2 octets/id                       │
+└─────────────────────────────────────────────────────┘
+            │
+            ↓
+┌─────────────────────────────────────────────────────┐
+│  Tileset (objets levelTileA/B) : 256 ou 512 tiles  │
+│  Chaque tile = bitmap 16x16 (en code asm)           │
+└─────────────────────────────────────────────────────┘
+            │
+            ↓
+┌─────────────────────────────────────────────────────┐
+│  Buffer A et B (objets scrollA/scrollB)             │
+│  Double-buffer cyclique, contient le snapshot       │
+│  du viewport en cours d'affichage                   │
+└─────────────────────────────────────────────────────┘
+            │
+            ↓
+┌─────────────────────────────────────────────────────┐
+│  Écran (BM16, 160x200 visible)                      │
+│  La caméra y_pos pointe dans la map ; le viewport  │
+│  affiche les lignes [y_pos, y_pos + viewport_height]│
+└─────────────────────────────────────────────────────┘
+```
+
+## Setup
+
+```asm
+        ; 1. Map
+        _vscroll.setMap #ObjID_levelMap
+        _vscroll.setMapHeight #38*16    ; 608 pixels (38 rows × 16)
+        
+        ; 2. Tileset
+        _vscroll.setTileset256 ObjID_levelTileA0,ObjID_levelTileB0
+        _vscroll.setTileNb #61          ; 61 tiles uniques dans le tileset
+        
+        ; 3. Buffer
+        _vscroll.setBuffer #ObjID_scrollA,#ObjID_scrollB
+        
+        ; 4. Camera
+        _vscroll.setCameraPos #0        ; commence en haut
+        _vscroll.setCameraSpeed #$0100  ; 1 px/frame
+        _vscroll.setViewport #0,#200    ; tout l'écran visible
+```
+
+## Macros détaillées
+
+### `_vscroll.setMap` — pointer la map
+
+```asm
+_vscroll.setMap MACRO
+        ldb   \1                        ; ObjID_ de la map
+        ldx   #Obj_Index_Page
+        lda   b,x
+        sta   vscroll.obj.map.page      ; sauve la page
+        aslb
+        ldx   #Obj_Index_Address
+        ldx   b,x
+        stx   vscroll.obj.map.address   ; sauve l'adresse
+ ENDM
+```
+
+L'objet `levelMap` doit contenir la map sous forme binaire (cf. pipeline `stm2bin`).
+
+### `_vscroll.setMapHeight`
+
+```asm
+_vscroll.setMapHeight MACRO
+        ldd   \1
+        std   vscroll.map.height
+ ENDM
+```
+
+Total height en pixels. La caméra ne peut pas dépasser cette valeur (sinon wrap ou crash selon le mode).
+
+### `_vscroll.setTileset256` vs `_vscroll.setTileset512`
+
+256 tiles : tile id sur 1 octet → 256 tiles uniques max.
+512 tiles : tile id sur 2 octets → 512 tiles uniques (avec mode 12-bit, valeurs paires : 256 distincts en mémoire).
+
+Pour 256 :
+```asm
+_vscroll.setTileset256 MACRO
+ IFDEF vscroll.tiles.DEFINED
+        lda   #16                       ; 16 lignes par page
+        _vscroll.setUpdateRoutine_
+ ENDC
+        _vscroll.setTileset_
+        fcb   \1                        ; ObjID tile A
+        fcb   \2                        ; ObjID tile B
+        ; ... répété 8 fois ...
+ ENDM
+```
+
+Deux ObjIDs (`A` et `B`) car les tiles sont stockés sur 2 pages (par paires AB) pour économiser de la RAM.
+
+### `_vscroll.setTileNb`
+
+```asm
+        _vscroll.setTileNb #61
+```
+
+Nombre de tiles **uniques** dans le tileset (vs. la capacité max 256/512). Permet d'optimiser le traitement.
+
+### `_vscroll.setBuffer`
+
+```asm
+        _vscroll.setBuffer #ObjID_scrollA,#ObjID_scrollB
+```
+
+Deux objets buffer pour le double-buffer. Chaque buffer = snapshot du viewport courant.
+
+### `_vscroll.setCameraPos` / `_vscroll.setCameraSpeed`
+
+```asm
+        _vscroll.setCameraPos #0        ; commence à y=0
+        _vscroll.setCameraSpeed #$0100  ; 1.0 px/frame (8.8 fixed-point)
+```
+
+Vitesse en 8.8 :
+- `$0100` = 1.0 px/frame
+- `$0080` = 0.5 px/frame
+- `$0040` = 0.25 px/frame
+- `$0200` = 2.0 px/frame
+
+### `_vscroll.setViewport`
+
+```asm
+        _vscroll.setViewport #0,#200    ; y_min=0, y_max=200 (full screen)
+        _vscroll.setViewport #40,#160   ; viewport partiel (40-159)
+```
+
+Permet d'avoir un HUD au-dessus/en-dessous du scroll.
+
+## Boucle MainLoop avec vscroll
+
+```asm
+MainLoop
+        jsr   RunObjects                ; les ennemis bougent
+        ; ... collisions ...
+        jsr   CheckSpritesRefresh
+        _gfxlock.on
+        jsr   EraseSprites
+        jsr   vscroll.do                ; dessine la slice de map
+        jsr   vscroll.move              ; avance la caméra
+        jsr   UnsetDisplayPriority
+        jsr   DrawSprites
+        _gfxlock.off
+        _gfxlock.loop
+        bra   MainLoop
+```
+
+`vscroll.do` lit la map et écrit les tiles dans le buffer courant. `vscroll.move` met à jour `vscroll.camera.y` selon la speed.
+
+## Pattern `scroll.goUntil` (bubble-bobble)
+
+Pour faire un scroll programmé jusqu'à une position cible, sans logique gameplay pendant :
+
+```asm
+scroll.goUntil.pos fdb 0
+
+scroll.goUntil
+@loop
+        jsr   scroll.doOneLoop          ; 1 tour de scroll
+        ldd   scroll.goUntil.pos
+        subd  #10
+        cmpd  vscroll.camera.y
+        bhi   @loop                     ; tant qu'on n'est pas à 10px de la cible
+        
+        ; fine scroll (vitesse réduite)
+        _vscroll.setCameraSpeed #$0040
+@loop2
+        jsr   scroll.doOneLoop
+        ldd   scroll.goUntil.pos
+        subd  #1
+        cmpd  vscroll.camera.y
+        bhi   @loop2                    ; jusqu'à 1px de la cible
+        
+        ; stop
+        _vscroll.setCameraSpeed #0
+        jsr   scroll.doOneLoop
+        jsr   scroll.doOneLoop          ; 2 derniers tours pour finaliser
+        rts
+
+scroll.doOneLoop
+        jsr   ReadJoypads
+        jsr   RunObjects
+        lda   #1
+        sta   <glb_force_sprite_refresh ; force refresh tout
+        jsr   CheckSpritesRefresh
+        _gfxlock.on
+        jsr   EraseSprites
+        jsr   vscroll.do
+        jsr   vscroll.move
+        jsr   UnsetDisplayPriority
+        jsr   DrawSprites
+        _gfxlock.off
+        _gfxlock.loop
+        rts
+```
+
+Permet un scroll cinématique entre deux écrans, avec fade de vitesse à l'arrivée.
+
+## Pipeline d'assets
+
+### 1. Pro Motion → STM
+
+Export "all" en .stm (Stamp Map), tiles 16×16, 1 colonne par fichier image.
+
+### 2. STM → BIN (map)
+
+```bash
+stm2bin -f="level1.stm" -obd=12 -mul=2
+```
+
+Convertit en binaire 12-bit par tile id, valeurs paires. Header STM supprimé.
+
+### 3. PNG → BIN (buffers de départ)
+
+```bash
+png2bin -f level1.start.png -lb 4 -pb 8 -p 2 -pd 4 -vs -slc
+```
+
+Convertit l'image initiale en buffers de code+data au format vscroll.
+
+Paramètres :
+- `lb 4` : 4 bits par pixel dans un plan
+- `pb 8` : 8 bits par plan (1 octet)
+- `p 2` : 2 plans mémoire (parité)
+- `pd 4` : 4 bits par pixel total
+- `vs` : output for Vertical Scroll
+- `slc` : shift colors left by 1
+
+### 4. Format buffer
+
+Dans les objets `scrollA.properties` et `scrollB.properties` :
+```asm
+        INCLUDE "./engine/graphics/tilemap/vscroll/vscroll.macro.asm"
+@loop
+        INCLUDEBIN "./objects/scroll/level1/level1.start.0.0.bin.vscroll"
+        _vscroll.buffer.line            ; macro qui découpe par ligne
+        jmp   @loop                     ; cyclique
+```
+
+### 5. Tileset (512 tiles)
+
+L'image tileset doit faire 8192 pixels de haut (512 × 16). Outil `6809-game-builder` pour la conversion.
+
+## Variables internes
+
+```asm
+vscroll.camera.y                fdb 0       ; position Y caméra (16 bits)
+vscroll.obj.map.page            fcb 0       ; page mémoire de la map
+vscroll.obj.map.address         fdb 0       ; adresse de la map
+vscroll.map.height              fdb 0       ; hauteur en pixels
+vscroll.obj.tile.pages          fill 0,16   ; pages des tiles (selon mode)
+vscroll.tiles.dyncall           ; routines dynamiques pour update tiles
+vscroll.tiles.updateTilesForNLines.address  ; adresse routine update
+vscroll.tiles.nbLinesByPage     ; nb de lignes par page (16 ou 8)
+```
+
+## Pitfalls
+
+- **Map dépassant `vscroll.map.height`** : lecture aléatoire après la fin, glitches visuels
+- **Tileset mal aligné** : tiles déplacées, pas en grille
+- **`_vscroll.setTileset256` mais 257+ tiles dans le tileset** : tile 256+ inaccessible
+- **`_vscroll.setBuffer` sur des objets non chargés** : crash
+- **Speed = 0 mais on attend du scroll** : la caméra reste fixe (à vérifier que `_vscroll.setCameraSpeed` a été appelée)
+- **Speed > 8 px/frame** : sauts visibles, pas de scroll fluide
+- **Modifier `vscroll.camera.y` manuellement** : possible mais override `vscroll.move`. Préférer changer `cameraSpeed` puis remettre 0
+- **Génération assets avec mauvais paramètres `png2bin`** : format incompatible, plantage à l'INCLUDEBIN
+- **Buffer A et B inversés** : le double-buffer ne fait plus son boulot, tearing

--- a/skills/thomson-to8-engine-storage-and-loaders/SKILL.md
+++ b/skills/thomson-to8-engine-storage-and-loaders/SKILL.md
@@ -1,0 +1,371 @@
+---
+name: thomson-to8-engine-storage-and-loaders
+description: "Décrit le pipeline de stockage et chargement du Thomson TO8/TO9 game engine (Bento8/wide-dot) : trois cibles principales disquette .fd / cartouche T2 megarom .t2 / cartouche T2 flash SDDRIVE .t2flash, boot loaders boot-fd.asm (FD, animation palette fade vers couleur cible, init commutation page espace données, chargement Game Mode Engine en page 4, ORG $6200) et boot-t2.asm (T2, ORG $0000 avec header Megarom) et boot-t2-flash.asm (SDDRIVE), RAMLoaderManager Fd et T2 pour gérer le chargement des pages RAM, RAMLoader (zx0/ ou exo/) pour décompresser, mécanisme RLM_SkipCommon pour skip les pages communes entre game-modes (économie chargement), LoadGameMode / LoadGameModeNow pour basculer entre game-modes avec auto-load, variables GameMode / ChangeGameMode / glb_Cur_Game_Mode / glb_Next_Game_Mode, format des index Gm_Index pour résoudre game-mode → adresse, T2 flash via t2-flash.asm + megarom-t2/t2-test.asm avec multi-disques SDDRIVE (4 disquettes pour 128 pages, 4 pistes x 16 secteurs par page, pistes 16-79 face 0 + face 1), formats compression ZX0 (zx0_6809_mega / zx0_6809_mega_back / zx0_6809_standard / zx0_6809_turbo, compresseur Java) vs Exomizer (exomizer.asm + exobin tool), routines ClearDataMem / ClearCartMemory / ClearDataMemoryRAMx pour clear pages, knapsack packing par le builder Java pour optimiser le placement des pages RAM. Utiliser pour comprendre le boot du jeu, choisir entre fd/t2/t2flash, configurer LoadGameMode pour les transitions, optimiser le packing des pages, comprendre la compression ZX0 vs Exomizer, gérer une cartouche multi-disques SDDRIVE. Mots-clés : boot-fd, boot-t2, boot-t2-flash, RAMLoaderManager, RAMLoaderManagerFd, RAMLoaderManagerT2, RAMLoader, RAMLoaderFd, RAMLoaderT2, LoadGameMode, LoadGameModeNow, GameMode, ChangeGameMode, glb_Cur_Game_Mode, glb_Next_Game_Mode, Build_RAMLoaderManager, Gm_Index, RLM_SkipCommon, RLM_SetPage, RLM_CopyCode, .fd disquette, .t2 megarom, .t2flash SDDRIVE, zx0, zx0_6809_mega, zx0_6809_standard, zx0_6809_turbo, zx0_mega.asm, exomizer, exobin, megarom T.2, SDDRIVE, IFDEF T2, page 4 RAMLoaderManager, page 0 RAM, $0555, $02AA, Megarom commands, boot palette fade, boot_color_gr, boot_color_b, builder.diskName, builder.t2Name, dist directory, knapsack, ClearDataMem, ClearCartMemory, ClearDataMemoryRAMx."
+machines: [to8, to8d, to9, to9+]
+user-invocable: false
+---
+
+# Storage et loaders — Thomson TO8/TO9 Game Engine
+
+L'engine supporte **3 cibles de stockage** :
+
+| Cible | Format | Boot loader | RAM Loader | Capacité |
+|-------|--------|-------------|------------|----------|
+| Disquette | `.fd` | `boot-fd.asm` | `RAMLoaderFd.asm` | 320 Ko / disque, multi-disques |
+| Cartouche T2 | `.t2` | `boot-t2.asm` | `RAMLoaderT2.asm` | 2 Mo (128 pages × 16 Ko) |
+| Cartouche T2 Flash | `.t2flash` | `boot-t2-flash.asm` | (SDDRIVE) | Multi-Mo via carte SD |
+
+Ce skill couvre le pipeline complet : boot, chargement des pages, transitions de game-modes, compression.
+
+---
+
+## Boot loaders
+
+### `boot-fd.asm` — démarrage disquette
+
+```asm
+        org   $6200
+
+PalInit
+        setdp $62
+        lda   #$62
+        tfr   a,dp                      ; DP = $62
+
+        ; Animation palette fade vers couleur cible (boot_color_gr/b)
+        ; ...
+        
+        ; Init commutation page espace données
+        ; ...
+        
+        ; Chargement Game Mode Engine en page 4
+        ; via routine disque
+        
+        ; Appel du Game Mode Engine
+        jmp   $6100
+```
+
+Caractéristiques :
+- ORG `$6200` (laisse de la place pour le secteur de boot)
+- Animation palette pendant le chargement (boot fade)
+- Charge le premier game-mode en page 4
+- Saute à `$6100` (point d'entrée standard)
+
+### `boot-t2.asm` — démarrage cartouche T2
+
+```asm
+        org   $0000
+
+; Header Megarom T.2 (caractères "S T 2")
+        fcb   $20, $53, $54, $32, $20   ; " ST2 " header
+        ; ...
+```
+
+Cartouche T2 :
+- ORG `$0000` (zone cartouche)
+- Header Megarom obligatoire (signature)
+- Charge le game-mode initial depuis la cartouche
+- Jump à `$6100`
+
+### `boot-t2-flash.asm` — SDDRIVE cartouche flash
+
+Pour le hardware SDDRIVE de Daniel Coulom (multi-disques sur carte SD). Multi-disques :
+- 4 disquettes pour 128 pages
+- 4 pistes × 16 secteurs par page
+- Pistes 16-79 face 0 + face 1 (16 inutilisées)
+
+Plus complexe que T2 classique car gère le changement de disque dynamique.
+
+---
+
+## RAMLoaderManager
+
+Responsable du **chargement des pages RAM** depuis le storage.
+
+### `RAMLoaderManagerFd.asm`
+
+```asm
+        org $0000
+
+RAMLoaderManager
+        ; input : A = nouveau game-mode, B = game-mode courant
+        sts   RLM_CopyCode_restore_s+2
+        ldu   #Gm_Index
+        aslb
+        ldx   b,u                       ; adresse data du game-mode courant
+        asla
+        ldu   a,u                       ; adresse data du nouveau
+
+        lds   -2,u                      ; destination address
+        tstb
+        bmi   RLM_SetPage                ; -1 = premier load
+        
+RLM_SkipCommon
+        ; Compare les 7 premiers octets pour skipper les pages communes
+        ldd   ,u
+        cmpd  ,x
+        bne   RLM_SetPage
+        ; ... compare octets 2-7 ...
+        ; si tout pareil :
+        leas  -7,s
+        leau  7,u
+        leax  7,x
+        bra   RLM_SkipCommon
+        
+RLM_SetPage
+        ; ... charge la page depuis le disque/cartouche ...
+```
+
+### `RLM_SkipCommon` — optimisation
+
+Si le **game-mode courant** et le **nouveau** partagent des pages identiques (e.g. via `gameModeCommon`), le manager **skip** ces pages au chargement. Économie majeure de temps disque.
+
+Compare les 7 premiers octets de l'index pour détecter les pages communes (identique = déjà en RAM, pas besoin de recharger).
+
+C'est ce qui rend `gameModeCommon` si efficace (cf. skill new-game).
+
+### Gm_Index — table des game-modes
+
+Generated par le builder Java. Format :
+```asm
+Gm_Index
+        fdb  gm_TitleScreen_data        ; index 0 = TitleScreen
+        fdb  gm_level01_data            ; index 1 = level01
+        fdb  gm_level02_data            ; index 2 = level02
+        ; ...
+```
+
+Chaque adresse pointe vers une zone qui contient :
+- Adresse destination (où charger)
+- Liste des pages à charger (chacune sur 7 octets)
+- Marqueur de fin ($FF négatif)
+
+---
+
+## RAMLoader (compression)
+
+### Variantes
+
+```
+engine/ram/
+├── zx0/
+│   ├── RAMLoaderFd.asm           # ZX0 pour FD
+│   └── RAMLoaderT2.asm           # ZX0 pour T2
+└── exo/
+    ├── RAMLoaderFd.asm           # Exomizer pour FD
+    └── RAMLoaderT2.asm           # Exomizer pour T2
+```
+
+### ZX0 (recommandé)
+
+Compresseur moderne, bon ratio, décodeur rapide.
+
+```
+engine/compression/zx0/
+├── zx0_6809_mega.asm
+├── zx0_6809_mega_back.asm
+├── zx0_6809_standard.asm
+├── zx0_6809_turbo.asm
+└── LICENSE / README.md
+```
+
+4 variantes selon vitesse vs taille :
+- `standard` : équilibré
+- `turbo` : décode plus rapide, légèrement plus de mémoire
+- `mega` : optimisé pour gros blobs
+- `mega_back` : décode en arrière (utile pour certains layouts)
+
+Sélectionné via `engine.asm.RAMLoader.fd=../../engine/ram/zx0/RAMLoaderFd.asm` dans config-windows.properties.
+
+### Exomizer
+
+Alternative légèrement moins compact mais décodeur très rapide :
+
+```properties
+builder.exobin=../../tools/win/exomizer.exe
+engine.asm.RAMLoader.fd=../../engine/ram/exo/RAMLoaderFd.asm
+```
+
+Nécessite `exomizer.exe` (outil externe Windows). Pas dans le repo par défaut.
+
+### Choix
+
+| Critère | ZX0 | Exomizer |
+|---------|-----|----------|
+| Ratio compression | Excellent | Bon |
+| Vitesse décode | Très rapide | Très rapide |
+| Mémoire décodeur | ~256 octets | ~1 Ko |
+| Disponibilité | Inclus engine | Outil externe |
+| **Recommandation** | **Défaut** | Si besoin spécifique |
+
+---
+
+## `LoadGameMode` — transitions
+
+```asm
+GameMode           fcb   $00            ; game-mode à charger
+ChangeGameMode     fcb   $00            ; flag : 1 = changement demandé
+glb_Cur_Game_Mode  fcb   $00            ; en cours
+glb_Next_Game_Mode fcb   $00            ; prochain (info utile pour transitions)
+
+LoadGameMode
+        lda   ChangeGameMode
+        bne   LoadGameModeNow
+        rts                             ; pas de changement, no-op
+
+LoadGameModeNow
+ IFDEF T2
+        lda   #$80                      ; ROM page 0
+        _SetCartPageA
+        lda   GameMode
+        ldb   glb_Cur_Game_Mode
+        jmp   Build_RAMLoaderManager
+ ELSE
+        ldb   #$64                      ; page 4 = RAMLoaderManager
+        stb   $E7E6
+        lda   GameMode
+        ldb   glb_Cur_Game_Mode
+        jmp   >$0000
+ ENDC
+```
+
+### Pattern d'usage
+
+```asm
+        ; trigger : aller au level 2
+        lda   #GmID_level02
+        sta   GameMode
+        lda   #1
+        sta   ChangeGameMode
+
+        ; Dans MainLoop, après l'IRQ off et cleanup :
+        jsr   LoadGameMode               ; ne retourne pas si change effectif
+```
+
+`LoadGameModeNow` :
+1. Mount le RAMLoaderManager (page 4 en FD, ROM en T2)
+2. Saute dedans avec A=destination, B=source
+3. Le manager charge les pages nécessaires
+4. Saute au point d'entrée du nouveau game-mode ($6100)
+
+**Pas de retour** : c'est un saut, pas un appel.
+
+### Variables globales préservées
+
+Tu peux poser des variables persistantes dans `globals.X` (à $9E28 par exemple, cf. r-type) qui survivent à la transition. Le nouveau game-mode les lit.
+
+Exemple :
+```asm
+globals.nextGameMode     equ GLOBAL_VARIABLES+0
+globals.score            equ GLOBAL_VARIABLES+1
+globals.lives            equ GLOBAL_VARIABLES+3
+; ...
+```
+
+`globals.score` = 0 init dans le premier game-mode, puis incrémenté pendant le gameplay, conservé à travers les niveaux.
+
+---
+
+## Format du disque .fd
+
+Format Thomson standard :
+- 80 pistes × 16 secteurs × 256 octets = 320 Ko
+- Piste 0 : boot + RAMLoaderManager
+- Pistes 1-79 : pages RAM compressées
+
+Le builder Java place les pages selon un **knapsack packing** pour minimiser le nombre de pistes utilisées.
+
+## Format de la cartouche .t2
+
+Megarom T2 (par Prehisto) :
+- 128 pages × 16 Ko = 2 Mo
+- Page 0 : boot + RAMLoaderManager
+- Page 1+ : code (page commune) + données
+
+Commutation via séquence Megarom :
+```asm
+        ; séquence T2 (cf. SetCartPageA)
+        sta   >$0555    ; $F0 sortie commande
+        sta   >$0555    ; $AA
+        sta   >$02AA    ; $55
+        sta   >$0555    ; $C0
+        sta   >$0555    ; numéro de page
+```
+
+## Format .t2flash (SDDRIVE)
+
+Multi-fichier sur carte SD. 4 disquettes pour les 128 pages :
+- Disquette 1 : pistes 0-15 (boot) + pages 0-31
+- Disquette 2 : pages 32-63
+- Disquette 3 : pages 64-95
+- Disquette 4 : pages 96-127
+
+Changement de disquette automatique par le hardware SDDRIVE.
+
+## Routines de clear mémoire
+
+```asm
+ClearDataMem                            ; clear page courante en zone donnée ($A000-$DFFF)
+        ldx   #$0000
+        ; ... rempli avec une valeur ...
+
+ClearCartMemory                         ; clear zone cartouche ($0000-$3FFF)
+ClearDataMemoryRAMx                     ; clear une RAM page spécifique
+```
+
+Utilisées au boot ou aux transitions pour reset l'état.
+
+## Patterns observés
+
+### Game-mode unique (test, demo)
+
+```properties
+gameModeBoot=test
+gameMode.test=./game-mode/test/test.properties
+```
+
+Pas de LoadGameMode, le game-mode reste en boucle main.
+
+### Game-mode multi (jeu normal)
+
+```properties
+gameModeBoot=TitleScreen
+gameMode.TitleScreen=./game-mode/00/main.properties
+gameMode.level01=./game-mode/01/main.properties
+gameMode.level02=./game-mode/02/main.properties
+```
+
+Transitions via `LoadGameMode`.
+
+### Build multi-target
+
+```properties
+# config-windows.properties pour FD
+gameMode.level01=./game-mode/01/main.d7.properties
+
+# config-windows.t2.properties pour T2
+gameMode.level01=./game-mode/01/main.t2.properties
+```
+
+Variantes de game-mode par target.
+
+## Pitfalls
+
+- **`gameModeBoot` invalide** : crash au boot (pas de fallback)
+- **`LoadGameMode` sans `ChangeGameMode = 1`** : no-op silencieux
+- **Modifier `GameMode` sans `ChangeGameMode`** : ignoré
+- **Page T2 incorrecte** dans le bit 7 : crash au mount
+- **Mélange ZX0 et Exomizer** : un seul compresseur par projet (le RAMLoader doit matcher la compression utilisée)
+- **`RLM_SkipCommon` mal aligné** : pages communes pas détectées → recharge inutile
+- **`builder.to8.memoryExtension=N` mais > 16 pages** : crash au build
+- **Cartouche T2 sans header** : ne boot pas
+- **SDDRIVE non détectée** : t2flash inutilisable
+- **`LoadGameMode` pendant IRQ** : crash (l'IRQ peut être appelée pendant la transition)
+
+---
+
+## Références détaillées
+
+- [references/boot-loaders.md](references/boot-loaders.md) — boot-fd.asm / boot-t2.asm / boot-t2-flash.asm détaillés : palette fade au démarrage, init commutation page, header Megarom T2, pin layout SDDRIVE, ORG, premier chargement
+- [references/ram-loader-manager.md](references/ram-loader-manager.md) — RAMLoaderManagerFd / RAMLoaderManagerT2, Gm_Index format, RLM_SkipCommon optimization, RLM_SetPage, RLM_CopyCode, transition entre game-modes, économie via gameModeCommon
+- [references/compression-zx0-exo.md](references/compression-zx0-exo.md) — Compression ZX0 (variantes standard/turbo/mega/mega_back, performance et trade-offs) vs Exomizer (exomizer.exe externe), choix selon le projet, intégration avec RAMLoader, ratio typique
+- [references/load-game-mode.md](references/load-game-mode.md) — LoadGameMode / LoadGameModeNow détails, variables GameMode / ChangeGameMode / glb_Cur_Game_Mode / glb_Next_Game_Mode, transition vs reset, variables globales persistantes (globals.X), patterns d'usage (intro→game→game over→retry)

--- a/skills/thomson-to8-engine-tilemap/SKILL.md
+++ b/skills/thomson-to8-engine-tilemap/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: thomson-to8-engine-tilemap
+description: "Décrit le système de tilemap statique (non-scrolling) du Thomson TO8/TO9 game engine (Bento8/wide-dot) : routine DrawTilemap pour afficher un layer de tiles à partir d'un submap (structure submap_x_pos / submap_y_pos / submap_camera_x_min/x_max/y_min/y_max / submap_layers), structure de layer (layer_parallax_X / parallax_Y / vp_offset / vp_tiles_x / vp_tiles_y / vp_x_size / vp_y_size / mem_step_x / mem_step_y / tile_size_bitmask_x / tile_size_divider_x / tiles_location / width / height) pour layers parallaxés, Tilemap16bits pour maps avec 64x128 tiles et chunks 8x8 (layer_map / layer_chunk0 / layer_chunk1 / layer_tiles / layer_mul_ref), TilemapBuffer pour buffer cyclique 2 Ko 32x16 tiles, Spritemap pour allocation dynamique de sprites depuis une map (spmap_x_pos / spmap_y_pos / spmap_vp_tiles_x / spmap_tile_size_bitmask_x / spmap_tile_size_divider_x / spmap_nb_tiles_x / spmap_map, variables glb_spritemap_obj / glb_spritemap_addr / glb_spritemap_page / glb_spritemap_index / spritemap_cur_index / spritemap_cur_index_end), TileAnimScript pour animer des tiles à partir d'un script déclaratif (ZACurIndex / ZACurFrame / ZADuration / ZAMaxFrame / ZASize, TileAnimScriptInit, TileAnimScriptList, integration avec gfxlock.frameDrop.count), bm4.drawChunbks pour rendu chunks BM4, types de data (layer.equ, submap.equ, map-16bits.equ, spritemap.equ), tilesets via tileset.X property dans object .properties (CENTER, TOP_LEFT, TILE8x16, TILE16x16, mapFile, mapBitDepth). Utiliser pour afficher un fond statique tilé (non-scrolling), gérer des layers avec parallax (8-bit decimal pour la vitesse de parallax), animer des tiles (eau, feu, plantes), allouer dynamiquement des sprites depuis une map (avec scroll), créer des chunks 8x8 tiles pour économiser la RAM map. Mots-clés : DrawTilemap, Tilemap, Tilemaps, Tilemap16bits, Spritemap, TileAnimScript, TileAnimScriptInit, TileAnimScriptList, TileAnimScriptData, TilemapBuffer, glb_submap, glb_submap_page, glb_submap_index, glb_submap_index_buf0, glb_submap_index_buf1, glb_submap_index_inactive, glb_spritemap_obj, glb_spritemap_addr, glb_spritemap_page, glb_spritemap_index, glb_spritemap_index_old, spritemap_cur_index, spritemap_cur_index_end, spritemap_cur_index_old, glb_map_pge, glb_map_adr, glb_map_chunk_pge, glb_map_chunk_adr, glb_map_defchunk0_pge, glb_map_defchunk0_adr, glb_map_tiles_pge, glb_map_tiles_adr, glb_map_width, layer_parallax_X, layer_parallax_Y, layer_vp_offset, layer_vp_tiles_x, layer_vp_tiles_y, layer_vp_x_size, layer_vp_y_size, layer_mem_step_x, layer_mem_step_y, layer_tile_size_bitmask_x, layer_tile_size_bitmask_y, layer_tile_size_divider_x, layer_tile_size_divider_y, layer_tiles_location, layer_width, layer_height, layer.equ, submap.equ, map-16bits.equ, spritemap.equ, submap_x_pos, submap_y_pos, submap_camera_x_min, submap_layers, layer_map, layer_chunk0, layer_chunk1, layer_tiles, layer_mul_ref, layer_map_width, layer_map_height, spmap_x_pos, spmap_vp_tiles_x, spmap_tile_size_bitmask_x, spmap_tile_size_divider_x, spmap_map, ZACurIndex, ZACurFrame, ZADuration, ZAMaxFrame, ZASize, tileset.X, CENTER, TOP_LEFT, TILE8x16, TILE16x16, mapFile, mapBitDepth, bm4.drawChunbks, chunk 8x8, chunks de tiles, parallax."
+machines: [to8, to8d, to9, to9+]
+user-invocable: false
+---
+
+# Tilemap statique — Thomson TO8/TO9 Game Engine
+
+L'engine fournit plusieurs systèmes de **tilemap** (affichage de fonds basés sur tiles) :
+
+1. **`Tilemap`** — tilemap statique multi-layers avec parallax
+2. **`Tilemap16bits`** — variante avec maps 64×128 tiles, chunks 8×8
+3. **`TilemapBuffer`** — buffer cyclique 2 Ko pour streaming (wide-dot)
+4. **`Spritemap`** — allocation dynamique de sprites depuis une map
+5. **`TileAnimScript`** — animation déclarative de tiles
+
+Ce skill couvre les structures de données, les routines de rendu, et les patterns d'usage.
+
+Pour le **scrolling** vertical/horizontal, voir le skill `engine-scrolling`.
+
+---
+
+## `Tilemap` — fond statique multi-layers
+
+### Variables globales
+
+```asm
+glb_submap                fdb   0       ; adresse du submap data structure
+glb_submap_page           fcb   0       ; page mémoire du submap
+glb_submap_index          fdb   0       ; index dans la map qui matche la caméra
+glb_submap_index_buf0     fdb   $FFFF   ; index actuel pour buffer 0
+glb_submap_index_buf1     fdb   $FFFF   ; index actuel pour buffer 1
+glb_submap_index_inactive equ   $FFFF   ; force background refresh
+```
+
+`buf0`/`buf1` séparés pour gérer le double-buffer (chaque buffer a son propre snapshot).
+
+### Routine `DrawTilemap`
+
+```asm
+DrawTilemap
+        lda   glb_submap_page
+        ldx   glb_submap
+        _SetCartPageA
+        
+        ; Parcours des layers du submap
+        ldu   submap_layers,x
+        
+        ; Conversion caméra → index map (avec tile_size_divider pour vitesse)
+        leay  layer_tilemap,u
+        ; ... arithmétique avec parallax ...
+        
+        ; Affichage des tiles
+```
+
+Le rendu dépend des champs du **layer** (parallax, mem_step, tile_size_divider).
+
+### Structure du submap (`submap.equ`)
+
+```asm
+submap_x_pos        equ   0     ; position dans la map globale (px)
+submap_y_pos        equ   2
+submap_camera_x_min equ   4     ; bornes de scroll
+submap_camera_y_min equ   6
+submap_camera_x_max equ   8
+submap_camera_y_max equ   10
+submap_layers       equ   12    ; table d'adresses de layers
+```
+
+Un submap peut contenir **plusieurs layers** (par exemple : sol + objets + ciel). Chaque layer a sa propre parallax.
+
+### Structure d'un layer (`layer.equ`)
+
+```asm
+layer_parallax_X          equ   0     ; vitesse parallax X en 8 bits décimal (n/256)
+layer_parallax_Y          equ   1     ; $FF = 1px/cam-px, $00 = fixed, $80 = 0.5
+layer_vp_offset           equ   2     ; offset viewport (col*4 + row*40 octets)
+layer_vp_tiles_x          equ   4     ; nb tiles en viewport rows
+layer_vp_tiles_y          equ   5
+layer_vp_x_size           equ   6     ; viewport X en pixels
+layer_vp_y_size           equ   8
+layer_mem_step_x          equ   10    ; octets entre 2 tiles d'une colonne
+layer_mem_step_y          equ   11    ; octets entre 2 lignes
+layer_tile_size_bitmask_x equ   13    ; mask pour sous-tile X (4px=2, 8px=3, 16px=4, 32px=5)
+layer_tile_size_bitmask_y equ   14
+layer_tile_size_divider_x equ   15    ; pour div rapide (4px=14, 8px=12, 16px=10)
+layer_tile_size_divider_y equ   16
+layer_tiles_location      equ   17    ; index tiles (page + adresse)
+layer_width               equ   19    ; tiles en rows
+layer_height              equ   20    ; tiles en cols
+```
+
+### Parallax
+
+```
+layer_parallax_X = $FF → 1 px de scroll par px caméra (au plus proche)
+layer_parallax_X = $80 → 0.5 px par px caméra (couche intermédiaire)
+layer_parallax_X = $20 → 0.125 px par px caméra (couche lointaine, ciel)
+layer_parallax_X = $00 → fixed (HUD-like)
+```
+
+Plusieurs layers avec des parallax différentes donnent l'illusion de profondeur (couches).
+
+Voir [references/tilemap-types.md](references/tilemap-types.md).
+
+---
+
+## `Tilemap16bits` — chunks pour économiser
+
+Variante pour maps **64×128 tiles** (= 8192 tiles, trop pour 1 octet/tile). Utilise des **chunks 8×8** comme niveau intermédiaire :
+
+```
+Map (64×128 tiles) ──[chunk id 1 octet]──→ Chunk (8×8 tiles) ──[tile id 1 octet]──→ Tile bitmap
+```
+
+Total : 64 × 128 = 8192 entrées dans la map, mais une carte de 1 octet/entrée fait 8 Ko. Avec chunks :
+- 64 × 128 / (8 × 8) = 128 chunks dans la map
+- Chaque chunk = 8 × 8 = 64 octets de tile IDs
+- Tile bitmaps : 256 max
+
+Économie : 1 Ko de map + 8 Ko de chunks + tiles vs 8 Ko de map directe + tiles.
+
+Structure (`map-16bits.equ`) :
+```asm
+submap_camera_x_min equ   0
+submap_camera_y_min equ   2
+submap_camera_x_max equ   4
+submap_camera_y_max equ   6
+layer_map_width     equ   8
+layer_map_height    equ   9
+layer_map           equ   10    ; w → [b] : map des chunk IDs (1 byte each)
+layer_chunk0        equ   12    ; w → [w] : chunks 0-127
+layer_chunk1        equ   14    ; w → [w] : chunks 128-255
+layer_tiles         equ   16    ; w → [bw] : tile index (3 bytes : page + addr)
+layer_mul_ref       equ   18    ; w : table pré-calculée pour Y dans map
+```
+
+Utilisé par sonic-2.
+
+---
+
+## `TilemapBuffer` — buffer cyclique
+
+Buffer 2 Ko (32×16 tiles de 16×16 px) pour streaming. Permet d'afficher une zone plus grande que l'écran en cyclant le buffer.
+
+Variables :
+```asm
+glb_map_pge             fcb   0
+glb_map_adr             fdb   0
+glb_map_chunk_pge       fcb   0     ; chunks
+glb_map_chunk_adr       fdb   0
+glb_map_defchunk0_pge   fcb   0     ; tile bitmaps
+glb_map_defchunk0_adr   fdb   0
+glb_map_defchunk1_pge   fcb   0
+glb_map_defchunk1_adr   fdb   0
+glb_map_tiles_pge       fcb   0
+glb_map_tiles_adr       fdb   0
+glb_map_width           fcb   0
+```
+
+Utilisé par wide-dot-engine (cf. skill `thomson-to8-to9-video/references/wide-dot-engine.md` dans gen-ai).
+
+---
+
+## `Spritemap` — sprites dynamiques depuis une map
+
+Permet de spawner des objets depuis une map (chaque entrée map = ObjID à spawn à cette position).
+
+Variables :
+```asm
+glb_spritemap_obj             fdb   0
+glb_spritemap_addr            fdb   0
+glb_spritemap_page            fcb   0
+glb_spritemap_index           fdb   0
+glb_spritemap_index_old       fdb   0
+spritemap_cur_index_end       fdb   0
+spritemap_cur_index           fdb   0
+```
+
+Structure (`spritemap.equ`) :
+```asm
+spmap_x_pos               equ   0
+spmap_y_pos               equ   2
+spmap_vp_tiles_x          equ   4
+spmap_tile_size_bitmask_x equ   6
+spmap_tile_size_divider_x equ   7
+smpap_tile_x_size         equ   8
+spmap_nb_tiles_x          equ   9
+spmap_map                 equ   10    ; map de ObjID + position
+```
+
+Algorithme : à chaque frame, calcule la zone visible (basée caméra) et alloue les objets dont la position tombe dans la zone.
+
+---
+
+## `TileAnimScript` — animation de tiles
+
+Anime des tiles via un script déclaratif (eau, feu, plantes mouvantes).
+
+Variables par animation script :
+```asm
+ZACurIndex equ   0       ; index courant dans le script
+ZACurFrame equ   1       ; frame courante de l'animation
+ZADuration equ   2       ; durée restante (frames 20ms)
+ZAMaxFrame equ   3       ; nb frames max
+ZASize     equ   4
+
+TileAnimScriptData       fill 0, 16*ZASize   ; jusqu'à 16 animations simultanées
+```
+
+### Init
+
+```asm
+        ldx   #my_anim_list
+        jsr   TileAnimScriptInit
+```
+
+`my_anim_list` est une suite de pointeurs vers les scripts d'animation, terminée par 0.
+
+### Tick
+
+```asm
+TileAnimScript
+        ldx   #0                        ; (dynamic = TileAnimScriptList)
+        ; Pour chaque script :
+        ;   Décrémenter ZADuration
+        ;   Si écoulé, charger frame suivante
+        ;   ...
+```
+
+Appelée chaque frame (typiquement depuis MainLoop ou IRQ).
+
+Synchro framerate via `gfxlock.frameDrop.count`.
+
+Voir [references/tile-anim-script.md](references/tile-anim-script.md).
+
+---
+
+## `tileset.X` property — pipeline
+
+Dans le `.properties` d'un objet, on peut déclarer un tileset :
+
+```properties
+tileset.TileSet_levelA=./objects/scroll/tileset.png;61,8,8,TILE16x16
+```
+
+Format :
+```
+tileset.<Nom>=<fichier>;<nbTiles>,<nbCols>,<nbRows>[,<centerMode>[,<mapFile>[,<mapBitDepth>]]]
+```
+
+| Champ | Valeurs |
+|-------|---------|
+| `nbTiles` | nb total |
+| `nbCols`/`nbRows` | grille |
+| `centerMode` | `CENTER`/`TOP_LEFT`/`TILE8x16`/`TILE16x16` (par défaut `TOP_LEFT`) |
+| `mapFile` | chemin map binaire (optionnel) |
+| `mapBitDepth` | profondeur bit des IDs (défaut 8) |
+
+Tilesets sont **toujours en RAM** (`tileset.inRAM = true` hardcodé pour vitesse).
+
+---
+
+## Choix entre les systèmes
+
+| Genre | Système recommandé |
+|-------|--------------------|
+| Fond statique HUD-like | Pas besoin de tilemap, `DrawFullscreenImage` |
+| Fond statique large (4-direction) | `Tilemap` ou `Tilemap16bits` |
+| Fond avec layers parallax | `Tilemap` multi-layers |
+| Sprites spawnés dynamiquement depuis map | `Spritemap` |
+| Tiles animées (eau, feu) | `TileAnimScript` + tilemap |
+| Vertical scrolling | `vscroll` (skill scrolling) |
+| Horizontal scrolling | `horizontal-scroll` (skill scrolling) |
+| Wide-dot avec streaming | `TilemapBuffer` |
+
+---
+
+## Pitfalls
+
+- **Submap dépassant la taille déclarée** : crash ou affichage random
+- **Layer parallax_X = 0** mais layer attendu fixe : OK, mais ne pas oublier `parallax_Y` aussi
+- **Tile size bitmask incompatible avec divider** : maths cassées, mauvaise position des tiles
+- **`Tilemap16bits` mais chunks pas définis** : crash (page 0 mountée)
+- **`TileAnimScript` non initialisée** : `TileAnimScriptList = 0` → routine skipée silencieusement
+- **`Spritemap` mais pool d'objets plein** : objets manqués silencieusement
+- **`mapBitDepth` incorrect** : tile IDs décodés en mauvaise valeur
+- **Tilesets pas en RAM** : impossibilité (toujours RAM par engine)
+
+---
+
+## Références détaillées
+
+- [references/tilemap-types.md](references/tilemap-types.md) — `Tilemap` détaillé : structure submap, layers, parallax 8-bit décimal, tile_size_bitmask/divider pour div rapide, `glb_submap_index_buf0/1` pour double buffer, viewport offset, `DrawTilemap` algorithme. `Tilemap16bits` avec chunks 8×8 : pourquoi, économie mémoire, structure
+- [references/tile-anim-script.md](references/tile-anim-script.md) — `TileAnimScript` complet : format binaire d'un script (frame duration / nb frames / tiles list), `TileAnimScriptInit` parcours de la liste, `TileAnimScriptData` (16 slots), sync framerate via `gfxlock.frameDrop.count`, patterns water/fire/plant
+- [references/spritemap.md](references/spritemap.md) — `Spritemap` allocation dynamique : structure spmap, conversion caméra → index, `LoadObject_u` automatique pour chaque entrée visible, `spritemap_cur_index*` pour tracker la zone visible vs précédente, pattern avec scroll
+- [references/tileset-pipeline.md](references/tileset-pipeline.md) — Pipeline du builder Java pour `tileset.X` : parsing des paramètres (nbTiles, cols, rows, centerMode, mapFile), génération du code asm tile par tile, modes CENTER/TOP_LEFT/TILE8x16/TILE16x16, restriction inRAM hardcoded, intégration avec `Tilemap`/`Tilemap16bits`

--- a/skills/thomson-to8-engine-tilemap/references/tile-anim-script.md
+++ b/skills/thomson-to8-engine-tilemap/references/tile-anim-script.md
@@ -1,0 +1,191 @@
+# `TileAnimScript` — animation de tiles
+
+Permet d'animer des tiles dans une tilemap (eau qui bouge, feu, plantes oscillantes) via un **script déclaratif**. Jusqu'à 16 animations simultanées.
+
+## Variables
+
+```asm
+ZACurIndex equ   0       ; offset 0 : index courant dans le script
+ZACurFrame equ   1       ; offset 1 : frame courante de l'animation
+ZADuration equ   2       ; offset 2 : durée restante (frames 20ms)
+ZAMaxFrame equ   3       ; offset 3 : nb frames max
+ZASize     equ   4       ; taille struct = 4 octets
+
+TileAnimScriptData
+        fill  0,16*ZASize ; jusqu'à 16 animations
+```
+
+## Initialisation — `TileAnimScriptInit`
+
+```asm
+        ldx   #my_animation_list
+        jsr   TileAnimScriptInit
+```
+
+`my_animation_list` est une suite de pointeurs vers les scripts d'animation (chacun pointant vers un format de données spécifique), terminée par 0 :
+
+```asm
+my_animation_list
+        fdb   anim_water
+        fdb   anim_fire
+        fdb   anim_plant
+        fdb   0                         ; fin
+```
+
+`TileAnimScriptInit` :
+```asm
+TileAnimScriptInit
+        stx   TileAnimScriptList        ; sauve la liste pour TileAnimScript
+        ldu   #TileAnimScriptData
+@loop   ldy   ,x++                      ; lit pointeur vers script
+        beq   @rts
+        ldd   ,y                        ; lit 1er octet (duration globale ?)
+        bpl   @globalduration
+        ; ... global duration ou per-frame duration ...
+        stb   ZAMaxFrame,u
+        ldd   2,y
+        incb
+        std   ZACurFrame,u
+        bra   @common
+@globalduration
+        inca
+        std   ZADuration,u
+        lda   2,y
+        sta   ZACurFrame,u
+@common
+        clr   ZACurIndex,u
+        leau  ZASize,u                  ; passe à l'entrée suivante dans Data
+        bra   @loop
+@rts    rts
+```
+
+Chaque script peut avoir :
+- Une **duration globale** (toutes les frames même duration) — flag négatif au début
+- Des durations **par frame** — flag positif
+
+## Format binaire d'un script
+
+### Avec duration globale (legacy)
+
+```
+@anim_water
+        fcb   $05                      ; positive = duration globale = 5 frames
+        fcb   4                        ; nb frames = 4
+        ; ... (peut-être données complémentaires)
+```
+
+### Avec duration par frame
+
+```
+@anim_fire
+        fcb   $80, 4                   ; négative = per-frame mode, nb frames = 4
+        fdb   tile_fire_001            ; frame 0
+        fdb   tile_fire_002            ; frame 1
+        ; ...
+```
+
+(format à vérifier dans le code engine pour le détail exact)
+
+## Tick — `TileAnimScript`
+
+```asm
+TileAnimScript
+        ldx   #0                        ; (dynamic = TileAnimScriptList)
+TileAnimScriptList equ *-2
+        beq   @rts                      ; pas de liste init → rien
+        ldu   #TileAnimScriptData
+@loop   ldy   ,x++
+        beq   @rts                      ; fin de liste
+        
+        lda   ZADuration,u
+        suba  gfxlock.frameDrop.count   ; sync framerate
+        bcs   @loadScript
+        sta   ZADuration,u
+        leau  ZASize,u
+        bra   @loop
+        
+@loadScript
+        sta   @delta                    ; report frames sautées
+        lda   ZACurIndex,u
+        inca
+        cmpa  ZAMaxFrame,u
+        bne   @a
+        lda   #0                        ; reset
+@a      sta   ZACurIndex,u
+        ; ... mettre à jour le tile bitmap ...
+        leau  ZASize,u
+        bra   @loop
+```
+
+Boucle sur les 16 slots possibles. Pour chacun :
+1. Décrémente `ZADuration` selon `frameDrop.count` (sync)
+2. Si écoulé, avance `ZACurIndex` (frame suivante)
+3. Met à jour le bitmap du tile correspondant
+
+## Quand appeler
+
+```asm
+MainLoop
+        jsr   RunObjects
+        jsr   TileAnimScript            ; tick animations de tiles
+        jsr   CheckSpritesRefresh
+        ; ...
+```
+
+Appelée chaque frame. Sync via `gfxlock.frameDrop.count` (donc adaptive).
+
+## Cas d'usage
+
+### Eau qui bouge (4 frames)
+
+```asm
+anim_water
+        fcb   $05, 4                    ; 5 frames per image, 4 images
+        fdb   tile_water_001            ; ondulation 1
+        fdb   tile_water_002
+        fdb   tile_water_003
+        fdb   tile_water_004
+```
+
+### Feu (looping)
+
+```asm
+anim_fire
+        fcb   $03, 4                    ; 3 frames per image, 4 images
+        fdb   tile_fire_001
+        fdb   tile_fire_002
+        fdb   tile_fire_003
+        fdb   tile_fire_002             ; ping-pong via duplicate
+```
+
+### Plante oscillante (slow)
+
+```asm
+anim_plant
+        fcb   $10, 2                    ; 16 frames per image, 2 images
+        fdb   tile_plant_norm
+        fdb   tile_plant_tilted
+```
+
+## Intégration avec `Tilemap`
+
+Le tile animé est référencé par la map normalement. Quand `TileAnimScript` change le bitmap pointé par le tile_id, **toutes les occurrences** du tile sont automatiquement mises à jour visuellement à la prochaine `DrawTilemap`.
+
+Pratique : pas besoin de modifier la map elle-même, juste le pointeur de bitmap.
+
+## Limites
+
+- **16 animations** simultanées max (taille du buffer `TileAnimScriptData`)
+- **1 octet pour ZADuration** : max 127 frames (~2.5s) entre changements
+- **1 octet pour ZAMaxFrame** : max 256 frames par animation
+- Synchro framerate via `gfxlock.frameDrop.count` (donc nécessite gfxlock)
+
+## Pitfalls
+
+- **Liste non terminée par 0** : `TileAnimScript` lit après la fin → boucle infinie / crash
+- **Plus de 16 animations** : seules les 16 premières sont prises (silencieux)
+- **`TileAnimScriptInit` non appelé** : `TileAnimScriptList = 0`, routine skipée silencieusement
+- **Modifier `TileAnimScriptData` à la main** : risque de corruption (préférer réinitialiser via Init)
+- **`gfxlock.frameDrop.count = 0`** (pas de gfxlock) : animation figée
+- **Sync avec changement de game-mode** : `TileAnimScriptData` partagé, à reset au boot
+- **Anim sans pointeurs valides** : tiles affichés au pointeur 0 (image noire ou random)

--- a/skills/thomson-to8-engine-tilemap/references/tilemap-types.md
+++ b/skills/thomson-to8-engine-tilemap/references/tilemap-types.md
@@ -1,0 +1,211 @@
+# `Tilemap` et `Tilemap16bits` — détails
+
+## `Tilemap` — multi-layers avec parallax
+
+### Structure submap (`submap.equ`)
+
+```asm
+submap_x_pos        equ   0    ; w - position dans la map globale (incl. caméra border)
+submap_y_pos        equ   2
+submap_camera_x_min equ   4    ; bornes scroll
+submap_camera_y_min equ   6
+submap_camera_x_max equ   8
+submap_camera_y_max equ   10
+submap_layers       equ   12   ; table d'adresses de layers
+```
+
+Un submap = une « zone » de la map globale (typiquement plus grande que l'écran), avec ses propres bornes de scroll. Le `submap_layers` pointe vers une suite d'adresses de layers (chaque layer indépendant).
+
+### Structure layer (`layer.equ`)
+
+```asm
+layer_parallax_X          equ   0     ; 8-bit decimal (n/256) vitesse parallax X
+layer_parallax_Y          equ   1
+layer_vp_offset           equ   2     ; offset viewport (col*4 + row*40 octets)
+layer_vp_tiles_x          equ   4     ; nb tiles visible en X
+layer_vp_tiles_y          equ   5
+layer_vp_x_size           equ   6     ; viewport X en pixels
+layer_vp_y_size           equ   8
+layer_mem_step_x          equ   10    ; octets entre 2 tiles d'une colonne
+layer_mem_step_y          equ   11    ; octets entre lignes
+layer_tile_size_bitmask_x equ   13    ; mask sous-tile X (4px=2, 8=3, 16=4)
+layer_tile_size_bitmask_y equ   14
+layer_tile_size_divider_x equ   15    ; nb bytes à brancher pour div rapide
+layer_tile_size_divider_y equ   16
+layer_tiles_location      equ   17    ; index tiles (page + adresse)
+layer_width               equ   19    ; tiles en rows
+layer_height              equ   20    ; tiles en cols
+```
+
+### Parallax — 8-bit decimal
+
+```
+parallax_X = $FF (255)  → 0.996 px / px caméra  ≈ 1:1 (sol/foreground)
+parallax_X = $C0 (192)  → 0.75 px / px caméra   (couche intermédiaire)
+parallax_X = $80 (128)  → 0.5 px / px caméra    (montagnes lointaines)
+parallax_X = $40 (64)   → 0.25 px / px caméra   (ciel lointain)
+parallax_X = $20 (32)   → 0.125 px / px caméra  (étoiles très lointaines)
+parallax_X = $00        → fixed                 (HUD, ne bouge pas)
+```
+
+Combine plusieurs layers (3-5 typiquement) pour un effet de profondeur convaincant.
+
+### `tile_size_bitmask` et `_divider`
+
+Pour calculer rapidement `position / tile_size` (division pour trouver l'index de tile), au lieu d'une vraie division, l'engine utilise un **bitmask** et un **branch** :
+
+```asm
+        ldd   <glb_camera_x_pos
+        subd  submap_x_pos,x
+@dynb1  bra   *+2                       ; (modifié à init avec layer_tile_size_divider_x)
+        _lsrd                           ; lsrd répété N fois
+        _lsrd
+        ; ...
+```
+
+Le `bra` est patché à init pour brancher en sautant N `_lsrd` selon la taille de tile :
+- 4 px tile → 14 octets (brancher tous les `_lsrd`)
+- 8 px → 12 octets
+- 16 px → 10 octets
+- 32 px → 8 octets
+- 256 px → 2 octets (ne saute rien)
+
+Économie : pas de boucle, pas de division, juste un branch + un nombre fixe de shifts.
+
+### `DrawTilemap` algorithme
+
+```asm
+DrawTilemap
+        lda   glb_submap_page
+        ldx   glb_submap
+        _SetCartPageA                   ; mount page du submap
+        
+        ldu   submap_layers,x           ; premier layer
+        
+        leay  layer_tilemap,u
+        sty   @dyn2+1                   ; modif l'adresse dans la routine
+        ldb   layer_tile_size_divider_x,u
+        stb   @dynb1+1                  ; modif le branch divider
+        ldd   <glb_camera_x_pos
+        subd  submap_x_pos,x            ; relatif à submap
+@dynb1  bra   *+2                       ; (patched)
+        _lsrd                           ; divide par tile_size
+        _lsrd
+        ; ...
+```
+
+`glb_submap_index` retourné, indexe dans la map.
+
+Pour le double-buffer :
+- `glb_submap_index_buf0` = ce qui est affiché sur buffer 0
+- `glb_submap_index_buf1` = idem buffer 1
+
+Si `glb_submap_index_buf0 != glb_submap_index`, redessine.
+
+### Setup du game-mode
+
+```asm
+        ; Charger le submap
+        ldd   #my_submap_addr
+        std   glb_submap
+        lda   #my_submap_page
+        sta   glb_submap_page
+        
+        ; Force refresh des deux buffers
+        ldd   #glb_submap_index_inactive
+        std   glb_submap_index_buf0
+        std   glb_submap_index_buf1
+        
+        ; Caméra
+        ldd   #initial_camera_x
+        std   <glb_camera_x_pos
+        ; ...
+
+; Dans MainLoop
+MainLoop
+        ; ... 
+        jsr   DrawTilemap               ; affiche le submap
+        ; ...
+```
+
+---
+
+## `Tilemap16bits` — maps avec chunks 8×8
+
+Pour les maps **très grandes** (64×128 tiles = 8192 entrées), une représentation directe (1 octet/tile) coûte 8 Ko en RAM. Pas viable.
+
+`Tilemap16bits` introduit un **niveau intermédiaire** : la map référence des **chunks** (groupes de 8×8 tiles), et chaque chunk référence des **tiles** réelles.
+
+### Hiérarchie
+
+```
+Map (64×128 entrées)
+   │
+   │  chaque entrée = 1 octet = chunk_id (0-255)
+   ↓
+Chunks (128-256 chunks, chacun 8×8 tiles)
+   │
+   │  chaque tile dans le chunk = 2 octets = tile_id
+   ↓
+Tile bitmaps
+```
+
+### Économie
+
+Pour une map 64×128 :
+- Directe : 64×128 × 1 = 8 Ko
+- Avec chunks : 64×128/64 = 128 chunks de pointeur (~1 Ko) + chunks données (~4 Ko) = ~5 Ko
+
+Avantage : possibilité de **réutiliser** des chunks (zones similaires de la map).
+
+### Structure (`map-16bits.equ`)
+
+```asm
+submap_camera_x_min equ   0
+submap_camera_y_min equ   2
+submap_camera_x_max equ   4
+submap_camera_y_max equ   6
+layer_map_width     equ   8    ; b
+layer_map_height    equ   9    ; b
+layer_map           equ   10   ; w → [b] : map de chunk IDs
+layer_chunk0        equ   12   ; w → [w] : chunks 0-127 (2 octets/tile)
+layer_chunk1        equ   14   ; w → [w] : chunks 128-255
+layer_tiles         equ   16   ; w → [bw] : tile index (3 octets/tile)
+layer_mul_ref       equ   18   ; w : table pré-calculée Y position
+```
+
+Le `layer_mul_ref` est une LUT pour multiplier rapidement `y * width` (évite mul à runtime).
+
+### Pourquoi `chunk0` et `chunk1` séparés ?
+
+Pour permettre l'usage de **direct page** sur les chunks fréquents (chunk0 = ceux les plus utilisés en DP, chunk1 = secondaires en mémoire normale).
+
+### Différence vs `Tilemap`
+
+- `Tilemap` : 1 octet/tile direct dans la map → max 256 tiles, map jusqu'à ~256×256
+- `Tilemap16bits` : 1 octet (chunk_id) → chunks → tile (2 octets dans le chunk) → 65536 tiles possibles, map jusqu'à 64×128 (limitations actuelles)
+
+---
+
+## Choix entre les deux
+
+| Scénario | Système |
+|----------|---------|
+| Petite map < 256 tiles uniques | `Tilemap` |
+| Map avec parallax (couches multiples) | `Tilemap` |
+| Grande map avec patterns répétés | `Tilemap16bits` (économise via chunks) |
+| Map avec > 256 tiles uniques | `Tilemap16bits` |
+| Sonic-2 (EHZ) | `Tilemap16bits` + `TileAnimScript` |
+
+---
+
+## Pitfalls
+
+- **`glb_submap` à 0** : crash de `DrawTilemap`
+- **`tile_size_divider` mal initialisé** : maths cassées, mauvaise tile à mauvaise position
+- **`parallax_X` = 0** mais on attend du mouvement : layer fixe (intentionnel ou bug)
+- **Plusieurs layers avec parallax identique** : pas une erreur mais doublon visuel
+- **`layer_tiles_location` pointant vers une page non-mountable** : crash
+- **Map > 64×128 en `Tilemap16bits`** : `layer_map_width` overflow (8 bits)
+- **Chunk_id pointant vers chunk1 mais chunk1 = 0** : crash
+- **Modifier la map en runtime sans force refresh** : `glb_submap_index_buf0/1` ne détectent pas le change


### PR DESCRIPTION
## Summary
- Whitelist les 21 skills `thomson-to8-engine-*` dans `.gitignore` pour qu'ils soient versionnés avec le repo.
- Ajoute leurs `SKILL.md` et `references/*.md` (1 dossier par sous-système : animation, audio, collision, scrolling, palette, irq, etc.).
- Ajoute les deux docs de gouvernance `skills/SKILLS-ROADMAP.md` (roadmap d'écriture, matrice d'usage par game-project) et `skills/QUESTIONS.md` (questions ouvertes à valider).
- Les autres collections (skills Thomson généralistes, asm-ark) restent local-only via les symlinks `.claude/skills/` toujours gitignorés.

## Effet sur .gitignore
La règle `/skills/` est remplacée par un whitelist sélectif :

```
/skills/*
!/skills/thomson-to8-engine-*/
!/skills/SKILLS-ROADMAP.md
!/skills/QUESTIONS.md
```

Tout futur skill engine nommé `thomson-to8-engine-<topic>/` sera automatiquement versionné. Tout brouillon `skills/<autre-nom>/` restera local sans modif du `.gitignore`.

## Test plan
- [x] `git ls-files --others --exclude-standard skills/` ne sort que les 21 dossiers engine + les 2 .md → OK
- [x] `git check-ignore` confirme que `.claude/skills/*` et `.claude/commands` restent ignorés → OK
- [x] `skills/.DS_Store` reste ignoré via la règle `.DS_Store` globale → OK
- [ ] Rebase-and-merge dans main une fois revue


Made with [Cursor](https://cursor.com)