### PR TITLE
fix(collision): AddAABB clears the box links instead of inheriting ga…

### DIFF
--- a/engine/collision/collision-list.asm
+++ b/engine/collision/collision-list.asm
@@ -7,15 +7,28 @@
 ; resident quand seul le main l'appelle).
 ; ------------------------------------------------------------------------------
 
+; La boite ajoutee repart de liens PROPRES. Sans cela elle gardait ce qui
+; trainait a ses offsets prev/next dans le slot OST au moment de l'ajout : la
+; branche liste-vide ci-dessous n'ecrivait ni l'un ni l'autre, et la branche
+; liste-non-vide ne posait que prev. Constate en aout 2026 sur un jeu : une
+; liste a un seul element dont le next valait $0200, donc Collision_Do partait
+; dans le vide des le premier noeud et les tirs ne touchaient plus rien de cette
+; liste. C'est aussi ce que demandait _Collision_CleanLinksAABB avant un
+; changement de liste, qui devient inutile.
 Collision_AddAABB
         ldu   2,y
         beq   >
         stx   AABB.next,u
         stx   2,y
-        stu   AABB.prev,x
+        stu   AABB.prev,x              ; u = ancienne queue, a lire avant de le
+        ldu   #0                       ; remettre a zero
+        stu   AABB.next,x
         rts
 !       stx   2,y
         stx   ,y
+        ldu   #0
+        stu   AABB.prev,x
+        stu   AABB.next,x
         rts
 
 ; ------------------------------------------------------------------------------


### PR DESCRIPTION
…rbage

Collision_AddAABB chained a box without initialising its own links. On an empty list it wrote neither prev nor next; on a non empty one it only set prev. The box therefore kept whatever sat at its prev/next offsets in the OST slot at the moment of the add.

Caught live on a game (battlesquadron) through the TOJE debugger: a one element ennemyfloor list whose single node had next = $0200. Collision_Do walked off into nothing from the very first node, so player bullets could no longer hit any ground enemy while flying ones were still killable. Progressive, target dependent, and with no visible link to its trigger.

Both branches now clear the box's prev and next. In the non empty branch the order matters: stu AABB.prev,x reads the former tail and must run before u is zeroed.

This is the other half of the guard added to Collision_RemoveAABB, which used to wipe an entire list when handed a box that was not in it. Together they make _Collision_CleanLinksAABB unnecessary before moving a box between lists, which the macro header used to require.

Verified on the emulated machine: after the fix, ennemyfloor holds a well formed three node chain -- head prev=0, every prev pointing back, walk from head landing exactly on the tail, tail next=0 -- and stays so across two supernovas and more than a minute of emulated play. Before, a single node carried a garbage next.


Claude-Session: https://claude.ai/code/session_01DR9DCpGW6TiBAapztTXx6v