### PR TITLE
fix(sprite): skip objects whose image_set is null in the render loops

### DIFF
--- a/engine/graphics/sprite/background-erase-mode/CheckSpritesRefresh.asm
+++ b/engine/graphics/sprite/background-erase-mode/CheckSpritesRefresh.asm
@@ -164,6 +164,16 @@ CSR_CheckDelHide
         lda   render_flags,u
         anda  #render_hide_mask|render_todelete_mask
         bne   CSR_DoNotDisplaySprite      
+        ; BUGFIX (2026-08-23) : image_set==0 means "no image" (see constants.asm).
+        ; DisplaySprite returns early in that case and therefore never unregisters
+        ; an object that was registered while it still had an image, so a stale
+        ; entry stays in the DPS. Treat it like a hidden sprite: erase what was
+        ; drawn before, draw nothing new. Without this guard the null pointer is
+        ; dereferenced against whatever sits at offset $0000 of the object image
+        ; page: harmless zeros on a RAM page (.fd/.sd), but the cartridge header
+        ; on a T2/ROM build, which sends the engine into an erased flash bank.
+        ldx   image_set,u
+        beq   CSR_DoNotDisplaySprite
 
 CSR_CheckRefresh  
         lda   rsv_render_flags,u      

--- a/engine/graphics/sprite/overlay-mode/BuildSprites.asm
+++ b/engine/graphics/sprite/overlay-mode/BuildSprites.asm
@@ -80,6 +80,15 @@ BuildSprites
         bne   @nextobject1 
         bita  #render_subobjects_mask       ; is this a child multisprite sprite object?
         lbne  @multisprite
+        ; BUGFIX (2026-08-23) : image_set==0 means "no image" (see constants.asm).
+        ; DisplaySprite returns early in that case and therefore never unregisters
+        ; an object that was registered while it still had an image, so a stale
+        ; entry stays in the DPS. Without this guard the null pointer is
+        ; dereferenced against whatever sits at offset $0000 of the object image
+        ; page: harmless zeros on a RAM page (.fd/.sd), but the cartridge header
+        ; on a T2/ROM build, which sends the engine into an erased flash bank.
+        ldx   image_set,u
+        beq   @nextobject1
         sta   _render_flags     
 ;
 ; ****************************************************
@@ -330,6 +339,7 @@ BuildSprites
 @id     equ   *-1
         _SetCartPageA        
         ldx   4,y ; get child imageset
+        beq   @nextchild                    ; BUGFIX (2026-08-23) : no image for this child
         stx   _image_set
         ldb   image_center_offset,x
         sex
@@ -342,6 +352,7 @@ BuildSprites
         ldd   ,y
         std   _x_pos
         jsr   @processMulti
+@nextchild
         dec   _nbchild
         beq   @nextobject2
         leay  next_subspr,y


### PR DESCRIPTION
image_set==0 is the documented "no image" sentinel (constants.asm), and DisplaySprite honours it with an early return. But that early return happens before the priority handling, so an object registered in the Display Priority Structure while it still had an image is never unregistered when its image_set goes back to 0. The stale entry stays in the DPS and the render loops dereference the null pointer.

What that dereference reads depends on the byte at offset $0000 of the object's image page:
- RAM page (.fd/.sd builds): zero fill, so the mirror-subset lookup returns 0 and the sprite is silently skipped. Benign by luck.
- Cartridge bank 0 (T2/.rom build): the cartridge header " BATTLE SQUADRON", which is non-zero. The engine then walks the boot code as if it were a compiled-sprite table, pulls a bogus page/address pair out of it, switches to an erased flash bank and jumps into it. Runaway CPU.

Guard both render loops instead of touching DisplaySprite: forcing priority 0 there would leave rsv_priority stale (neither @ChangePriority nor UDP_SetNewPrioB0 resets it to the new value), so the object could never be registered again once its image came back.

- overlay-mode/BuildSprites.asm: skip to @nextobject1 in @process; skip a multisprite child whose imageset is null.
- background-erase-mode/CheckSpritesRefresh.asm: treat it like a hidden sprite in CSR_CheckDelHide, so what was drawn before still gets erased.

Found on battlesquadron: Enemy6/7/8 set image_set to 0 every frame they are not flashing their hit frame, and only the .rom build crashed.


Claude-Session: https://claude.ai/code/session_0194pvctmiKW2iQhAcpNcXRh