### PR TITLE
fix(collision): removing an absent AABB no longer wipes the whole list

### DIFF
--- a/engine/collision/collision-list.asm
+++ b/engine/collision/collision-list.asm
@@ -20,23 +20,47 @@ Collision_AddAABB
 
 ; ------------------------------------------------------------------------------
 
+; Retirer une boite ABSENTE de la liste doit rester sans effet. Sans le test
+; ci-dessous, un tel appel tombait dans @noNext avec y et u a zero, puis posait
+; tail = 0 et head = 0 : la liste etait videe d'un coup et TOUTES les autres
+; boites deschainees. Les objets concernes restaient affiches et mobiles mais
+; devenaient incollisionnables, et l'appel suivant a Collision_AddAABB repartait
+; sur une liste vide en laissant les orphelines derriere. Panne silencieuse,
+; aleatoire, et sans rapport visible avec son declencheur.
+;
+; Une boite est dans la liste si son prev est non nul, ou si elle en est la tete.
 Collision_RemoveAABB
+        ldu   AABB.prev,x
+        bne   @linked
+        cmpx  0
+Collision_Remove_4 equ *-2
+        beq   @linked
+        rts                            ; absente : ne rien faire
+@linked
         ldy   AABB.next,x
         beq   @noNext
         ldu   AABB.prev,x
         stu   AABB.prev,y
         beq   @noPrev
         sty   AABB.next,u
-        rts
+        bra   @clean
 @noPrev sty   0
 Collision_Remove_1 equ *-2
-        rts
+        bra   @clean
 @noNext ldu   AABB.prev,x
         beq   >
         sty   AABB.next,u
 !       stu   0
 Collision_Remove_2 equ *-2
-        bne   @end
+        bne   @clean
         stu   0
 Collision_Remove_3 equ *-2
-@end    rts
+; Les liens de la boite retiree sont remis a zero. Sans ca un second retrait
+; verrait un prev perime non nul, prendrait le test d'appartenance pour un
+; succes et repartirait dans le chainage d'une liste qu'elle a quittee. C'est
+; aussi ce que demandait _Collision_CleanLinksAABB avant un changement de liste,
+; qui devient donc inutile.
+@clean  ldu   #0
+        stu   AABB.prev,x
+        stu   AABB.next,x
+        rts

--- a/engine/collision/macros.asm
+++ b/engine/collision/macros.asm
@@ -42,6 +42,7 @@ _Collision_RemoveAABB MACRO
         ldx   #\2
         stx   Collision_Remove_1
         stx   Collision_Remove_3
+        stx   Collision_Remove_4       ; test d'appartenance, cf collision-list.asm
         leax  2,x
         stx   Collision_Remove_2
         leax  \1,u


### PR DESCRIPTION
Collision_RemoveAABB called on a box that is not in the list fell into @noNext with y and u both zero, then stored tail = 0 and head = 0. The list was emptied in one go and every other box silently unchained: the objects stayed visible and moving but became non-collidable, and the next Collision_AddAABB restarted on an empty list leaving the orphans behind.

Symptoms seen on a game (battlesquadron): after firing supernovas, player bullets stopped killing anything, then a hard freeze. Random, and with no visible link to its trigger.

Two parts, both needed:

- Membership test. A box is in the list if its prev is non zero, or if it is the head. Otherwise return without touching anything. The macro now patches a fourth site, Collision_Remove_4, with the head address it already had at hand.

- The removed box gets its own prev and next cleared. Without this a second removal would see a stale non zero prev, take the membership test for a success and walk back into a list it had left. This also makes _Collision_CleanLinksAABB unnecessary before moving a box between lists, which the macro header used to require.

Behaviour changes only in a case that was catastrophic before. Cost is a few cycles per removal.

Verified: builds clean, cmpx patch site assembled at the expected place, and the reported failure no longer reproduces on the .rom build after extended play including dying while a supernova was in flight.


Claude-Session: https://claude.ai/code/session_01DR9DCpGW6TiBAapztTXx6v