### PR TITLE
fix(vgc): allow the stream buffers to live outside the object page

### DIFF
--- a/engine/objects/sound/vgc/vgc.asm
+++ b/engine/objects/sound/vgc/vgc.asm
@@ -29,5 +29,11 @@
         INCLUDE "./engine/sound/vgc/lib/vgcplayer.h.asm"
         INCLUDE "./engine/sound/vgc/lib/vgcplayer.asm"
 
+ IFNDEF vgc_stream_buffers
+; Buffers live in the object page by default. A game mode whose page is too
+; tight can declare them in the resident code instead (ALIGN 256 + 8*256): the
+; symbol then comes in through main.glb, this block is skipped, and 2304 bytes
+; are given back to the page.
 vgc_stream_buffers equ (*&$FF00)+$100 ; cannot align in objects due to placement optimization
         fill 0,256*9                  ; added one 256 chunk to do manual alignment
+ ENDC


### PR DESCRIPTION
The vgc object always reserved its 2304 bytes of stream buffers inside its own 16Kb page. A game mode with a large track cannot afford that: on battlesquadron the title theme is 14368 bytes, so the object reached 17333 bytes and the build failed with "is too large (max:16384)". The gamescreen track is only 4747 bytes, which is why the limit was never hit before.

The buffers are plain scratch RAM and do not need to sit in the paged window. Wrapping the declaration in IFNDEF lets a game mode declare them in its resident code instead (ALIGN 256 followed by 8*256 bytes). The symbol then reaches the object through main.glb, which the generated object wrapper includes before the object source, so this block is skipped and 2304 bytes are given back to the page.

Strictly additive: the existing code is untouched, only made conditional. No project combined resident buffers with the vgc object before, since that would have failed on a duplicate symbol, so nothing can change behaviour anywhere else. Verified on battlesquadron: gamescreen does not declare the symbol in its resident code and its vgc01 object is byte for byte identical (7980 bytes before and after, vgc_stream_buffers still at $1F00 inside the object page), while titlescreen and menuscreen drop from a failed build to 15029 bytes.

Note that vgcplayer.asm already expects the same page alignment when used as a resident player, so a game mode that defines the symbol is bound by the same constraint either way.


Claude-Session: https://claude.ai/code/session_01DR9DCpGW6TiBAapztTXx6v